### PR TITLE
Disable web assembly; add perf tuning flags

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -19,7 +19,7 @@ Copy-Item $jsigitpath -Destination (Join-Path $workpath "v8build\v8\jsi") -Recur
 Push-Location (Join-Path $workpath "v8build\v8")
 
 # Generate the build system
-$gnargs = 'v8_enable_i18n_support=false is_component_build=false v8_monolithic=true v8_use_external_startup_data=false treat_warnings_as_errors=false'
+$gnargs = 'v8_enable_i18n_support=false v8_enable_webassembly=false is_component_build=false v8_monolithic=true v8_use_external_startup_data=false treat_warnings_as_errors=false'
 
 if ($Configuration -like "*android") {
     $gnargs += ' use_goma=false target_os=\"android\" target_cpu=\"' + $Platform + '\"'

--- a/scripts/patch/src.diff
+++ b/scripts/patch/src.diff
@@ -1,8 +1,8 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index f39529a3a9..b0275712b9 100644
+index d2bfb6129d..b14a7189f2 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -4270,11 +4270,18 @@ v8_component("v8_libbase") {
+@@ -4661,11 +4661,18 @@ v8_component("v8_libbase") {
  
      defines += [ "_CRT_RAND_S" ]  # for rand_s()
  
@@ -26,7 +26,7 @@ index f39529a3a9..b0275712b9 100644
  
      if (v8_enable_system_instrumentation) {
        libs += [ "advapi32.lib" ]  # Needed for TraceLoggingProvider.h
-@@ -5636,3 +5643,9 @@ if (!build_with_chromium && v8_use_perfetto) {
+@@ -6212,3 +6219,9 @@ if (!build_with_chromium && v8_use_perfetto) {
      ]
    }
  }  # if (!build_with_chromium && v8_use_perfetto)
@@ -37,10 +37,10 @@ index f39529a3a9..b0275712b9 100644
 +  ]
 +}
 diff --git a/DEPS b/DEPS
-index e6c2e762e0..d7f0294a38 100644
+index b27a4e8e8f..056054b8bd 100644
 --- a/DEPS
 +++ b/DEPS
-@@ -568,4 +568,15 @@ hooks = [
+@@ -580,4 +580,15 @@ hooks = [
        'tools/generate-header-include-checks.py',
      ],
    },
@@ -57,10 +57,10 @@ index e6c2e762e0..d7f0294a38 100644
 + }
  ]
 diff --git a/gni/snapshot_toolchain.gni b/gni/snapshot_toolchain.gni
-index b5fb1823b3..b5ddc1aba2 100644
+index e855b88e43..61d56e574f 100644
 --- a/gni/snapshot_toolchain.gni
 +++ b/gni/snapshot_toolchain.gni
-@@ -66,6 +66,9 @@ if (v8_snapshot_toolchain == "") {
+@@ -70,6 +70,9 @@ if (v8_snapshot_toolchain == "") {
      # therefore snapshots will need to be built using native mksnapshot
      # in combination with qemu
      v8_snapshot_toolchain = current_toolchain
@@ -120,7 +120,7 @@ index f981bec610..c054ba8dc9 100644
  }  // namespace base
  }  // namespace v8
 diff --git a/src/base/platform/platform-win32.cc b/src/base/platform/platform-win32.cc
