### PR TITLE
Fixing issues when tearing down inspector agent

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.64.17",
+    "version": "0.64.18",
     "v8ref": "refs/branch-heads/9.1"
 }

--- a/src/inspector/inspector_agent.cpp
+++ b/src/inspector/inspector_agent.cpp
@@ -460,7 +460,7 @@ bool AgentImpl::IsStarted() {
   return state_ == State::kAccepting || state_ == State::kConnected;
 }
 
-int AgentImpl::getInspectedContextsCount() { assert(inspectedContextsCount_>=0);(return inspectedContextsCount_; }
+int AgentImpl::getInspectedContextsCount() { assert(inspectedContextsCount_>=0); return inspectedContextsCount_; }
 
 void AgentImpl::addContext(v8::Local<v8::Context> context,
                        const char* context_name) {


### PR DESCRIPTION
1. Fixed the crash when removing the inspector server from the global pool of servers.\
2. Ensure the websocket server and connection is closed when the agent is closed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/65)