### PR TITLE
Publish symbols in separate package

### DIFF
--- a/ReactNative.V8Jsi.Windows.targets
+++ b/ReactNative.V8Jsi.Windows.targets
@@ -19,6 +19,7 @@
   </ItemDefinitionGroup>
   <ItemGroup Condition="'$(V8JsiNoDLLCopy)' == ''">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll" />
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll.pdb" />
+    <!-- Disable publishing PDBs due to increased package size; symbols are indexed instead and available through symweb internally -->
+    <!-- ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll.pdb" / -->
   </ItemGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,6 +97,12 @@ jobs:
             $Version = $config.version
             Write-Host "##vso[task.setvariable variable=Version]$Version"
 
+      - task: PublishSymbols@2
+        inputs:
+          SymbolsFolder: '$(System.DefaultWorkingDirectory)\V8Jsi\'
+          SearchPattern: 'lib/**/*.pdb'
+          SymbolServerType: 'TeamServices'
+
       - task: NuGetCommand@2
         displayName: 'NuGet Pack'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,13 +100,8 @@ jobs:
       - task: NuGetCommand@2
         displayName: 'NuGet Pack'
         inputs:
-          command: pack
-          includeSymbols: true
-          packagesToPack: $(System.DefaultWorkingDirectory)\V8Jsi\ReactNative.V8Jsi.Windows.nuspec
-          packDestination: $(System.DefaultWorkingDirectory)\NugetRootFinal
-          buildProperties: CommitId=$(Build.SourceVersion);nugetroot=$(System.DefaultWorkingDirectory)\V8Jsi;RepoUri=$(Build.Repository.Uri)
-          versioningScheme: byEnvVar
-          versionEnvVar: Version
+          command: 'custom'
+          arguments: 'pack $(System.DefaultWorkingDirectory)\V8Jsi\ReactNative.V8Jsi.Windows.nuspec -NonInteractive -OutputDirectory $(System.DefaultWorkingDirectory)\NugetRootFinal -Properties CommitId=$(Build.SourceVersion);nugetroot=$(System.DefaultWorkingDirectory)\V8Jsi;RepoUri=$(Build.Repository.Uri) -Symbols -SymbolPackageFormat snupkg -version $(Version) -Verbosity Detailed'
 
       - task: PublishBuildArtifacts@1
         displayName: "Publish final nuget artifacts"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ pool:
 
 jobs:
   - job: V8JsiBuild
-    timeoutInMinutes: 120
+    timeoutInMinutes: 150
     displayName: Build the v8jsi.dll binary for supported architectures and flavors
     strategy:
       matrix:
@@ -97,11 +97,12 @@ jobs:
             $Version = $config.version
             Write-Host "##vso[task.setvariable variable=Version]$Version"
 
-      - task: PublishSymbols@2
-        inputs:
-          SymbolsFolder: '$(System.DefaultWorkingDirectory)\V8Jsi\'
-          SearchPattern: 'lib/**/*.pdb'
-          SymbolServerType: 'TeamServices'
+      # Disabled for now until we figure out the right set of variables
+      #- task: PublishSymbols@2
+      #  inputs:
+      #    SymbolsFolder: '$(System.DefaultWorkingDirectory)\V8Jsi\'
+      #    SearchPattern: 'lib/**/*.pdb'
+      #    SymbolServerType: 'TeamServices'
 
       - task: NuGetCommand@2
         displayName: 'NuGet Pack'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,6 +101,7 @@ jobs:
         displayName: 'NuGet Pack'
         inputs:
           command: pack
+          includeSymbols: true
           packagesToPack: $(System.DefaultWorkingDirectory)\V8Jsi\ReactNative.V8Jsi.Windows.nuspec
           packDestination: $(System.DefaultWorkingDirectory)\NugetRootFinal
           buildProperties: CommitId=$(Build.SourceVersion);nugetroot=$(System.DefaultWorkingDirectory)\V8Jsi;RepoUri=$(Build.Repository.Uri)

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -66,7 +66,10 @@ if (!$?) {
     exit 1
 }
 
-& ninja -v -j 16 -C $buildoutput v8jsi jsitests | Tee-Object -FilePath "$SourcesPath\build.log"
+# We'll use 2x the number of cores for parallel execution
+$numberOfThreads = [int]((Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors) * 2
+
+& ninja -v -j $numberOfThreads -C $buildoutput v8jsi jsitests | Tee-Object -FilePath "$SourcesPath\build.log"
 if (!$?) {
     Write-Host "Build failure, check logs for details"
     exit 1


### PR DESCRIPTION
With UWP and WIN32 in the same NuGet, the resulting nupkg size is ~540Mb, whereas nuget.org has a 250Mb package size limit.

There is support for snupkg (symbol packages) in [nuget](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg), but very little documentation on the Azure DevOps side.

This removed the PDBs from the main v8jsi NuGet, we're still exploring options for where to upload the symbols.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/v8-jsi/pull/21)