### PR TITLE
Convert JS errors into C++ jsi::JSError exceptions; update JSI headers

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.2.3",
+    "version": "0.2.4",
     "v8ref": "refs/branch-heads/8.0"
 }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "version": "0.2.4",
-    "v8ref": "refs/branch-heads/8.0"
+    "v8ref": "refs/branch-heads/8.1"
 }

--- a/localbuild.ps1
+++ b/localbuild.ps1
@@ -1,8 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+param(
+    [string]$Platform = "x64",
+    [string]$Configuration = "Debug"
+)
+
 $OutputPath = "$PSScriptRoot\out"
 $SourcesPath = $PSScriptRoot
-$Platforms = "x64", "x86"
+$Platforms = "x64", "x86", "arm64"
 $Configurations = "Debug", "Release", "Release-Clang", "EXPERIMENTAL-libcpp-Clang"
 
 Write-Host "Downloading environment..."
@@ -14,21 +19,24 @@ if (!$?) {
 }
 
 Write-Host "Fetching code..."
-& ".\scripts\fetch_code.ps1" -SourcesPath $SourcesPath -OutputPath $OutputPath -Configuration $Configurations[0]
+& ".\scripts\fetch_code.ps1" -SourcesPath $SourcesPath -OutputPath $OutputPath -Configuration $Configuration
 
 if (!$?) {
     Write-Host "Failed to retrieve the v8 code"
     exit 1
 }
 
