### PR TITLE
Configure Component Governance to ignore build\v8build\depot_tools

### DIFF
--- a/.ado/android-build.yml
+++ b/.ado/android-build.yml
@@ -10,6 +10,10 @@ steps:
       filePath: $(Build.SourcesDirectory)/android/scripts/build.sh
       arguments: -p $(BuildPlatform) -f $(BuildFlavor) -s $(Build.SourcesDirectory)/android -o ${{parameters.outputPath}}
 
+  - task: ComponentGovernanceComponentDetection@0
+    inputs:
+      ignoreDirectories: 'build\v8build\depot_tools'
+
   - task: PublishBuildArtifacts@1
     displayName: "Publish Android artifacts"
     inputs:

--- a/.ado/build-dll.yml
+++ b/.ado/build-dll.yml
@@ -60,6 +60,10 @@ steps:
       vsTestVersion: latest
     condition: and(succeeded(), not(startsWith(variables.BuildPlatform, 'arm')), eq(variables.RunUnitTests, true))
 
+  - task: ComponentGovernanceComponentDetection@0
+    inputs:
+      ignoreDirectories: 'build\v8build\depot_tools'
+
   - task: PublishBuildArtifacts@1
     displayName: "Publish artifacts"
     inputs:


### PR DESCRIPTION
We have a lot of Component Governance (CG) alerts for this repo right now. Most of these appear to be coming from V8 code, which is downloaded at build time. This PR overwrites the auto-injected CG ADO task and adds a manual one that's configured to ignore build\v8build\depot_tools.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/93)