### PR TITLE
Fix dll resolution for uwp applications

### DIFF
--- a/ReactNative.V8Jsi.Windows.targets
+++ b/ReactNative.V8Jsi.Windows.targets
@@ -1,5 +1,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <V8AppPlatform Condition="'$(V8AppPlatform)' == '' AND $(AppContainerApplication) == 'true'">uwp</V8AppPlatform>
     <V8AppPlatform Condition="'$(V8AppPlatform)' == ''">win32</V8AppPlatform>
 
     <V8Platform Condition="'$(V8Platform)' == ''">$(Platform)</V8Platform>
@@ -18,6 +19,8 @@
   </ItemDefinitionGroup>
   <ItemGroup Condition="'$(V8JsiNoDLLCopy)' == ''">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll" />
+        <!-- We have no winmd, so make sure uwp dlls get copied over -->
+    <CopyLocalFilesOutputGroupOutput Condition="'$(V8AppPlatform)' == 'uwp'" Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll" />
     <!-- Disable publishing PDBs for UWP due to increased package size -->
     <ReferenceCopyLocalPaths Condition="'$(V8AppPlatform)' == 'win32'" Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll.pdb" />
   </ItemGroup>

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.64.17",
+    "version": "0.64.18",
     "v8ref": "refs/branch-heads/9.1"
 }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.64.18",
+    "version": "0.64.19",
     "v8ref": "refs/branch-heads/9.1"
 }


### PR DESCRIPTION
Right now the uwp dlls don't get resolved correctly.

1. The path used always defaults to win32
2. There is no winmd referenced to include the dlls in the build

To fix this, this review adds the following:

1. We set the v8platform to uwp if the application is built with the intention of running in an app container
2. We have the uwp dlls copied to the application output folder so that they get included in the appx

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/66)