### PR TITLE
Enable open inspector servers on active runtime instance

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.64.15",
+    "version": "0.64.16",
     "v8ref": "refs/branch-heads/9.1"
 }

--- a/src/IsolateData.h
+++ b/src/IsolateData.h
@@ -9,6 +9,7 @@
 namespace v8runtime {
 
 constexpr int ISOLATE_DATA_SLOT = 0;
+constexpr int ISOLATE_INSPECTOR_SLOT = 1;
 
 // Custom data associated with each V8 isolate.
 struct IsolateData {

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -154,6 +154,14 @@ class V8Runtime : public facebook::jsi::Runtime {
   V8Runtime(V8RuntimeArgs &&args);
   ~V8Runtime();
 
+  public:  // Used by openInspector public API.
+#if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
+  std::shared_ptr<inspector::Agent> getInspectorAgent() {
+    return inspector_agent_;
+  }
+#endif
+
+
  public: // Used by NAPI implementation
   v8::Global<v8::Context> &GetContext() {
     return context_;
@@ -178,7 +186,7 @@ class V8Runtime : public facebook::jsi::Runtime {
 
   napi_status NapiGetUniqueUtf8StringRef(napi_env env, const char *str, size_t length, napi_ext_ref *result);
 
- private: // Used by NAPI implementation
+ private:  // Used by NAPI implementation
   static void PromiseRejectCallback(v8::PromiseRejectMessage data);
   void
   SetUnhandledPromise(v8::Local<v8::Promise> promise, v8::Local<v8::Message> message, v8::Local<v8::Value> exception);
@@ -605,10 +613,10 @@ class V8Runtime : public facebook::jsi::Runtime {
 
   static void GCEpilogueCallback(v8::Isolate *isolate, v8::GCType type, v8::GCCallbackFlags flags);
 
-  V8RuntimeArgs &runtimeArgs() {
+  V8RuntimeArgs& runtimeArgs() {
     return args_;
   }
-
+ 
  private:
   v8::Local<v8::Context> CreateContext(v8::Isolate *isolate);
 
@@ -651,7 +659,7 @@ class V8Runtime : public facebook::jsi::Runtime {
   facebook::jsi::Value createValue(v8::Local<v8::Value> value) const;
 
 #if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
-  std::unique_ptr<inspector::Agent> inspector_agent_;
+  std::shared_ptr<inspector::Agent> inspector_agent_;
 #endif
 
   V8RuntimeArgs args_;

--- a/src/inspector/inspector_agent.cpp
+++ b/src/inspector/inspector_agent.cpp
@@ -67,12 +67,14 @@ class AgentImpl : public std::enable_shared_from_this<AgentImpl> {
  public:
   explicit AgentImpl(
       v8::Isolate *isolate,
-      v8::Local<v8::Context> context,
-      const char *context_name,
       int port);
   ~AgentImpl();
 
   InspectorSocketServer& ensureServer();
+
+  void addContext(v8::Local<v8::Context> context,
+                             const char* context_name);
+  void removeContext(v8::Local<v8::Context> context);
 
   void Start();
   void Stop();
@@ -80,7 +82,7 @@ class AgentImpl : public std::enable_shared_from_this<AgentImpl> {
   void waitForDebugger();
 
   bool IsStarted();
-  // bool IsConnected();
+  bool IsConnected();
   void WaitForDisconnect();
 
   void notifyLoadedUrl(const std::string& url);
@@ -93,6 +95,7 @@ class AgentImpl : public std::enable_shared_from_this<AgentImpl> {
   void ResumeStartup() {}
 
   std::string getTitle();
+  std::string targetId() { return targetId_; };
 
  private:
   using MessageQueue =
@@ -120,7 +123,6 @@ class AgentImpl : public std::enable_shared_from_this<AgentImpl> {
 
   std::mutex incoming_message_cond_m_;
   std::condition_variable incoming_message_cond_;
-
   std::mutex state_m;
 
   int port_;
@@ -142,6 +144,7 @@ class AgentImpl : public std::enable_shared_from_this<AgentImpl> {
 
   std::string title_;
   std::string loaded_urls_;
+  std::string targetId_;
 
   friend class ChannelImpl;
   friend class DispatchOnInspectorBackendTask;
@@ -219,6 +222,10 @@ class V8NodeInspector : public v8_inspector::V8InspectorClient {
     inspector_->contextCreated(info);
   }
 
+  void tearDownContext(v8::Local<v8::Context> context) {
+    inspector_->contextDestroyed(context);
+  }
+
   void runMessageLoopOnPause(int context_group_id) override {
     waiting_for_resume_ = true;
     if (running_nested_loop_)
@@ -284,10 +291,26 @@ class V8NodeInspector : public v8_inspector::V8InspectorClient {
   std::unique_ptr<V8Inspector> inspector_;
 };
 
+namespace {
+std::string GenerateID() {
+  static std::random_device rd;
+  static std::mt19937 mte(rd());
+
+  std::uniform_int_distribution<uint16_t> dist;
+
+  std::array<uint16_t, 8> buffer;
+  std::generate(buffer.begin(), buffer.end(), [&]() { return dist(mte); });
+
+  char uuid[256];
+  snprintf(uuid, sizeof(uuid), "%04x%04x-%04x-%04x-%04x-%04x%04x%04x",
+           buffer[0], buffer[1], buffer[2], (buffer[3] & 0x0fff) | 0x4000,
+           (buffer[4] & 0x3fff) | 0x8000, buffer[5], buffer[6], buffer[7]);
+  return uuid;
+}
+}  // namespace
+
 AgentImpl::AgentImpl(
     v8::Isolate *isolate,
-    v8::Local<v8::Context> context,
-    const char *context_name,
     int port)
     : isolate_(isolate),
       port_(port),
@@ -296,9 +319,9 @@ AgentImpl::AgentImpl(
       state_(State::kNew),
       inspector_(nullptr),
       dispatching_messages_(false),
-      session_id_(0) {
+      session_id_(0),
+      targetId_(GenerateID()) {
   inspector_ = std::make_unique<V8NodeInspector>(*this);
-  inspector_->setupContext(context, context_name);
 }
 
 AgentImpl::~AgentImpl() {}
@@ -412,26 +435,34 @@ void AgentImpl::waitForDebugger() {
 
 
 void AgentImpl::Stop() {
-  std::string msg("{\"method\":\"Runtime.executionContextsCleared\"}");
-  Write(session_id_,
-        v8_inspector::StringBuffer::create((v8_inspector::StringView(
-            reinterpret_cast<const uint8_t*>(msg.c_str()), msg.length()))));
+  if (!IsStarted()) return;
 
+  // Note: To close the inspector session, We send a "magic" message, which is an empty message.
+  // Our tcp session code has code to handle the magic message by closing the tcp connection to the browser/vscode/inspector and triggers the close callback to the V8 inspector client.
   Write(session_id_,
         v8_inspector::StringBuffer::create((v8_inspector::StringView(
             reinterpret_cast<const uint8_t*>(""), 0))));
 
   WaitForDisconnect();
-  inspector_.reset();
+  state_ = State::kDone;
+
+  auto& server = ensureServer();
+  server.RemoveTarget(shared_from_this());
 }
 
-//bool AgentImpl::IsConnected() {
-//  auto& server = ensureServer();
-//  return server.IsConnected();
-//}
+bool AgentImpl::IsConnected() { return state_ == State::kConnected; }
 
 bool AgentImpl::IsStarted() {
-  return true;
+  return state_ == State::kAccepting || state_ == State::kConnected;
+}
+
+void AgentImpl::addContext(v8::Local<v8::Context> context,
+                       const char* context_name) {
+  inspector_->setupContext(context, context_name);
+}
+
+void AgentImpl::removeContext(v8::Local<v8::Context> context) {
+  inspector_->tearDownContext(context);
 }
 
 void AgentImpl::WaitForDisconnect() {
@@ -630,13 +661,16 @@ std::string AgentImpl::getTitle() { return title_; }
 // Exported class Agent
 Agent::Agent(
     v8::Isolate *isolate,
-    v8::Local<v8::Context> context,
-    const char *context_name,
     int port)
-    : impl(std::make_shared<AgentImpl>(isolate, context, context_name, port))
-{}
+    : impl(std::make_shared<AgentImpl>(isolate, port)) {
+}
 
 Agent::~Agent() {
+  if (IsStarted()) {
+    stop();
+  }
+
+  agents_s_.erase(shared_from_this());
 }
 
 void Agent::waitForDebugger() {
@@ -656,15 +690,36 @@ bool Agent::IsStarted() {
   return impl->IsStarted();
 }
 
-//bool Agent::IsConnected() {
-//  return impl->IsConnected();
-//}
+void Agent::addContext(v8::Local<v8::Context> context,
+  const char* context_name) {
+  impl->addContext(context, context_name);
+
+  // We want to add the current to the static list in constructor, but shared_from_this can't be called in constructor.
+  auto shared = shared_from_this();
+  agents_s_.insert(shared);
+}
+
+void Agent::removeContext(v8::Local<v8::Context> context) {
+  impl->removeContext(context);
+}
+
+bool Agent::IsConnected() {
+  return impl->IsConnected();
+}
 
 void Agent::WaitForDisconnect() {
   impl->WaitForDisconnect();
 }
 
 void Agent::notifyLoadedUrl(const std::string& url) { impl->notifyLoadedUrl(url); }
+
+std::shared_ptr<Agent> Agent::getShared() { return shared_from_this(); }
+
+/*static*/ std::unordered_set<std::shared_ptr<inspector::Agent>>
+        Agent::agents_s_;
+std::unordered_set<std::shared_ptr<inspector::Agent>> Agent::getActiveAgents() {
+  return agents_s_;
+}
 
 void Agent::FatalException(
     v8::Local<v8::Value> error,
@@ -682,24 +737,6 @@ void InspectorAgentDelegate::StartSession(
   agent->PostIncomingMessage(session_id, TAG_CONNECT);
 }
 
-namespace {
-std::string GenerateID() {
-  static std::random_device rd;
-  static std::mt19937 mte(rd());
-
-  std::uniform_int_distribution<uint16_t> dist;
-
-  std::array<uint16_t, 8> buffer;
-  std::generate(buffer.begin(), buffer.end(), [&]() { return dist(mte); });
-
-  char uuid[256];
-  snprintf(uuid, sizeof(uuid), "%04x%04x-%04x-%04x-%04x-%04x%04x%04x",
-           buffer[0], buffer[1], buffer[2], (buffer[3] & 0x0fff) | 0x4000,
-           (buffer[4] & 0x3fff) | 0x8000, buffer[5], buffer[6], buffer[7]);
-  return uuid;
-}
-}  // namespace
-
 void InspectorAgentDelegate::MessageReceived(
     int session_id,
     const std::string &message) {
@@ -714,8 +751,13 @@ void InspectorAgentDelegate::EndSession(int session_id) {
 
 
 void InspectorAgentDelegate::AddTarget(std::shared_ptr<AgentImpl> agent) {
-  std::string targetId = GenerateID();
+  std::string targetId = agent->targetId();
   targets_map_.emplace(targetId, agent);
+}
+
+void InspectorAgentDelegate::RemoveTarget(std::shared_ptr<AgentImpl> agent) {
+  std::string targetId = agent->targetId();
+  targets_map_.erase(targetId);
 }
 
 std::vector<std::string> InspectorAgentDelegate::GetTargetIds() {

--- a/src/inspector/inspector_socket_server.cpp
+++ b/src/inspector/inspector_socket_server.cpp
@@ -328,10 +328,15 @@ void InspectorSocketServer::AddTarget(std::shared_ptr<AgentImpl> agent) {
   delegate_->AddTarget(agent);
 }
 
+void InspectorSocketServer::RemoveTarget(std::shared_ptr<AgentImpl> agent) {
+  delegate_->RemoveTarget(agent);
+}
+
 bool InspectorSocketServer::Start() {
-  tcp_server_ = std::make_shared<tcp_server>(port_, InspectorSocketServer::SocketConnectedCallback, this);
   state_ = ServerState::kRunning;
   std::thread([this]() {
+    tcp_server_ = std::make_shared<tcp_server>(
+        port_, InspectorSocketServer::SocketConnectedCallback, this);
     tcp_server_->run();
   }).detach();
   return true;

--- a/src/inspector/inspector_socket_server.h
+++ b/src/inspector/inspector_socket_server.h
@@ -27,6 +27,7 @@ class InspectorAgentDelegate {
   std::string GetTargetTitle(const std::string &id);
   std::string GetTargetUrl(const std::string &id);
   void AddTarget(std::shared_ptr<AgentImpl> agent);
+  void RemoveTarget(std::shared_ptr<AgentImpl> agent);
 
  private:
   std::unordered_map<std::string, std::shared_ptr<AgentImpl>> targets_map_;
@@ -51,6 +52,7 @@ public:
   int Port() const;
 
   void AddTarget(std::shared_ptr<AgentImpl> agent);
+  void RemoveTarget(std::shared_ptr<AgentImpl> agent);
 
   // Session connection lifecycle
   void Accept(std::shared_ptr<tcp_connection> connection, int server_port/*, uv_stream_t* server_socket*/);

--- a/src/public/V8JsiRuntime.h
+++ b/src/public/V8JsiRuntime.h
@@ -88,6 +88,10 @@ __attribute__((visibility("default")))
 
 #if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
   __declspec(dllexport) void openInspector(facebook::jsi::Runtime& runtime);
+
+  // This API will be removed once we have a proper entry point for users to enable inspector on an active runtime.
+  // This function should be callable from any thread, including the synthetic WinDbg break thread.
+  // For example, break to the host app and issue this to open the inspector servers : .call v8jsi!v8runtime::openInspectors_toberemoved()
   __declspec(dllexport) void openInspectors_toberemoved();
 #endif
 } // namespace v8runtime

--- a/src/public/V8JsiRuntime.h
+++ b/src/public/V8JsiRuntime.h
@@ -86,4 +86,8 @@ __attribute__((visibility("default")))
 #endif
     std::unique_ptr<facebook::jsi::Runtime> __cdecl makeV8Runtime(V8RuntimeArgs &&args);
 
+#if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
+  __declspec(dllexport) void openInspector(facebook::jsi::Runtime& runtime);
+  __declspec(dllexport) void openInspectors_toberemoved();
+#endif
 } // namespace v8runtime


### PR DESCRIPTION
This change has the following effects,
1. API available to open inspector server on an active runtime instance.
2. Ensure that the server management APIs in inspector can be called from any thread.
3. Ensuring the contexts are registered correctly to the inspector. This will correct some issues in multi context runtimes, and when sharing isolates between runtimes, and also result in more symmetric APIs. I don't think we have a multi context/shared-isolate scenario in Office, but having the right model will help us in better reasoning when diagnosing issues.
4. Some improvements in the shutdown flow.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/59)