### PR TITLE
Generate a separate package for UWP

### DIFF
--- a/.ado/build-dll.yml
+++ b/.ado/build-dll.yml
@@ -20,6 +20,7 @@ steps:
         -SourcesPath:$(Build.SourcesDirectory)
         -Configuration:$(BuildConfiguration)
         -OutputPath:${{parameters.outputPath}}
+        -AppPlatform:${{parameters.appPlatform}}
 
   - task: PowerShell@2
     displayName: Actually run the build

--- a/ReactNative.V8Jsi.Windows.targets
+++ b/ReactNative.V8Jsi.Windows.targets
@@ -1,7 +1,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <!-- Set V8_ARCH to "win32" for desktop builds -->
-    <V8AppPlatform Condition="'$(V8AppPlatform)' == ''">uwp</V8AppPlatform>
+    <V8AppPlatform Condition="'$(V8AppPlatform)' == ''">win32</V8AppPlatform>
 
     <V8Platform Condition="'$(V8Platform)' == ''">$(Platform)</V8Platform>
     <!-- Fix platform name (win32 should be x86) -->
@@ -19,7 +18,7 @@
   </ItemDefinitionGroup>
   <ItemGroup Condition="'$(V8JsiNoDLLCopy)' == ''">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll" />
-    <!-- Disable publishing PDBs due to increased package size; symbols are indexed instead and available through symweb internally -->
-    <!-- ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll.pdb" / -->
+    <!-- Disable publishing PDBs for UWP due to increased package size -->
+    <ReferenceCopyLocalPaths Condition="'$(V8AppPlatform)' == 'win32'" Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll.pdb" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines-uwp.yml
+++ b/azure-pipelines-uwp.yml
@@ -15,26 +15,34 @@ pool:
 
 jobs:
   - job: V8JsiBuild
-    timeoutInMinutes: 120
-    displayName: Build the Win32 v8jsi.dll binary for supported architectures and flavors
+    timeoutInMinutes: 150
+    displayName: Build the UWP v8jsi.dll binary for supported architectures and flavors
     strategy:
       matrix:
-        X64Debug:
+        UWPX64Debug:
           BuildConfiguration: Debug
           BuildPlatform: x64
-          AppPlatform: win32
-        X86Debug:
+          AppPlatform: uwp
+        UWPX86Debug:
           BuildConfiguration: Debug
           BuildPlatform: x86
-          AppPlatform: win32
-        X64Release:
+          AppPlatform: uwp
+        UWPARM64Debug:
+          BuildConfiguration: Debug
+          BuildPlatform: arm64
+          AppPlatform: uwp
+        UWPX64Release:
           BuildConfiguration: Release
           BuildPlatform: x64
-          AppPlatform: win32
-        X86Release:
+          AppPlatform: uwp
+        UWPX86Release:
           BuildConfiguration: Release
           BuildPlatform: x86
-          AppPlatform: win32
+          AppPlatform: uwp
+        UWPARM64Release:
+          BuildConfiguration: Release
+          BuildPlatform: arm64
+          AppPlatform: uwp
 
     steps:
       - task: UsePythonVersion@0
@@ -83,7 +91,7 @@ jobs:
         displayName: 'NuGet Pack'
         inputs:
           command: pack
-          packagesToPack: $(System.DefaultWorkingDirectory)\V8Jsi\ReactNative.V8Jsi.Windows.nuspec
+          packagesToPack: $(System.DefaultWorkingDirectory)\V8Jsi\ReactNative.V8Jsi.Windows.UWP.nuspec
           packDestination: $(System.DefaultWorkingDirectory)\NugetRootFinal
           buildProperties: CommitId=$(Build.SourceVersion);nugetroot=$(System.DefaultWorkingDirectory)\V8Jsi;RepoUri=$(Build.Repository.Uri)
           versioningScheme: byEnvVar

--- a/azure-pipelines-uwp.yml
+++ b/azure-pipelines-uwp.yml
@@ -81,12 +81,6 @@ jobs:
             $Version = $config.version
             Write-Host "##vso[task.setvariable variable=Version]$Version"
 