-<#foreach ($Platform in $Platforms) {
-    foreach ($Configuration in $Configurations) {
-        Write-Host "Building $Platform $Configuration..."
-        & ".\scripts\build.ps1" -SourcesPath $SourcesPath -OutputPath $OutputPath -Platform $Platform -Configuration $Configuration
+if ($Platform -like "all") {
+    foreach ($Plat in $Platforms) {
+        foreach ($Config in $Configurations) {
+            Write-Host "Building $Plat $Config..."
+            & ".\scripts\build.ps1" -SourcesPath $SourcesPath -OutputPath $OutputPath -Platform $Plat -Configuration $Config
+        }
     }
-}#>
-
-& ".\scripts\build.ps1" -SourcesPath $SourcesPath -OutputPath $OutputPath -Platform $Platforms[0] -Configuration $Configurations[0]
+}
+else {
+    & ".\scripts\build.ps1" -SourcesPath $SourcesPath -OutputPath $OutputPath -Platform $Platform -Configuration $Configuration
+}
 
 if (!$?) {
     Write-Host "Build failure"

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -57,6 +57,10 @@ else {
         $gnargs += ' use_custom_libcxx=false'
     }
 
+    if ($Configuration -like "UWP*") {
+        $gnargs += ' target_os=\"winuwp\"'
+    }
+
     $gnargs += ' target_cpu=\"' + $Platform + '\"'
 
     if ($Configuration -like "*clang") {
@@ -73,7 +77,7 @@ else {
     }
 }
 
-if ($Configuration -like "?ebug") {
+if ($Configuration -like "*ebug*") {
     $gnargs += ' enable_iterator_debugging=true is_debug=true'
 }
 else {
@@ -82,6 +86,7 @@ else {
 
 $buildoutput = Join-Path $workpath "v8build\v8\out\$Platform\$Configuration"
 
+Write-Host "gn command line: gn gen $buildoutput --args='$gnargs'"
 & gn gen $buildoutput --args="$gnargs"
 if (!$?) {
     Write-Host "Failed during build system generation (gn)"

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -368,9 +368,6 @@ struct SameCodeObjects {
     const v8::JitCodeEvent *event) {
   switch (event->type) {
     case v8::JitCodeEvent::CODE_ADDED:
-      if (event->code_type == v8::JitCodeEvent::CodeType::BYTE_CODE) {
-        std::cout << "B!!";
-      }
 #ifdef _WIN32
       EventWriteJIT_CODE_EVENT(
           event->type,
@@ -1245,11 +1242,16 @@ jsi::Value V8Runtime::call(
     argv.push_back(valueRef(args[i]));
   }
 
+  v8::TryCatch trycatch(isolate_);
   v8::MaybeLocal<v8::Value> result = func->Call(
       isolate_->GetCurrentContext(),
       valueRef(jsThis),
       static_cast<int>(count),
       argv.data());
+
+  if (trycatch.HasCaught()) {
+    ReportException(&trycatch);
+  }
 
   // Call can return
   if (result.IsEmpty()) {
@@ -1271,6 +1273,7 @@ jsi::Value V8Runtime::callAsConstructor(
     argv.push_back(valueRef(args[i]));
   }
 
+  v8::TryCatch trycatch(isolate_);
   v8::Local<v8::Object> newObject;
   if (!func->NewInstance(
                GetIsolate()->GetCurrentContext(),
@@ -1278,6 +1281,10 @@ jsi::Value V8Runtime::callAsConstructor(
                argv.data())
            .ToLocal(&newObject)) {
     new jsi::JSError(*this, "Object construction failed!!");
+  }
+
+  if (trycatch.HasCaught()) {
+    ReportException(&trycatch);
   }
 
   return createValue(newObject);

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -364,8 +364,7 @@ struct SameCodeObjects {
   }
 };
 
-/*static */ void V8Runtime::JitCodeEventListener(
-    const v8::JitCodeEvent *event) {
+/*static */ void V8Runtime::JitCodeEventListener(const v8::JitCodeEvent *event) {
   switch (event->type) {
     case v8::JitCodeEvent::CODE_ADDED:
 #ifdef _WIN32

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -191,7 +191,6 @@ class V8Runtime : public facebook::jsi::Runtime {
     // Useful for debugging.
     ~HostObjectLifetimeTracker() {
       assert(isReset_);
-      std::cout << "~HostObjectLifetimeTracker" << std::endl;
     }
 
     bool IsEqual(IHostProxy *hostProxy) const noexcept {

--- a/src/V8Platform.cpp
+++ b/src/V8Platform.cpp
@@ -318,25 +318,6 @@ void V8Platform::CallDelayedOnWorkerThread(
   worker_task_runner_->PostDelayedTask(std::move(task), delay_in_seconds);
 }
 
-void V8Platform::CallOnForegroundThread(v8::Isolate *isolate, v8::Task *task) {
-  GetForegroundTaskRunner(isolate)->PostTask(std::unique_ptr<v8::Task>(task));
-}
-
-void V8Platform::CallDelayedOnForegroundThread(
-    v8::Isolate *isolate,
-    v8::Task *task,
-    double delay_in_seconds) {
-  // We don't need it as of now.
-  std::abort();
-}
-
-void V8Platform::CallIdleOnForegroundThread(
-    v8::Isolate *isolate,
-    v8::IdleTask *task) {
-  GetForegroundTaskRunner(isolate)->PostIdleTask(
-      std::unique_ptr<v8::IdleTask>(task));
-}
-
 bool V8Platform::IdleTasksEnabled(v8::Isolate *isolate) {
   return GetForegroundTaskRunner(isolate)->IdleTasksEnabled();
 }

--- a/src/V8Platform.h
+++ b/src/V8Platform.h
@@ -147,14 +147,6 @@ class V8Platform : public v8::Platform {
       std::unique_ptr<v8::Task> task,
       double delay_in_seconds) override;
 
-  void CallOnForegroundThread(v8::Isolate *isolate, v8::Task *task) override;
-  void CallDelayedOnForegroundThread(
-      v8::Isolate *isolate,
-      v8::Task *task,
-      double delay_in_seconds) override;
-
-  void CallIdleOnForegroundThread(v8::Isolate *isolate, v8::IdleTask *task)
-      override;
   bool IdleTasksEnabled(v8::Isolate *isolate) override;
 
   double MonotonicallyIncreasingTime() override;

--- a/src/inspector/inspector_agent.cpp
+++ b/src/inspector/inspector_agent.cpp
@@ -530,8 +530,8 @@ void AgentImpl::PostIncomingMessage(
     const std::string &message) {
   if (AppendMessage(
           &incoming_message_queue_, session_id, Utf8ToStringView(message))) {
-    platform_.CallOnForegroundThread(
-        isolate_, new DispatchOnInspectorBackendTask(this));
+
+    platform_.GetForegroundTaskRunner(isolate_)->PostTask(std::make_unique<DispatchOnInspectorBackendTask>(this));
     isolate_->RequestInterrupt(InterruptCallback, this);
   }
   NotifyMessageReceived();

--- a/src/jsi/decorator.h
+++ b/src/jsi/decorator.h
@@ -335,18 +335,18 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     plain().instrumentation().collectGarbage();
   }
 
-  bool createSnapshotToFile(const std::string& path) override {
-    return plain().instrumentation().createSnapshotToFile(path);
+  void createSnapshotToFile(const std::string& path) override {
+    plain().instrumentation().createSnapshotToFile(path);
   }
 
-  bool createSnapshotToStream(std::ostream& os) override {
-    return plain().instrumentation().createSnapshotToStream(os);
+  void createSnapshotToStream(std::ostream& os) override {
+    plain().instrumentation().createSnapshotToStream(os);
   }
 
-  void writeBridgeTrafficTraceToFile(
-      const std::string& fileName) const override {
-    const_cast<Plain&>(plain()).instrumentation().writeBridgeTrafficTraceToFile(
-        fileName);
+  std::string flushAndDisableBridgeTrafficTrace() override {
+    return const_cast<Plain&>(plain())
+        .instrumentation()
+        .flushAndDisableBridgeTrafficTrace();
   }
 
   void writeBasicBlockProfileTraceToFile(

--- a/src/jsi/instrumentation.h
+++ b/src/jsi/instrumentation.h
@@ -55,20 +55,18 @@ class Instrumentation {
   /// Captures the heap to a file
   ///
   /// \param path to save the heap capture
-  ///
-  /// \return true iff the heap capture succeeded
-  virtual bool createSnapshotToFile(const std::string& path) = 0;
+  virtual void createSnapshotToFile(const std::string& path) = 0;
 
   /// Captures the heap to an output stream
   ///
   /// \param os output stream to write to.
-  ///
-  /// \return true iff the heap capture succeeded.
-  virtual bool createSnapshotToStream(std::ostream& os) = 0;
+  virtual void createSnapshotToStream(std::ostream& os) = 0;
 
-  /// Write a trace of bridge traffic to the given file name.
-  virtual void writeBridgeTrafficTraceToFile(
-      const std::string& fileName) const = 0;
+  /// If the runtime has been created to trace to a temp file, flush
+  /// any unwritten parts of the trace of bridge traffic to the file,
+  /// and return the name of  the file.  Otherwise, return the empty string.
+  /// Tracing is disabled after this call.
+  virtual std::string flushAndDisableBridgeTrafficTrace() = 0;
 
   /// Write basic block profile trace to the given file name.
   virtual void writeBasicBlockProfileTraceToFile(

--- a/src/jsi/jsi-inl.h
+++ b/src/jsi/jsi-inl.h
@@ -30,7 +30,7 @@ inline Value toValue(Runtime& runtime, const char* str) {
   return String::createFromAscii(runtime, str);
 }
 inline Value toValue(Runtime& runtime, const std::string& str) {
-  return String::createFromAscii(runtime, str);
+  return String::createFromUtf8(runtime, str);
 }
 template <typename T>
 inline Value toValue(Runtime& runtime, const T& other) {

--- a/src/jsi/jsi.cpp
+++ b/src/jsi/jsi.cpp
@@ -37,6 +37,27 @@ std::string kindToString(const Value& v, Runtime* rt = nullptr) {
   }
 }
 
+// getPropertyAsFunction() will try to create a JSError.  If the
+// failure is in building a JSError, this will lead to infinite
+// recursion.  This function is used in place of getPropertyAsFunction
+// when building JSError, to avoid that infinite recursion.
+Value callGlobalFunction(Runtime& runtime, const char* name, const Value& arg) {
+  Value v = runtime.global().getProperty(runtime, name);
+  if (!v.isObject()) {
+    throw JSINativeException(
+        std::string("callGlobalFunction: JS global property '") + name +
+        "' is " + kindToString(v, &runtime) + ", expected a Function");
+  }
+  Object o = v.getObject(runtime);
+  if (!o.isFunction(runtime)) {
+    throw JSINativeException(
+        std::string("callGlobalFunction: JS global property '") + name +
+        "' is a non-callable Object, expected a Function");
+  }
+  Function f = std::move(o).getFunction(runtime);
+  return f.call(runtime, arg);
+}
+
 } // namespace
 
 namespace detail {
@@ -78,15 +99,17 @@ Instrumentation& Runtime::instrumentation() {
 
     void collectGarbage() override {}
 
-    bool createSnapshotToFile(const std::string&) override {
-      return false;
+    void createSnapshotToFile(const std::string&) override {
+      throw JSINativeException(
+          "Default instrumentation cannot create a heap snapshot");
     }
 
-    bool createSnapshotToStream(std::ostream&) override {
-      return false;
+    void createSnapshotToStream(std::ostream&) override {
+      throw JSINativeException(
+          "Default instrumentation cannot create a heap snapshot");
     }
 
-    void writeBridgeTrafficTraceToFile(const std::string&) const override {
+    std::string flushAndDisableBridgeTrafficTrace() override {
       std::abort();
     }
 
@@ -142,9 +165,7 @@ Function Object::getPropertyAsFunction(Runtime& runtime, const char* name)
             kindToString(std::move(obj), &runtime) + ", expected a Function");
   };
 
-  Runtime::PointerValue* value = obj.ptr_;
-  obj.ptr_ = nullptr;
-  return Function(value);
+  return std::move(obj).getFunction(runtime);
 }
 
 Array Object::asArray(Runtime& runtime) const& {
@@ -347,7 +368,11 @@ JSError::JSError(Runtime& rt, Value&& value) {
 JSError::JSError(Runtime& rt, std::string msg) : message_(std::move(msg)) {
   try {
     setValue(
-        rt, rt.global().getPropertyAsFunction(rt, "Error").call(rt, message_));
+        rt,
+        callGlobalFunction(rt, "Error", String::createFromUtf8(rt, message_)));
+  } catch (const std::exception& ex) {
+    message_ = std::string(ex.what()) + " (while raising " + message_ + ")";
+    setValue(rt, String::createFromUtf8(rt, message_));
   } catch (...) {
     setValue(rt, Value());
   }
@@ -360,6 +385,8 @@ JSError::JSError(Runtime& rt, std::string msg, std::string stack)
     e.setProperty(rt, "message", String::createFromUtf8(rt, message_));
     e.setProperty(rt, "stack", String::createFromUtf8(rt, stack_));
     setValue(rt, std::move(e));
+  } catch (const std::exception& ex) {
+    setValue(rt, String::createFromUtf8(rt, ex.what()));
   } catch (...) {
     setValue(rt, Value());
   }
@@ -380,20 +407,23 @@ void JSError::setValue(Runtime& rt, Value&& value) {
       if (message_.empty()) {
         jsi::Value message = obj.getProperty(rt, "message");
         if (!message.isUndefined()) {
-          message_ = message.toString(rt).utf8(rt);
+          message_ =
+              callGlobalFunction(rt, "String", message).getString(rt).utf8(rt);
         }
       }
 
       if (stack_.empty()) {
         jsi::Value stack = obj.getProperty(rt, "stack");
         if (!stack.isUndefined()) {
-          stack_ = stack.toString(rt).utf8(rt);
+          stack_ =
+              callGlobalFunction(rt, "String", stack).getString(rt).utf8(rt);
         }
       }
     }
 
     if (message_.empty()) {
-      message_ = value_->toString(rt).utf8(rt);
+      message_ =
+          callGlobalFunction(rt, "String", *value_).getString(rt).utf8(rt);
     }
 
     if (stack_.empty()) {
@@ -403,6 +433,13 @@ void JSError::setValue(Runtime& rt, Value&& value) {
     if (what_.empty()) {
       what_ = message_ + "\n\n" + stack_;
     }
+  } catch (const std::exception& ex) {
+    message_ = std::string("[Exception while creating message string: ") +
+        ex.what() + "]";
+    stack_ = std::string("Exception while creating stack string: ") +
+        ex.what() + "]";
+    what_ =
+        std::string("Exception while getting value fields: ") + ex.what() + "]";
   } catch (...) {
     message_ = "[Exception caught creating message string]";
     stack_ = "[Exception caught creating stack string]";

--- a/src/jsi/jsi.h
+++ b/src/jsi/jsi.h
@@ -52,8 +52,8 @@ class StringBuffer : public Buffer {
   std::string s_;
 };
 
-/// PreparedJavaScript is a base class representing JavaScript which is in a form
-/// optimized for execution, in a runtime-specific way. Construct one via
+/// PreparedJavaScript is a base class representing JavaScript which is in a
+/// form optimized for execution, in a runtime-specific way. Construct one via
 /// jsi::Runtime::prepareJavaScript().
 /// ** This is an experimental API that is subject to change. **
 class PreparedJavaScript {
@@ -811,23 +811,35 @@ class Function : public Object {
       unsigned int paramCount,
       jsi::HostFunctionType func);
 
-  /// Calls the function with \c count \c args.  The \c this value of
-  /// the JS function will be undefined.
+  /// Calls the function with \c count \c args.  The \c this value of the JS
+  /// function will not be set by the C++ caller, similar to calling
+  /// Function.prototype.apply(undefined, args) in JS.
+  /// \b Note: as with Function.prototype.apply, \c this may not always be
+  /// \c undefined in the function itself.  If the function is non-strict,
+  /// \c this will be set to the global object.
   Value call(Runtime& runtime, const Value* args, size_t count) const;
 
   /// Calls the function with a \c std::initializer_list of Value
-  /// arguments. The \c this value of the JS function will be
-  /// undefined.
+  /// arguments.  The \c this value of the JS function will not be set by the
+  /// C++ caller, similar to calling Function.prototype.apply(undefined, args)
+  /// in JS.
+  /// \b Note: as with Function.prototype.apply, \c this may not always be
+  /// \c undefined in the function itself.  If the function is non-strict,
+  /// \c this will be set to the global object.
   Value call(Runtime& runtime, std::initializer_list<Value> args) const;
 
   /// Calls the function with any number of arguments similarly to
-  /// Object::setProperty().  The \c this value of the JS function
-  /// will be undefined.
+  /// Object::setProperty().  The \c this value of the JS function will not be
+  /// set by the C++ caller, similar to calling
+  /// Function.prototype.call(undefined, ...args) in JS.
+  /// \b Note: as with Function.prototype.call, \c this may not always be
+  /// \c undefined in the function itself.  If the function is non-strict,
+  /// \c this will be set to the global object.
   template <typename... Args>
   Value call(Runtime& runtime, Args&&... args) const;
 
   /// Calls the function with \c count \c args and \c jsThis value passed
-  /// as this value.
+  /// as the \c this value.
   Value callWithThis(
       Runtime& Runtime,
       const Object& jsThis,
@@ -835,16 +847,14 @@ class Function : public Object {
       size_t count) const;
 
   /// Calls the function with a \c std::initializer_list of Value
-  /// arguments. The \c this value of the JS function will be
-  /// undefined.
+  /// arguments and \c jsThis passed as the \c this value.
   Value callWithThis(
       Runtime& runtime,
       const Object& jsThis,
       std::initializer_list<Value> args) const;
 
   /// Calls the function with any number of arguments similarly to
-  /// Object::setProperty().  The \c this value of the JS function
-  /// will be undefined.
+  /// Object::setProperty(), and with \c jsThis passed as the \c this value.
   template <typename... Args>
   Value callWithThis(Runtime& runtime, const Object& jsThis, Args&&... args)
       const;
@@ -1191,7 +1201,7 @@ class Scope {
 };
 
 /// Base class for jsi exceptions
-class JSIException : public std::exception {
+class JSI_EXPORT JSIException : public std::exception {
  protected:
   JSIException(){};
   JSIException(std::string what) : what_(std::move(what)){};
@@ -1207,7 +1217,7 @@ class JSIException : public std::exception {
 
 /// This exception will be thrown by API functions on errors not related to
 /// JavaScript execution.
-class JSINativeException : public JSIException {
+class JSI_EXPORT JSINativeException : public JSIException {
  public:
   JSINativeException(std::string what) : JSIException(std::move(what)) {}
 };
@@ -1215,7 +1225,7 @@ class JSINativeException : public JSIException {
 /// This exception will be thrown by API functions whenever a JS
 /// operation causes an exception as described by the spec, or as
 /// otherwise described.
-class JSError : public JSIException {
+class JSI_EXPORT JSError : public JSIException {
  public:
   /// Creates a JSError referring to provided \c value
   JSError(Runtime& r, Value&& value);

--- a/src/jsi/test/testlib.cpp
+++ b/src/jsi/test/testlib.cpp
@@ -191,7 +191,7 @@ TEST_P(JSITest, HostObjectTest) {
                   .call(rt, cho)
                   .getBool());
   EXPECT_TRUE(cho.isHostObject(rt));
-  //EXPECT_TRUE(cho.getHostObject<ConstantHostObject>(rt).get() != nullptr);
+  EXPECT_TRUE(cho.getHostObject<ConstantHostObject>(rt).get() != nullptr);
 
   struct SameRuntimeHostObject : HostObject {
     SameRuntimeHostObject(Runtime& rt) : rt_(rt){};
@@ -242,10 +242,10 @@ TEST_P(JSITest, HostObjectTest) {
                   .call(rt, tho)
                   .getBool());
   EXPECT_TRUE(tho.isHostObject(rt));
-  /*EXPECT_TRUE(
+  EXPECT_TRUE(
       std::dynamic_pointer_cast<ConstantHostObject>(tho.getHostObject(rt)) ==
-      nullptr);*/
-  //EXPECT_TRUE(tho.getHostObject<TwiceHostObject>(rt).get() != nullptr);
+      nullptr);
+  EXPECT_TRUE(tho.getHostObject<TwiceHostObject>(rt).get() != nullptr);
 
   class PropNameIDHostObject : public HostObject {
     Value get(Runtime& rt, const PropNameID& sym) override {
@@ -474,7 +474,8 @@ TEST_P(JSITest, FunctionTest) {
   // This tests all the function argument converters, and all the
   // non-lvalue overloads of call().
   Function f = function(
-      "function(n, b, d, df, i, s1, s2, s3, o, a, f, v) { return "
+      "function(n, b, d, df, i, s1, s2, s3, s_sun, s_bad, o, a, f, v) { "
+      "return "
       "n === null && "
       "b === true && "
       "d === 3.14 && "
@@ -483,11 +484,12 @@ TEST_P(JSITest, FunctionTest) {
       "s1 == 's1' && "
       "s2 == 's2' && "
       "s3 == 's3' && "
+      "s_sun == 's\\u2600' && "
+      "typeof s_bad == 'string' && "
       "typeof o == 'object' && "
       "Array.isArray(a) && "
       "typeof f == 'function' && "
       "v == 42 }");
-  std::string s3 = "s3";
   EXPECT_TRUE(f.call(
                    rt,
                    nullptr,
@@ -497,7 +499,10 @@ TEST_P(JSITest, FunctionTest) {
                    17,
                    "s1",
                    String::createFromAscii(rt, "s2"),
-                   s3,
+                   std::string{"s3"},
+                   std::string{u8"s\u2600"},
+                   // invalid UTF8 sequence due to unexpected continuation byte
+                   std::string{"s\x80"},
                    Object(rt),
                    Array(rt, 1),
                    function("function(){}"),
@@ -559,11 +564,11 @@ TEST_P(JSITest, FunctionConstructorTest) {
       .getObject(rt)
       .setProperty(rt, "pika", "chu");
   auto empty = ctor.callAsConstructor(rt);
-  ASSERT_TRUE(empty.isObject());
+  EXPECT_TRUE(empty.isObject());
   auto emptyObj = std::move(empty).getObject(rt);
   EXPECT_EQ(emptyObj.getProperty(rt, "pika").getString(rt).utf8(rt), "chu");
   auto who = ctor.callAsConstructor(rt, "who");
-  ASSERT_TRUE(who.isObject());
+  EXPECT_TRUE(who.isObject());
   auto whoObj = std::move(who).getObject(rt);
   EXPECT_EQ(whoObj.getProperty(rt, "pika").getString(rt).utf8(rt), "who");
 
@@ -939,7 +944,7 @@ unsigned countOccurences(const std::string& of, const std::string& in) {
 } // namespace
 
 TEST_P(JSITest, JSErrorsArePropagatedNicely) {
-  unsigned callsBeoreError = 5;
+  unsigned callsBeforeError = 5;
 
   Function sometimesThrows = function(
       "function sometimesThrows(shouldThrow, callback) {"
@@ -953,9 +958,9 @@ TEST_P(JSITest, JSErrorsArePropagatedNicely) {
       rt,
       PropNameID::forAscii(rt, "callback"),
       0,
-      [&sometimesThrows, &callsBeoreError](
+      [&sometimesThrows, &callsBeforeError](
           Runtime& rt, const Value& thisVal, const Value* args, size_t count) {
-        return sometimesThrows.call(rt, --callsBeoreError == 0, args[0]);
+        return sometimesThrows.call(rt, --callsBeforeError == 0, args[0]);
       });
 
   try {
@@ -973,6 +978,79 @@ TEST_P(JSITest, JSErrorsCanBeConstructedWithStack) {
   auto err = JSError(rt, "message", "stack");
   EXPECT_EQ(err.getMessage(), "message");
   EXPECT_EQ(err.getStack(), "stack");
+}
+
+TEST_P(JSITest, JSErrorDoesNotInfinitelyRecurse) {
+  Value globalString = rt.global().getProperty(rt, "String");
+  rt.global().setProperty(rt, "String", Value::undefined());
+  try {
+    eval("throw Error('whoops')");
+    FAIL() << "expected exception";
+  } catch (const JSError& ex) {
+    EXPECT_EQ(
+        ex.getMessage(),
+        "[Exception while creating message string: callGlobalFunction: "
+        "JS global property 'String' is undefined, expected a Function]");
+  }
+  rt.global().setProperty(rt, "String", globalString);
+
+  Value globalError = rt.global().getProperty(rt, "Error");
+  rt.global().setProperty(rt, "Error", Value::undefined());
+  try {
+    rt.global().getPropertyAsFunction(rt, "NotAFunction");
+    FAIL() << "expected exception";
+  } catch (const JSError& ex) {
+    EXPECT_EQ(
+        ex.getMessage(),
+        "callGlobalFunction: JS global property 'Error' is undefined, "
+        "expected a Function (while raising getPropertyAsObject: "
+        "property 'NotAFunction' is undefined, expected an Object)");
+  }
+
+  // If Error is missing, this is fundamentally a problem with JS code
+  // messing up the global object, so it should present in JS code as
+  // a catchable string.  Not an Error (because that's broken), or as
+  // a C++ failure.
+
+  auto fails = [](Runtime& rt, const Value&, const Value*, size_t) -> Value {
+    return rt.global().getPropertyAsObject(rt, "NotAProperty");
+  };
+  EXPECT_EQ(
+      function("function (f) { try { f(); return 'undefined'; }"
+               "catch (e) { return typeof e; } }")
+          .call(
+              rt,
+              Function::createFromHostFunction(
+                  rt, PropNameID::forAscii(rt, "fails"), 0, fails))
+          .getString(rt)
+          .utf8(rt),
+      "string");
+
+  rt.global().setProperty(rt, "Error", globalError);
+}
+
+TEST_P(JSITest, JSErrorStackOverflowHandling) {
+  rt.global().setProperty(
+      rt,
+      "callSomething",
+      Function::createFromHostFunction(
+          rt,
+          PropNameID::forAscii(rt, "callSomething"),
+          0,
+          [this](
+              Runtime& rt2,
+              const Value& thisVal,
+              const Value* args,
+              size_t count) {
+            EXPECT_EQ(&rt, &rt2);
+            return function("function() { return 0; }").call(rt);
+          }));
+  try {
+    eval("(function f() { callSomething(); f.apply(); })()");
+    FAIL();
+  } catch (const JSError& ex) {
+    EXPECT_NE(std::string(ex.what()).find("exceeded"), std::string::npos);
+  }
 }
 
 TEST_P(JSITest, ScopeDoesNotCrashTest) {
@@ -1191,6 +1269,88 @@ TEST_P(JSITest, SymbolTest) {
   EXPECT_TRUE(Value::strictEquals(
       rt, eval("Symbol.for('a')"), eval("Symbol.for('a')")));
   EXPECT_FALSE(Value::strictEquals(rt, eval("Symbol('a')"), eval("'a'")));
+}
+
+//----------------------------------------------------------------------
+// Test that multiple levels of delegation in DecoratedHostObjects works.
+
+class RD1 : public RuntimeDecorator<Runtime, Runtime> {
+ public:
+  RD1(Runtime& plain) : RuntimeDecorator(plain) {}
+
+  Object createObject(std::shared_ptr<HostObject> ho) {
+    class DHO1 : public DecoratedHostObject {
+     public:
+      using DecoratedHostObject::DecoratedHostObject;
+
+      Value get(Runtime& rt, const PropNameID& name) override {
+        numGets++;
+        return DecoratedHostObject::get(rt, name);
+      }
+    };
+    return Object::createFromHostObject(
+        plain(), std::make_shared<DHO1>(*this, ho));
+  }
+
+  static unsigned numGets;
+};
+
+class RD2 : public RuntimeDecorator<Runtime, Runtime> {
+ public:
+  RD2(Runtime& plain) : RuntimeDecorator(plain) {}
+
+  Object createObject(std::shared_ptr<HostObject> ho) {
+    class DHO2 : public DecoratedHostObject {
+     public:
+      using DecoratedHostObject::DecoratedHostObject;
+
+      Value get(Runtime& rt, const PropNameID& name) override {
+        numGets++;
+        return DecoratedHostObject::get(rt, name);
+      }
+    };
+    return Object::createFromHostObject(
+        plain(), std::make_shared<DHO2>(*this, ho));
+  }
+
+  static unsigned numGets;
+};
+
+class HO : public HostObject {
+ public:
+  explicit HO(Runtime* expectedRT) : expectedRT_(expectedRT) {}
+
+  Value get(Runtime& rt, const PropNameID& name) override {
+    EXPECT_EQ(expectedRT_, &rt);
+    return Value(17.0);
+  }
+
+ private:
+  // The runtime we expect to be called with.
+  Runtime* expectedRT_;
+};
+
+unsigned RD1::numGets = 0;
+unsigned RD2::numGets = 0;
+
+TEST_P(JSITest, MultilevelDecoratedHostObject) {
+  // This test will be run for various test instantiations, so initialize these
+  // counters.
+  RD1::numGets = 0;
+  RD2::numGets = 0;
+
+  RD1 rd1(rt);
+  RD2 rd2(rd1);
+  // We expect the "get" operation of ho to be called with rd2.
+  auto ho = std::make_shared<HO>(&rd2);
+  auto obj = Object::createFromHostObject(rd2, ho);
+  Value v = obj.getProperty(rd2, "p");
+  EXPECT_TRUE(v.isNumber());
+  EXPECT_EQ(17.0, v.asNumber());
+  auto ho2 = obj.getHostObject(rd2);
+  EXPECT_EQ(ho, ho2);
+  EXPECT_EQ(1, RD1::numGets);
+  EXPECT_EQ(1, RD2::numGets);
 }
 
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
- convert JS errors into C++ jsi::JSError exceptions to match Hermes (for now this covers only function calls);
- update JSI headers to latest available (API compatible, this includes an UTF8 conversion issue fix we found in Office LPC);
- remove some console logging that was leftover from previous implementations;