-index 7f6c0e97d2..3a752cf789 100644
+index 50da60c72f..3a3b94af98 100644
 --- a/src/base/platform/platform-win32.cc
 +++ b/src/base/platform/platform-win32.cc
 @@ -1069,7 +1069,7 @@ Win32MemoryMappedFile::~Win32MemoryMappedFile() {
@@ -132,6 +132,28 @@ index 7f6c0e97d2..3a752cf789 100644
  // DbgHelp.h functions.
  using DLL_FUNC_TYPE(SymInitialize) = BOOL(__stdcall*)(IN HANDLE hProcess,
                                                        IN PSTR UserSearchPath,
+diff --git a/src/compiler/backend/ia32/instruction-selector-ia32.cc b/src/compiler/backend/ia32/instruction-selector-ia32.cc
+index 033a566e11..99a2ee6f5d 100644
+--- a/src/compiler/backend/ia32/instruction-selector-ia32.cc
++++ b/src/compiler/backend/ia32/instruction-selector-ia32.cc
+@@ -3000,6 +3000,7 @@ void InstructionSelector::VisitI8x16Shuffle(Node* node) {
+ void InstructionSelector::VisitI8x16Shuffle(Node* node) { UNREACHABLE(); }
+ #endif  // V8_ENABLE_WEBASSEMBLY
+ 
++#if V8_ENABLE_WEBASSEMBLY
+ void InstructionSelector::VisitI8x16Swizzle(Node* node) {
+   InstructionCode op = kIA32I8x16Swizzle;
+ 
+@@ -3019,6 +3020,9 @@ void InstructionSelector::VisitI8x16Swizzle(Node* node) {
+        g.UseRegister(node->InputAt(0)), g.UseRegister(node->InputAt(1)),
+        arraysize(temps), temps);
+ }
++#else
++void InstructionSelector::VisitI8x16Swizzle(Node* node) { UNREACHABLE(); }
++#endif  // V8_ENABLE_WEBASSEMBLY
+ 
+ namespace {
+ void VisitPminOrPmax(InstructionSelector* selector, Node* node,
 diff --git a/src/diagnostics/unwinding-info-win64.cc b/src/diagnostics/unwinding-info-win64.cc
 index 9a5f7069e7..a53c0ad644 100644
 --- a/src/diagnostics/unwinding-info-win64.cc
@@ -155,10 +177,10 @@ index 9a5f7069e7..a53c0ad644 100644
      // handling only unwind info for compatibility.
      if (unhandled_exception_callback_g) {
 diff --git a/src/objects/scope-info.cc b/src/objects/scope-info.cc
-index bd6fd3cb0b..f9666cf74b 100644
+index 308b57a309..8e943c7ae9 100644
 --- a/src/objects/scope-info.cc
 +++ b/src/objects/scope-info.cc
-@@ -924,7 +924,9 @@ int ScopeInfo::ReceiverContextSlotIndex() const {
+@@ -978,7 +978,9 @@ int ScopeInfo::ReceiverContextSlotIndex() const {
  }
  
  int ScopeInfo::FunctionContextSlotIndex(String name) const {

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -379,7 +379,7 @@ v8::Isolate *V8Runtime::CreateNewIsolate() {
   }
 
   counter_map_ = new CounterMap();
-  if (args_.trackGCObjectStats) {
+  if (args_.flags.trackGCObjectStats) {
     create_params_.counter_lookup_callback = LookupCounter;
     create_params_.create_histogram_callback = CreateHistogram;
     create_params_.add_histogram_sample_callback = AddHistogramSample;
@@ -396,23 +396,23 @@ v8::Isolate *V8Runtime::CreateNewIsolate() {
 
   isolate_data_->CreateProperties();
 
-  if (!args_.ignoreUnhandledPromises) {
+  if (!args_.flags.ignoreUnhandledPromises) {
     isolate_->SetPromiseRejectCallback(PromiseRejectCallback);
   }
 
-  if (args_.trackGCObjectStats) {
+  if (args_.flags.trackGCObjectStats) {
     MapCounters(isolate_, "v8jsi");
   }
 
-  if (args_.enableJitTracing) {
+  if (args_.flags.enableJitTracing) {
     isolate_->SetJitCodeEventHandler(v8::kJitCodeEventDefault, JitCodeEventListener);
   }
 
-  if (args_.enableMessageTracing) {
+  if (args_.flags.enableMessageTracing) {
     isolate_->AddMessageListener(OnMessage);
   }
 
-  if (args_.enableGCTracing) {
+  if (args_.flags.enableGCTracing) {
     isolate_->AddGCPrologueCallback(GCPrologueCallback);
     isolate_->AddGCEpilogueCallback(GCEpilogueCallback);
   }
@@ -458,25 +458,25 @@ void V8Runtime::initializeV8() {
   std::vector<const char *> argv;
   argv.push_back("v8jsi");
 
-  if (args_.trackGCObjectStats)
+  if (args_.flags.trackGCObjectStats)
     argv.push_back("--track_gc_object_stats");
 
-  if (args_.enableGCApi)
+  if (args_.flags.enableGCApi)
     argv.push_back("--expose_gc");
 
-  if (args_.sparkplug)
+  if (args_.flags.sparkplug)
     argv.push_back("--sparkplug");
 
-  if (args_.predictable)
+  if (args_.flags.predictable)
     argv.push_back("--predictable");
 
-  if (args_.optimize_for_size)
+  if (args_.flags.optimize_for_size)
     argv.push_back("--optimize_for_size");
 
-  if (args_.always_compact)
+  if (args_.flags.always_compact)
     argv.push_back("--always_compact");
 
-  if (args_.jitless)
+  if (args_.flags.jitless)
     argv.push_back("--jitless");
 
   int argc = static_cast<int>(argv.size());
@@ -515,13 +515,13 @@ V8Runtime::V8Runtime(V8RuntimeArgs &&args) : args_(std::move(args)) {
   v8::Context::Scope context_scope(context);
 
 #if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
-  if (args_.enableInspector) {
+  if (args_.flags.enableInspector) {
     TRACEV8RUNTIME_VERBOSE("Inspector enabled");
     inspector_agent_ = std::make_unique<inspector::Agent>(
         isolate_, context_.Get(GetIsolate()), "JSIRuntime context", args_.inspectorPort);
     inspector_agent_->start();
 
-    if (args_.waitForDebugger) {
+    if (args_.flags.waitForDebugger) {
       TRACEV8RUNTIME_VERBOSE("Waiting for inspector frontend to attach");
       inspector_agent_->waitForDebugger();
     }

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -464,6 +464,21 @@ void V8Runtime::initializeV8() {
   if (args_.enableGCApi)
     argv.push_back("--expose_gc");
 
+  if (args_.sparkplug)
+    argv.push_back("--sparkplug");
+
+  if (args_.predictable)
+    argv.push_back("--predictable");
+
+  if (args_.optimize_for_size)
+    argv.push_back("--optimize_for_size");
+
+  if (args_.always_compact)
+    argv.push_back("--always_compact");
+
+  if (args_.jitless)
+    argv.push_back("--jitless");
+
   int argc = static_cast<int>(argv.size());
   v8::V8::SetFlagsFromCommandLine(&argc, const_cast<char **>(&argv[0]), false);
 }

--- a/src/napi/js_native_ext_api_v8.cpp
+++ b/src/napi/js_native_ext_api_v8.cpp
@@ -214,17 +214,17 @@ static struct EnvScope {
 
 napi_status napi_ext_create_env(napi_ext_env_attributes attributes, napi_env *env) {
   v8runtime::V8RuntimeArgs args;
-  args.trackGCObjectStats = false;
-  args.enableJitTracing = false;
-  args.enableMessageTracing = false;
-  args.enableGCTracing = false;
+  args.flags.trackGCObjectStats = false;
+  args.flags.enableJitTracing = false;
+  args.flags.enableMessageTracing = false;
+  args.flags.enableGCTracing = false;
 
   if ((attributes & napi_ext_env_attribute_enable_gc_api) != 0) {
-    args.enableGCApi = true;
+    args.flags.enableGCApi = true;
   }
 
   if ((attributes & napi_ext_env_attribute_ignore_unhandled_promises) != 0) {
-    args.ignoreUnhandledPromises = true;
+    args.flags.ignoreUnhandledPromises = true;
   }
 
   auto runtime = std::make_unique<v8runtime::V8Runtime>(std::move(args));

--- a/src/public/V8JsiRuntime.h
+++ b/src/public/V8JsiRuntime.h
@@ -72,8 +72,8 @@ struct V8RuntimeArgs {
       bool optimize_for_size:1; // enables optimizations which favor memory size over execution speed
       bool always_compact:1; // perform compaction on every full GC
       bool jitless:1; // disable JIT entirely
-    };
-    uint32_t _flags {0};
+    } flags;
+    uint32_t _flagspad {0};
   };
 };
 


### PR DESCRIPTION
- Disable webassembly support (this shaves 2Mb of the DLL size in x64 release)
- Expose V8 performance tuning flags through the arguments
- Make the flags in V8RuntimeArgs more flexible and resilient to ABI changes (by using a padded struct with some leftover room)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/57)