### PR TITLE
Rely on NuGet metadata to manage packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = false
+
+[*]
+end_of_line = crlf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+# Xml project files
+[*.{config,csproj,nuspec,props,targets,vcxitems,vcxproj,vcxproj.filters}]
+insert_final_newline = false
+
+[*.ps1]
+indent_size = 4
+
+[package.json]
+insert_final_newline = false

--- a/localbuild.ps1
+++ b/localbuild.ps1
@@ -14,12 +14,10 @@ param(
     [ValidateSet('win32', 'uwp')]
     [String[]]$AppPlatform = @('win32'),
 
-    [bool]$Setup = $true,
-
-    [switch] $UseOldGn
+    [switch]$NoSetup
 )
 
-if ($Setup) {
+if (! $NoSetup.IsPresent) {
     Write-Host "Downloading environment..."
     & ".\scripts\download_depottools.ps1" -SourcesPath $SourcesPath
 
@@ -34,16 +32,6 @@ if ($Setup) {
     if (!$?) {
         Write-Host "Failed to retrieve the v8 code"
         exit 1
-    }
-
-    if ($UseOldGn) {
-        $gnzip = "$([System.IO.Path]::GetTempFileName()).zip"
-        # From https://chrome-infra-packages.appspot.com/p/gn/gn/windows-amd64/+/2PLNlcZUEpB2kqsVjfC_JbdH8Cy0-8euFKq-BTPNcJ8C
-        Invoke-WebRequest `
-            -Uri 'https://storage.googleapis.com/chrome-infra-packages/store/SHA256/d8f2cd95c65412907692ab158df0bf25b747f02cb4fbc7ae14aabe0533cd709f?Expires=1603154260&GoogleAccessId=chrome-infra-packages%40appspot.gserviceaccount.com&Signature=E6mVPDUwiKYcO6HtemYQ8C7%2BuPzu%2Bqco1soBxtaEtukfLfBE9MnY%2FtPZGlNgRVBh0MX1%2FtcO62edOaV0Qmp511oQTyBnhyrnoaNz1eem4XAOmHP6RsQ2DGceM524wbW95gYHQQyOmgdnTtwbLXcGRzJ6naW%2B1wttzp5oOKkgBzu3lt1ToeWu1pPT7BzgfqzdF7mG2JaYtiQpd2uknDdVKIrXBEnXVHOT6wWYtIXZawB3phzZJKKVCOjR1XxQf2psvxUeAhhROCitY5%2BoRNvQgc5M09lnsWqA3SesAgLBzJMVHJ7GzPuusi8Y7Pw%2FpTRaJPhTnmY3Qv5mlxhoTzWrEw%3D%3D&response-content-disposition=attachment%3B+filename%3D%22gn-windows-amd64.zip%22' `
-            -OutFile $gnzip
-
-        Expand-Archive -Path $gnzip -DestinationPath $SourcesPath\build\v8build\v8\buildtools\win\ -Force
     }
 }
 

--- a/localbuild.ps1
+++ b/localbuild.ps1
@@ -14,7 +14,9 @@ param(
     [ValidateSet('win32', 'uwp')]
     [String[]]$AppPlatform = @('win32'),
 
-    [bool]$Setup = $true
+    [bool]$Setup = $true,
+
+    [switch] $UseOldGn
 )
 
 if ($Setup) {
@@ -32,6 +34,16 @@ if ($Setup) {
     if (!$?) {
         Write-Host "Failed to retrieve the v8 code"
         exit 1
+    }
+
+    if ($UseOldGn) {
+        $gnzip = "$([System.IO.Path]::GetTempFileName()).zip"
+        # From https://chrome-infra-packages.appspot.com/p/gn/gn/windows-amd64/+/2PLNlcZUEpB2kqsVjfC_JbdH8Cy0-8euFKq-BTPNcJ8C
+        Invoke-WebRequest `
+            -Uri 'https://storage.googleapis.com/chrome-infra-packages/store/SHA256/d8f2cd95c65412907692ab158df0bf25b747f02cb4fbc7ae14aabe0533cd709f?Expires=1603154260&GoogleAccessId=chrome-infra-packages%40appspot.gserviceaccount.com&Signature=E6mVPDUwiKYcO6HtemYQ8C7%2BuPzu%2Bqco1soBxtaEtukfLfBE9MnY%2FtPZGlNgRVBh0MX1%2FtcO62edOaV0Qmp511oQTyBnhyrnoaNz1eem4XAOmHP6RsQ2DGceM524wbW95gYHQQyOmgdnTtwbLXcGRzJ6naW%2B1wttzp5oOKkgBzu3lt1ToeWu1pPT7BzgfqzdF7mG2JaYtiQpd2uknDdVKIrXBEnXVHOT6wWYtIXZawB3phzZJKKVCOjR1XxQf2psvxUeAhhROCitY5%2BoRNvQgc5M09lnsWqA3SesAgLBzJMVHJ7GzPuusi8Y7Pw%2FpTRaJPhTnmY3Qv5mlxhoTzWrEw%3D%3D&response-content-disposition=attachment%3B+filename%3D%22gn-windows-amd64.zip%22' `
+            -OutFile $gnzip
+
+        Expand-Archive -Path $gnzip -DestinationPath $SourcesPath\build\v8build\v8\buildtools\win\ -Force
     }
 }
 

--- a/localbuild.ps1
+++ b/localbuild.ps1
@@ -1,14 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 param(
-    [string]$SourcesPath = $PSScriptRoot,
-    [string]$OutputPath = "$PSScriptRoot\out",
+    [System.IO.DirectoryInfo]$SourcesPath = $PSScriptRoot,
+
+    [System.IO.DirectoryInfo]$OutputPath = "$PSScriptRoot\out",
+
     [ValidateSet("x64", "x86", "arm64")]
     [String[]]$Platform = @("x64"),
+
     [ValidateSet("debug", "release")]
     [String[]]$Configuration = @("debug"),
+
     [ValidateSet("win32", "uwp")]
     [String[]]$AppPlatform = @("win32"),
+
     [bool]$Setup = $true
 )
 

--- a/localbuild.ps1
+++ b/localbuild.ps1
@@ -5,14 +5,14 @@ param(
 
     [System.IO.DirectoryInfo]$OutputPath = "$PSScriptRoot\out",
 
-    [ValidateSet("x64", "x86", "arm64")]
-    [String[]]$Platform = @("x64"),
+    [ValidateSet('x64', 'x86', 'arm64')]
+    [String[]]$Platform = @('x64'),
 
-    [ValidateSet("debug", "release")]
-    [String[]]$Configuration = @("debug"),
+    [ValidateSet('Debug', 'Release')]
+    [String[]]$Configuration = @('Debug'),
 
-    [ValidateSet("win32", "uwp")]
-    [String[]]$AppPlatform = @("win32"),
+    [ValidateSet('win32', 'uwp')]
+    [String[]]$AppPlatform = @('win32'),
 
     [bool]$Setup = $true
 )

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositoryPath" value="build\v8build" />
+  </config>
+</configuration>

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.72.0" />
+</packages>

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.72.0" />
+  <package id="boost" version="1.72.0.0" />
 </packages>

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 param(
-    [string]$OutputPath = "$PSScriptRoot\out",
-    [string]$SourcesPath = $PSScriptRoot,
+    [System.IO.DirectoryInfo]$OutputPath = "$PSScriptRoot\out",
+    [System.IO.DirectoryInfo]$SourcesPath = $PSScriptRoot,
     [string]$Platform = "x64",
     [string]$Configuration = "Release",
     [string]$AppPlatform = "win32",

--- a/scripts/download_depottools.ps1
+++ b/scripts/download_depottools.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 param(
-    [string]$SourcesPath = $PSScriptRoot
+    [System.IO.DirectoryInfo]$SourcesPath = $PSScriptRoot
 )
 
 $workpath = Join-Path $SourcesPath "build"

--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -93,5 +93,5 @@ $boostPkg = Select-Xml  -Path (Join-Path $SourcesPath 'packages.config') -XPath 
             Select-Object -ExpandProperty Node |
             Where-Object { $_.id -eq 'boost' }
 
-$env:BOOST_ROOT = Join-Path $workpath "v8build/boost.$($boostPkg.version)/lib/native/include"
+$env:BOOST_ROOT = Join-Path $workpath "v8build/boost.$($boostPkg.version)\lib\native\include"
 Write-Host "##vso[task.setvariable variable=BOOST_ROOT;]$env:BOOST_ROOT"

--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -84,13 +84,14 @@ if ($PSVersionTable.Platform -and !$IsWindows) {
 #TODO (#2): Use the .gzip for Android / Linux builds
 # Verify the Boost installation
 if (-not (Test-Path "$env:BOOST_ROOT\boost\asio.hpp")) {
+    #TODO: Don't use hard-coded package version.
     if (-not (Test-Path (Join-Path $workpath "v8build/boost.1.72.0.0/lib/native/include/boost/asio.hpp"))) {
         Write-Host "Boost ASIO not found, downloading..."
 
         $targetNugetExe = Join-Path $workpath "nuget.exe"
         Invoke-WebRequest "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile $targetNugetExe
 
-        & $targetNugetExe install -OutputDirectory (Join-Path $workpath "v8build") boost -Version 1.72.0
+        & $targetNugetExe restore
     }
 
     $env:BOOST_ROOT = Join-Path $workpath "v8build/boost.1.72.0.0/lib/native/include"

--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 param(
-    [string]$SourcesPath = $PSScriptRoot,
-    [string]$OutputPath = "$PSScriptRoot\out",
+    [System.IO.DirectoryInfo]$SourcesPath = $PSScriptRoot,
+    [System.IO.DirectoryInfo]$OutputPath = "$PSScriptRoot\out",
     [string]$Configuration = "Release",
     [string]$AppPlatform = "win32"
 )


### PR DESCRIPTION
Use NuGet files to define the version and location of this type of dependencies.
This allows for single-source implicit version dependency management.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/v8-jsi/pull/31)