### PR TITLE
Apply NAPI TaskRunner

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.65.1",
+    "version": "0.65.2",
     "v8ref": "refs/branch-heads/9.3"
 }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.64.17",
+    "version": "0.64.18",
     "v8ref": "refs/branch-heads/9.1"
 }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -106,7 +106,7 @@ target("executable", "jsitests") {
     ":v8jsi",
     "//build/win:default_exe_manifest",
     "//testing/gtest",
-  ] 
+  ]
 
   configs += [ "//:internal_config_base", "//build/config/compiler:exceptions", "//build/config/compiler:rtti" ]
   configs -= [ "//build/config/compiler:no_exceptions", "//build/config/compiler:no_rtti" ]

--- a/src/napi/js_native_ext_api_v8.cpp
+++ b/src/napi/js_native_ext_api_v8.cpp
@@ -242,12 +242,18 @@ struct NapiJSITaskRunner : v8runtime::JSITaskRunner {
 napi_status napi_ext_create_env(napi_ext_env_settings *settings, napi_env *env)
 {
   v8runtime::V8RuntimeArgs args;
+
   args.flags.trackGCObjectStats       = settings->flags.track_gc_object_stats;
   args.flags.enableJitTracing         = settings->flags.enable_jit_tracing;
   args.flags.enableMessageTracing     = settings->flags.enable_message_tracing;
   args.flags.enableGCTracing          = settings->flags.enable_gc_tracing;
   args.flags.enableGCApi              = settings->flags.enable_gc_api;
   args.flags.ignoreUnhandledPromises  = settings->flags.ignore_unhandled_promises;
+
+  args.foreground_task_runner = std::make_shared<NapiJSITaskRunner>(
+    *env,
+    settings->foreground_scheduler
+  );
 
   auto runtime = std::make_unique<v8runtime::V8Runtime>(std::move(args));
 

--- a/src/napi/js_native_ext_api_v8.cpp
+++ b/src/napi/js_native_ext_api_v8.cpp
@@ -234,6 +234,10 @@ struct NapiJSITaskRunner : v8runtime::JSITaskRunner {
         nullptr);
   }
 
+  void setEnv(napi_env env) {
+    env_ = env;
+  }
+
  private:
   napi_env env_;
   napi_ext_schedule_task_callback scheduler_;
@@ -247,18 +251,22 @@ napi_status napi_ext_create_env(napi_ext_env_settings *settings, napi_env *env)
   args.flags.enableJitTracing         = settings->flags.enable_jit_tracing;
   args.flags.enableMessageTracing     = settings->flags.enable_message_tracing;
   args.flags.enableGCTracing          = settings->flags.enable_gc_tracing;
+  args.flags.enableInspector          = settings->flags.enable_inspector;
+  args.flags.waitForDebugger          = settings->flags.wait_for_debugger;
   args.flags.enableGCApi              = settings->flags.enable_gc_api;
   args.flags.ignoreUnhandledPromises  = settings->flags.ignore_unhandled_promises;
 
-  args.foreground_task_runner = std::make_shared<NapiJSITaskRunner>(
+  auto taskRunner = std::make_shared<NapiJSITaskRunner>(
     *env,
     settings->foreground_scheduler
   );
+  args.foreground_task_runner = taskRunner;
 
   auto runtime = std::make_unique<v8runtime::V8Runtime>(std::move(args));
 
   auto context = v8impl::PersistentToLocal::Strong(runtime->GetContext());
   *env = new napi_env__(context);
+  taskRunner->setEnv(*env);
 
   // Let the runtime exists. It can be accessed from the Context.
   new v8impl::V8RuntimeHolder(*env, runtime.release());


### PR DESCRIPTION
Add remaining settings for the task runner class:

- `enableInspector`
- `waitForDebugger`
- `foreground_scheduler`
  - Required to initialize `foreground_task_runner`

## Notes
- Depends on #74.
- Must be backported to `0.64-stable` and `0.63-stable`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/75)