-      - task: PublishSymbols@2
-        inputs:
-          SymbolsFolder: '$(System.DefaultWorkingDirectory)\V8Jsi\'
-          SearchPattern: 'lib/**/*.pdb'
-          SymbolServerType: 'TeamServices'
-
       - task: NuGetCommand@2
         displayName: 'NuGet Pack'
         inputs:

--- a/azure-pipelines-uwp.yml
+++ b/azure-pipelines-uwp.yml
@@ -1,8 +1,4 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
+name: v8jsi_uwp.0.0.$(Date:yyMM.d)$(Rev:rrr)
 
 trigger:
 - master
@@ -62,7 +58,6 @@ jobs:
     steps:
       - checkout: none
 
-      # The commit tag in the nuspec requires that we use at least nuget 4.6
       - task: NuGetToolInstaller@0
         inputs:
           versionSpec: ">=4.6.0"
@@ -90,6 +85,7 @@ jobs:
           buildProperties: CommitId=$(Build.SourceVersion);nugetroot=$(System.DefaultWorkingDirectory)\V8Jsi;RepoUri=$(Build.Repository.Uri)
           versioningScheme: byEnvVar
           versionEnvVar: Version
+          includeSymbols: true
 
       - task: PublishBuildArtifacts@1
         displayName: "Publish final nuget artifacts"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,4 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
+name: v8jsi_win32.0.0.$(Date:yyMM.d)$(Rev:rrr)
 
 trigger:
 - master
@@ -54,7 +50,6 @@ jobs:
     steps:
       - checkout: none
 
-      # The commit tag in the nuspec requires that we use at least nuget 4.6
       - task: NuGetToolInstaller@0
         inputs:
           versionSpec: ">=4.6.0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,12 +97,11 @@ jobs:
             $Version = $config.version
             Write-Host "##vso[task.setvariable variable=Version]$Version"
 
-      # Disabled for now until we figure out the right set of variables
-      #- task: PublishSymbols@2
-      #  inputs:
-      #    SymbolsFolder: '$(System.DefaultWorkingDirectory)\V8Jsi\'
-      #    SearchPattern: 'lib/**/*.pdb'
-      #    SymbolServerType: 'TeamServices'
+      - task: PublishSymbols@2
+        inputs:
+          SymbolsFolder: '$(System.DefaultWorkingDirectory)\V8Jsi\'
+          SearchPattern: 'lib/**/*.pdb'
+          SymbolServerType: 'TeamServices'
 
       - task: NuGetCommand@2
         displayName: 'NuGet Pack'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,12 +73,6 @@ jobs:
             $Version = $config.version
             Write-Host "##vso[task.setvariable variable=Version]$Version"
 
-      - task: PublishSymbols@2
-        inputs:
-          SymbolsFolder: '$(System.DefaultWorkingDirectory)\V8Jsi\'
-          SearchPattern: 'lib/**/*.pdb'
-          SymbolServerType: 'TeamServices'
-
       - task: NuGetCommand@2
         displayName: 'NuGet Pack'
         inputs:

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.3.3",
+    "version": "0.3.4",
     "v8ref": "refs/branch-heads/8.5"
 }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -116,8 +116,12 @@ Copy-Item "$jsigitpath\jsi\jsi.cpp" -Destination "$OutputPath\build\native\inclu
 Copy-Item "$jsigitpath\jsi\instrumentation.h" -Destination "$OutputPath\build\native\include\jsi\"
 
 # Miscellaneous
-#Copy-Item "$SourcesPath\ReactNative.V8Jsi.Windows.nuspec" -Destination "$OutputPath\"
-Copy-Item "$SourcesPath\ReactNative.V8Jsi.Windows.targets" -Destination "$OutputPath\build\native\"
+if ($AppPlatform -eq "uwp") {
+    (Get-Content "$SourcesPath\ReactNative.V8Jsi.Windows.targets") -replace ('win32</V8AppPlatform>', "uwp</V8AppPlatform>") | Set-Content "$OutputPath\build\native\ReactNative.V8Jsi.Windows.UWP.targets"
+} else {
+    Copy-Item "$SourcesPath\ReactNative.V8Jsi.Windows.targets" -Destination "$OutputPath\build\native\"
+}
+
 Copy-Item "$SourcesPath\config.json" -Destination "$OutputPath\"
 Copy-Item "$SourcesPath\LICENSE" -Destination "$OutputPath\license\"
 Copy-Item "$SourcesPath\LICENSE.jsi.md" -Destination "$OutputPath\license\"

