### PR TITLE
[0.63-stable] Add a flag for enabling built-in V8 ETW instrumentation

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.63.14",
+    "version": "0.63.15",
     "v8ref": "refs/branch-heads/9.3"
 }

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -464,6 +464,9 @@ void V8Runtime::initializeV8() {
   if (args_.flags.enableGCApi)
     argv.push_back("--expose_gc");
 
+  if (args_.flags.enableSystemInstrumentation)
+    argv.push_back("--enable-system-instrumentation");
+
   if (args_.flags.sparkplug)
     argv.push_back("--sparkplug");
 

--- a/src/napi/js_native_ext_api_v8.cpp
+++ b/src/napi/js_native_ext_api_v8.cpp
@@ -247,14 +247,20 @@ napi_status napi_ext_create_env(napi_ext_env_settings *settings, napi_env *env)
 {
   v8runtime::V8RuntimeArgs args;
 
-  args.flags.trackGCObjectStats       = settings->flags.track_gc_object_stats;
-  args.flags.enableJitTracing         = settings->flags.enable_jit_tracing;
-  args.flags.enableMessageTracing     = settings->flags.enable_message_tracing;
-  args.flags.enableGCTracing          = settings->flags.enable_gc_tracing;
-  args.flags.enableInspector          = settings->flags.enable_inspector;
-  args.flags.waitForDebugger          = settings->flags.wait_for_debugger;
-  args.flags.enableGCApi              = settings->flags.enable_gc_api;
-  args.flags.ignoreUnhandledPromises  = settings->flags.ignore_unhandled_promises;
+  args.flags.trackGCObjectStats           = settings->flags.track_gc_object_stats;
+  args.flags.enableJitTracing             = settings->flags.enable_jit_tracing;
+  args.flags.enableMessageTracing         = settings->flags.enable_message_tracing;
+  args.flags.enableGCTracing              = settings->flags.enable_gc_tracing;
+  args.flags.enableInspector              = settings->flags.enable_inspector;
+  args.flags.waitForDebugger              = settings->flags.wait_for_debugger;
+  args.flags.enableGCApi                  = settings->flags.enable_gc_api;
+  args.flags.ignoreUnhandledPromises      = settings->flags.ignore_unhandled_promises;
+  args.flags.enableSystemInstrumentation  = settings->flags.enable_system_instrumentation;
+  args.flags.sparkplug                    = settings->flags.sparkplug;
+  args.flags.predictable                  = settings->flags.predictable;
+  args.flags.optimize_for_size            = settings->flags.optimize_for_size;
+  args.flags.always_compact               = settings->flags.always_compact;
+  args.flags.jitless                      = settings->flags.jitless;
 
   auto taskRunner = std::make_shared<NapiJSITaskRunner>(
     *env,

--- a/src/public/V8JsiRuntime.h
+++ b/src/public/V8JsiRuntime.h
@@ -68,6 +68,7 @@ struct V8RuntimeArgs {
       bool waitForDebugger:1;
       bool enableGCApi:1;
       bool ignoreUnhandledPromises:1;
+      bool enableSystemInstrumentation:1; // Provider GUID "57277741-3638-4A4B-BDBA-0AC6E45DA56C"
 
       // Experimental flags (for memory-constrained optimization testing)
       bool sparkplug:1; // https://v8.dev/blog/sparkplug

--- a/src/public/js_native_ext_api.h
+++ b/src/public/js_native_ext_api.h
@@ -81,6 +81,7 @@ typedef struct _napi_ext_env_settings
       bool wait_for_debugger:1;
       bool enable_gc_api:1;
       bool ignore_unhandled_promises:1;
+      bool enable_system_instrumentation:1;
 
       // Experimental flags (for memory-constrained optimization testing)
       bool sparkplug:1; // https://v8.dev/blog/sparkplug


### PR DESCRIPTION
Backport / cherry-pick from master

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/81)