### PR TITLE
Delay load v8jsi.dll

### DIFF
--- a/.ado/build-dll.yml
+++ b/.ado/build-dll.yml
@@ -18,6 +18,7 @@ steps:
       arguments:
         -SourcesPath:$(Build.SourcesDirectory)
         -Configuration:$(BuildConfiguration)
+        -OutputPath:${{parameters.outputPath}}
 
   - task: PowerShell@2
     displayName: Actually run the build

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # React Native V8 JSI adapter
 A V8 adapter implemention of the JSI interface for the react-native framework.
 
-## Requirements
-Download and install/unzip [Boost](https://www.boost.org/users/download/) and make sure the BOOST_ROOT environment variable is set (for example `SET BOOST_ROOT=d:\Stuff\boost_1_71_0\` or `$Env:BOOST_ROOT="d:\Stuff\boost_1_71_0\"`)
+[![Build Status](https://dev.azure.com/ms/v8-jsi/_apis/build/status/microsoft.v8-jsi?branchName=master)](https://dev.azure.com/ms/v8-jsi/_build/latest?definitionId=321&branchName=master)
 
-Code in jsi\jsi should be synchronized with the matching version of JSI from react-native (from https://github.com/facebook/hermes/tree/master/API/jsi/jsi).
+## Requirements
+[Optionally] download and install/unzip [Boost](https://www.boost.org/users/download/) and make sure the BOOST_ROOT environment variable is set (for example `SET BOOST_ROOT=d:\work\boost_1_71_0\` or `$Env:BOOST_ROOT="d:\work\boost_1_71_0\"`)
+
+## Building
+Run ./localbuild.ps1 in a PowerShell terminal; by default, this will only build the win32 x64 release version of the binary. Edit the file to specify other platforms, architectures or flavors.
+
+### Out-of-sync issues
+Until the JSI headers find a more suitable home, they're currently duplicated between the various repos. Code in jsi\jsi should be synchronized with the matching version of JSI from react-native (from https://github.com/facebook/hermes/tree/master/API/jsi/jsi).
 
 ## Contributing
 See [Contributing guidelines](./docs/CONTRIBUTING.md) for how to setup your fork of the repo and start a PR to contribute to React Native V8 JSI adapter.

--- a/ReactNative.V8Jsi.Windows.targets
+++ b/ReactNative.V8Jsi.Windows.targets
@@ -6,6 +6,7 @@
       <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\lib\Debug\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Release' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\lib\Release\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>v8jsi.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>v8jsi.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.2.2",
+    "version": "0.2.3",
     "v8ref": "refs/branch-heads/8.0"
 }

--- a/localbuild.ps1
+++ b/localbuild.ps1
@@ -3,7 +3,7 @@
 $OutputPath = "$PSScriptRoot\out"
 $SourcesPath = $PSScriptRoot
 $Platforms = "x64", "x86"
-$Configurations = "Release", "Debug", "Release-Clang", "EXPERIMENTAL-libcpp-Clang"
+$Configurations = "Debug", "Release", "Release-Clang", "EXPERIMENTAL-libcpp-Clang"
 
 Write-Host "Downloading environment..."
 & ".\scripts\download_depottools.ps1" -SourcesPath $SourcesPath

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -1144,7 +1144,7 @@ bool V8Runtime::isHostObject(const jsi::Object &obj) const {
 
   HostObjectProxy *hostObjectProxy = reinterpret_cast<HostObjectProxy *>(internalField->Value());
 
-  for (std::shared_ptr<HostObjectLifetimeTracker> hostObjectLifetimeTracker :
+  for (const std::shared_ptr<HostObjectLifetimeTracker>& hostObjectLifetimeTracker :
        host_object_lifetime_tracker_list_) {
     if (hostObjectLifetimeTracker->IsEqual(hostObjectProxy)) {
       return true;


### PR DESCRIPTION
* delay load the dll by default (so that consumers can have a run-time / optional dependency on v8jsi.dll without needing to distribute it if unused);
* the Platform must be process-singleton to match v8 internals (V8 is not embedder-friendly and makes several assumptions about objects that are initialized once per process - we're matching that design with our V8Platform to avoid crashes if multiple contexts are created / shut down during a process' lifetime);