### PR TITLE
Fix dll copy path

### DIFF
--- a/ReactNative.V8Jsi.Windows.targets
+++ b/ReactNative.V8Jsi.Windows.targets
@@ -18,10 +18,10 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup Condition="'$(V8JsiNoDLLCopy)' == ''">
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll" />
-        <!-- We have no winmd, so make sure uwp dlls get copied over -->
-    <CopyLocalFilesOutputGroupOutput Condition="'$(V8AppPlatform)' == 'uwp'" Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll" />
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\lib\$(Configuration)\$(V8Platform)\v8jsi.dll" />
+    <!-- We have no winmd, so make sure uwp dlls get copied over -->
+    <CopyLocalFilesOutputGroupOutput Condition="'$(V8AppPlatform)' == 'uwp'" Include="$(MSBuildThisFileDirectory)..\..\lib\$(Configuration)\$(V8Platform)\v8jsi.dll" />
     <!-- Disable publishing PDBs for UWP due to increased package size -->
-    <ReferenceCopyLocalPaths Condition="'$(V8AppPlatform)' == 'win32'" Include="$(MSBuildThisFileDirectory)..\..\lib\$(V8AppPlatform)\$(Configuration)\$(V8Platform)\v8jsi.dll.pdb" />
+    <ReferenceCopyLocalPaths Condition="'$(V8AppPlatform)' == 'win32'" Include="$(MSBuildThisFileDirectory)..\..\lib\$(Configuration)\$(V8Platform)\v8jsi.dll.pdb" />
   </ItemGroup>
 </Project>

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.64.21",
+    "version": "0.64.22",
     "v8ref": "refs/branch-heads/9.3"
 }


### PR DESCRIPTION
Now that the NuGet packages don't have `AppPlatform` folders we should remove that part of the path for the dll.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/72)