### PR TITLE
Implement ArrayBuffer runtime methods

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.64.10",
+    "version": "0.64.11",
     "v8ref": "refs/branch-heads/9.0"
 }

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -1239,16 +1239,19 @@ bool V8Runtime::isArray(const jsi::Object &obj) const {
   return objectRef(obj)->IsArray();
 }
 
-bool V8Runtime::isArrayBuffer(const jsi::Object & /*obj*/) const {
-  throw std::runtime_error("Unsupported");
+bool V8Runtime::isArrayBuffer(const jsi::Object &obj) const {
+  _ISOLATE_CONTEXT_ENTER
+  return objectRef(obj)->IsArrayBuffer();
 }
 
 uint8_t *V8Runtime::data(const jsi::ArrayBuffer &obj) {
-  throw std::runtime_error("Unsupported");
+  _ISOLATE_CONTEXT_ENTER
+  return reinterpret_cast<uint8_t*>(objectRef(obj).As<v8::ArrayBuffer>()->GetContents().Data());
 }
 
-size_t V8Runtime::size(const jsi::ArrayBuffer & /*obj*/) {
-  throw std::runtime_error("Unsupported");
+size_t V8Runtime::size(const jsi::ArrayBuffer &obj) {
+  _ISOLATE_CONTEXT_ENTER
+  return objectRef(obj).As<v8::ArrayBuffer>()->ByteLength();
 }
 
 bool V8Runtime::isFunction(const jsi::Object &obj) const {


### PR DESCRIPTION
[BabylonReactNative](https://github.com/BabylonJS/BabylonReactNative) uses a [BabylonNative polyfill](https://github.com/BabylonJS/BabylonNative/blob/master/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp#L108) to request a remote resource, and that [uses JSI ArrayBuffer methods](https://github.com/BabylonJS/BabylonNative/blob/master/Dependencies/napi/napi-jsi/include/napi/napi-inl.h#L789), which then call into our implementation of the V8 JSI runtime.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/47)