--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -66,6 +66,7 @@ $buildoutput = Join-Path $workpath "v8build\v8\out\$Platform\$Configuration"
 (Get-Content "$SourcesPath\src\version.rc") -replace ('V8JSIVER_MAJOR', $vermap[0]) -replace ('V8JSIVER_MINOR', $vermap[1]) -replace ('V8JSIVER_BUILD', $vermap[2]) -replace ('V8JSIVER_V8REF', $v8Version.Replace('.', '_')) | Set-Content "$SourcesPath\src\version_gen.rc"
 
 (Get-Content "$SourcesPath\ReactNative.V8Jsi.Windows.nuspec") -replace ('VERSION_DETAILS', "V8 version: $v8Version; Git revision: $gitRevision") | Set-Content "$OutputPath\ReactNative.V8Jsi.Windows.nuspec"
+(Get-Content "$SourcesPath\ReactNative.V8Jsi.Windows.nuspec") -replace ('VERSION_DETAILS', "UWP, V8 version: $v8Version; Git revision: $gitRevision") | Set-Content "$OutputPath\ReactNative.V8Jsi.Windows.UWP.nuspec"
 
 Write-Host "##vso[task.setvariable variable=V8JSI_VERSION;]$verString"
 

--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -3,7 +3,8 @@
 param(
     [string]$SourcesPath = $PSScriptRoot,
     [string]$OutputPath = "$PSScriptRoot\out",
-    [string]$Configuration = "Release"
+    [string]$Configuration = "Release",
+    [string]$AppPlatform = "win32"
 )
 
 $workpath = Join-Path $SourcesPath "build"
@@ -65,8 +66,11 @@ $buildoutput = Join-Path $workpath "v8build\v8\out\$Platform\$Configuration"
 
 (Get-Content "$SourcesPath\src\version.rc") -replace ('V8JSIVER_MAJOR', $vermap[0]) -replace ('V8JSIVER_MINOR', $vermap[1]) -replace ('V8JSIVER_BUILD', $vermap[2]) -replace ('V8JSIVER_V8REF', $v8Version.Replace('.', '_')) | Set-Content "$SourcesPath\src\version_gen.rc"
 
-(Get-Content "$SourcesPath\ReactNative.V8Jsi.Windows.nuspec") -replace ('VERSION_DETAILS', "V8 version: $v8Version; Git revision: $gitRevision") | Set-Content "$OutputPath\ReactNative.V8Jsi.Windows.nuspec"
-(Get-Content "$SourcesPath\ReactNative.V8Jsi.Windows.nuspec") -replace ('VERSION_DETAILS', "UWP, V8 version: $v8Version; Git revision: $gitRevision") | Set-Content "$OutputPath\ReactNative.V8Jsi.Windows.UWP.nuspec"
+if ($AppPlatform -eq "uwp") {
+    (Get-Content "$SourcesPath\ReactNative.V8Jsi.Windows.nuspec") -replace ('VERSION_DETAILS', "UWP, V8 version: $v8Version; Git revision: $gitRevision") -replace ('ipdb;', 'pdb;') -replace ('V8Jsi.Windows', 'V8Jsi.Windows.UWP') | Set-Content "$OutputPath\ReactNative.V8Jsi.Windows.UWP.nuspec"
+} else {
+    (Get-Content "$SourcesPath\ReactNative.V8Jsi.Windows.nuspec") -replace ('VERSION_DETAILS', "V8 version: $v8Version; Git revision: $gitRevision") | Set-Content "$OutputPath\ReactNative.V8Jsi.Windows.nuspec"
+}
 
 Write-Host "##vso[task.setvariable variable=V8JSI_VERSION;]$verString"
 


### PR DESCRIPTION
Generate separate packages for win32 and uwp, since together they go over the nuget.org 250Mb limit.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/v8-jsi/pull/23)