### PR TITLE
Revert webassembly disabling

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.63.8",
+    "version": "0.63.9",
     "v8ref": "refs/branch-heads/9.1"
 }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -21,7 +21,7 @@ Push-Location (Join-Path $workpath "v8build\v8")
 # TODO: v8_enable_webassembly=false will reduce the binary size by > 20%, but it causes crashes on x86; needs deeper investigation
 
 # Generate the build system
-$gnargs = 'v8_enable_i18n_support=false v8_enable_webassembly=false is_component_build=false v8_monolithic=true v8_use_external_startup_data=false treat_warnings_as_errors=false'
+$gnargs = 'v8_enable_i18n_support=false is_component_build=false v8_monolithic=true v8_use_external_startup_data=false treat_warnings_as_errors=false'
 
 if ($Configuration -like "*android") {
     $gnargs += ' use_goma=false target_os=\"android\" target_cpu=\"' + $Platform + '\"'

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -18,8 +18,10 @@ Copy-Item $jsigitpath -Destination (Join-Path $workpath "v8build\v8\jsi") -Recur
 
 Push-Location (Join-Path $workpath "v8build\v8")
 
+# TODO: v8_enable_webassembly=false will reduce the binary size by > 20%, but it causes crashes on x86; needs deeper investigation
+
 # Generate the build system
-$gnargs = 'v8_enable_i18n_support=false v8_enable_webassembly=false is_component_build=false v8_monolithic=true v8_use_external_startup_data=false treat_warnings_as_errors=false'
+$gnargs = 'v8_enable_i18n_support=false is_component_build=false v8_monolithic=true v8_use_external_startup_data=false treat_warnings_as_errors=false'
 
 if ($Configuration -like "*android") {
     $gnargs += ' use_goma=false target_os=\"android\" target_cpu=\"' + $Platform + '\"'

--- a/scripts/patch/build.diff
+++ b/scripts/patch/build.diff
@@ -1,24 +1,3 @@
-diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
-index 5ea2f2130..9a88e0651 100644
---- a/config/compiler/BUILD.gn
-+++ b/config/compiler/BUILD.gn
-@@ -1376,8 +1376,6 @@ config("default_warnings") {
-       "/wd4512",  # Assignment operator could not be generated.
-       "/wd4610",  # Class can never be instantiated, constructor required.
-       "/wd4838",  # Narrowing conversion. Doesn't seem to be very useful.
--      "/wd4995",  # 'X': name was marked as #pragma deprecated
--      "/wd4996",  # Deprecated function warning.
- 
-       # These are variable shadowing warnings that are new in VS2015. We
-       # should work through these at some point -- they may be removed from
-@@ -1676,7 +1674,6 @@ config("no_chromium_code") {
-       "/W3",  # Warning level 3.
-       "/wd4800",  # Disable warning when forcing value to bool.
-       "/wd4267",  # TODO(jschuh): size_t to int.
--      "/wd4996",  # Deprecated function warning.
-     ]
-     defines += [
-       "_CRT_NONSTDC_NO_WARNINGS",
 diff --git a/config/win/BUILD.gn b/config/win/BUILD.gn
 index 51437c66c..728555267 100644
 --- a/config/win/BUILD.gn

--- a/scripts/patch/src.diff
+++ b/scripts/patch/src.diff
@@ -132,28 +132,6 @@ index 50da60c72f..3a3b94af98 100644
  // DbgHelp.h functions.
  using DLL_FUNC_TYPE(SymInitialize) = BOOL(__stdcall*)(IN HANDLE hProcess,
                                                        IN PSTR UserSearchPath,
-diff --git a/src/compiler/backend/ia32/instruction-selector-ia32.cc b/src/compiler/backend/ia32/instruction-selector-ia32.cc
-index 033a566e11..99a2ee6f5d 100644
---- a/src/compiler/backend/ia32/instruction-selector-ia32.cc
-+++ b/src/compiler/backend/ia32/instruction-selector-ia32.cc
-@@ -3000,6 +3000,7 @@ void InstructionSelector::VisitI8x16Shuffle(Node* node) {
- void InstructionSelector::VisitI8x16Shuffle(Node* node) { UNREACHABLE(); }
- #endif  // V8_ENABLE_WEBASSEMBLY
- 
-+#if V8_ENABLE_WEBASSEMBLY
- void InstructionSelector::VisitI8x16Swizzle(Node* node) {
-   InstructionCode op = kIA32I8x16Swizzle;
- 
-@@ -3019,6 +3020,9 @@ void InstructionSelector::VisitI8x16Swizzle(Node* node) {
-        g.UseRegister(node->InputAt(0)), g.UseRegister(node->InputAt(1)),
-        arraysize(temps), temps);
- }
-+#else
-+void InstructionSelector::VisitI8x16Swizzle(Node* node) { UNREACHABLE(); }
-+#endif  // V8_ENABLE_WEBASSEMBLY
- 
- namespace {
- void VisitPminOrPmax(InstructionSelector* selector, Node* node,
 diff --git a/src/diagnostics/unwinding-info-win64.cc b/src/diagnostics/unwinding-info-win64.cc
 index 9a5f7069e7..a53c0ad644 100644
 --- a/src/diagnostics/unwinding-info-win64.cc

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -518,7 +518,7 @@ V8Runtime::V8Runtime(V8RuntimeArgs &&args) : args_(std::move(args)) {
   if (args_.flags.enableInspector) {
     TRACEV8RUNTIME_VERBOSE("Inspector enabled");
     inspector_agent_ = std::make_unique<inspector::Agent>(
-        isolate_, context_.Get(GetIsolate()), "JSIRuntime context", args_.inspectorPort);
+        isolate_, context_.Get(GetIsolate()), args_.debuggerRuntimeName.empty() ? "JSIRuntime context" : args_.debuggerRuntimeName.c_str(), args_.inspectorPort);
     inspector_agent_->start();
 
     if (args_.flags.waitForDebugger) {

--- a/src/inspector/inspector_agent.cpp
+++ b/src/inspector/inspector_agent.cpp
@@ -296,6 +296,7 @@ AgentImpl::AgentImpl(
       state_(State::kNew),
       inspector_(nullptr),
       dispatching_messages_(false),
+      title_(context_name),
       session_id_(0) {
   inspector_ = std::make_unique<V8NodeInspector>(*this);
   inspector_->setupContext(context, context_name);

--- a/src/public/V8JsiRuntime.h
+++ b/src/public/V8JsiRuntime.h
@@ -54,6 +54,9 @@ struct V8RuntimeArgs {
   size_t initial_heap_size_in_bytes{0};
   size_t maximum_heap_size_in_bytes{0};
 
+  // Set this to override the target name displayed in the debugger (to distinguish multiple parallel runtimes)
+  std::string debuggerRuntimeName;
+
   // Padded to allow adding boolean flags without breaking the ABI
   union {
     struct {


### PR DESCRIPTION
- revert webassembly disabling which was causing issues with x86 builds (this needs further investigation and follow-up with Google);
- expose debuggerRuntimeName from arguments;

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/60)