### PR TITLE
Protect tcp_server access

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.65.6",
+    "version": "0.65.7",
     "v8ref": "refs/branch-heads/9.7"
 }

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -704,7 +704,7 @@ jsi::Value V8Runtime::ExecuteString(const v8::Local<v8::String> &source, const s
   std::shared_ptr<const jsi::Buffer> cache;
   if (args_.preparedScriptStore) {
     jsi::ScriptSignature scriptSignature = {sourceURL, 1};
-    jsi::JSRuntimeSignature runtimeSignature = {"V8", 76};
+    jsi::JSRuntimeSignature runtimeSignature = {"V8", V8_MAJOR_VERSION * 10000 + V8_MINOR_VERSION * 1000 + V8_BUILD_NUMBER};
     cache = args_.preparedScriptStore->tryGetPreparedScript(scriptSignature, runtimeSignature, "perf");
   }
 
@@ -740,7 +740,7 @@ jsi::Value V8Runtime::ExecuteString(const v8::Local<v8::String> &source, const s
         v8::ScriptCompiler::CachedData *codeCache = v8::ScriptCompiler::CreateCodeCache(script->GetUnboundScript());
 
         jsi::ScriptSignature scriptSignature = {sourceURL, 1};
-        jsi::JSRuntimeSignature runtimeSignature = {"V8", 76};
+        jsi::JSRuntimeSignature runtimeSignature = {"V8", V8_MAJOR_VERSION * 10000 + V8_MINOR_VERSION * 1000 + V8_BUILD_NUMBER};
 
         args_.preparedScriptStore->persistPreparedScript(
             std::make_shared<ByteArrayBuffer>(codeCache->data, codeCache->length),

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -701,10 +701,12 @@ jsi::Value V8Runtime::ExecuteString(const v8::Local<v8::String> &source, const s
   v8::ScriptCompiler::CompileOptions options = v8::ScriptCompiler::CompileOptions::kNoCompileOptions;
   v8::ScriptCompiler::CachedData *cached_data = nullptr;
 
+  jsi::JSRuntimeVersion_t runtimeVersion = V8_MAJOR_VERSION * 10000 + V8_MINOR_VERSION * 1000 + V8_BUILD_NUMBER;
+
   std::shared_ptr<const jsi::Buffer> cache;
   if (args_.preparedScriptStore) {
     jsi::ScriptSignature scriptSignature = {sourceURL, 1};
-    jsi::JSRuntimeSignature runtimeSignature = {"V8", V8_MAJOR_VERSION * 10000 + V8_MINOR_VERSION * 1000 + V8_BUILD_NUMBER};
+    jsi::JSRuntimeSignature runtimeSignature = {"V8", runtimeVersion};
     cache = args_.preparedScriptStore->tryGetPreparedScript(scriptSignature, runtimeSignature, "perf");
   }
 
@@ -740,7 +742,7 @@ jsi::Value V8Runtime::ExecuteString(const v8::Local<v8::String> &source, const s
         v8::ScriptCompiler::CachedData *codeCache = v8::ScriptCompiler::CreateCodeCache(script->GetUnboundScript());
 
         jsi::ScriptSignature scriptSignature = {sourceURL, 1};
-        jsi::JSRuntimeSignature runtimeSignature = {"V8", V8_MAJOR_VERSION * 10000 + V8_MINOR_VERSION * 1000 + V8_BUILD_NUMBER};
+        jsi::JSRuntimeSignature runtimeSignature = {"V8", runtimeVersion};
 
         args_.preparedScriptStore->persistPreparedScript(
             std::make_shared<ByteArrayBuffer>(codeCache->data, codeCache->length),

--- a/src/inspector/inspector_socket_server.cpp
+++ b/src/inspector/inspector_socket_server.cpp
@@ -339,12 +339,16 @@ bool InspectorSocketServer::HasTargets() {
 bool InspectorSocketServer::Start() {
   state_ = ServerState::kRunning;
 
-  // It feels safer to lock before the thread jump; if we get through Start, then Stop, then the thread gets scheduled now touching deleted memory that's not good either.
-  // In real-life this won't really matter; it's only an issue in unit tests that quickly bring up and tear down runtimes.
-  std::unique_lock<std::mutex> tcp_server_lock(mutex_tcp_server_);
-  std::thread([this, lock = std::move(tcp_server_lock)]() {
-    tcp_server_ = std::make_shared<tcp_server>(
-        port_, InspectorSocketServer::SocketConnectedCallback, this);
+  std::thread([this]() {
+    {
+      std::unique_lock<std::mutex> tcp_server_lock(mutex_tcp_server_);
+      if (tcp_server_stopped_) {
+        return;
+      }
+
+      tcp_server_ = std::make_shared<tcp_server>(port_, InspectorSocketServer::SocketConnectedCallback, this);
+    }
+
     tcp_server_->run();
   }).detach();
   return true;
@@ -361,6 +365,7 @@ void InspectorSocketServer::Stop() {
     std::unique_lock<std::mutex> tcp_server_lock(mutex_tcp_server_);
     // This will stop the the server io_context which will result in stopping the server thread as well.
     tcp_server_->stop();
+    tcp_server_stopped_ = true;
   }
 
   if (state_ == ServerState::kStopped) {

--- a/src/inspector/inspector_socket_server.cpp
+++ b/src/inspector/inspector_socket_server.cpp
@@ -338,6 +338,9 @@ bool InspectorSocketServer::HasTargets() {
 
 bool InspectorSocketServer::Start() {
   state_ = ServerState::kRunning;
+
+  // It feels safer to lock before the thread jump; if we get through Start, then Stop, then the thread gets scheduled now touching deleted memory that's not good either.
+  // In real-life this won't really matter; it's only an issue in unit tests that quickly bring up and tear down runtimes.
   std::unique_lock<std::mutex> tcp_server_lock(mutex_tcp_server_);
   std::thread([this, lock = std::move(tcp_server_lock)]() {
     tcp_server_ = std::make_shared<tcp_server>(

--- a/src/inspector/inspector_socket_server.cpp
+++ b/src/inspector/inspector_socket_server.cpp
@@ -337,6 +337,7 @@ bool InspectorSocketServer::HasTargets() {
 }
 
 bool InspectorSocketServer::Start() {
+  CHECK_NE(state_, ServerState::kStopped);
   state_ = ServerState::kRunning;
 
   std::thread([self = shared_from_this()]() {
@@ -364,7 +365,10 @@ void InspectorSocketServer::Stop() {
   {
     std::unique_lock<std::mutex> tcp_server_lock(mutex_tcp_server_);
     // This will stop the the server io_context which will result in stopping the server thread as well.
-    tcp_server_->stop();
+    if (tcp_server_) {
+      tcp_server_->stop();
+    }
+
     tcp_server_stopped_ = true;
   }
 

--- a/src/inspector/inspector_socket_server.cpp
+++ b/src/inspector/inspector_socket_server.cpp
@@ -339,17 +339,17 @@ bool InspectorSocketServer::HasTargets() {
 bool InspectorSocketServer::Start() {
   state_ = ServerState::kRunning;
 
-  std::thread([this]() {
+  std::thread([self = shared_from_this()]() {
     {
-      std::unique_lock<std::mutex> tcp_server_lock(mutex_tcp_server_);
-      if (tcp_server_stopped_) {
+      std::unique_lock<std::mutex> tcp_server_lock(self->mutex_tcp_server_);
+      if (self->tcp_server_stopped_) {
         return;
       }
 
-      tcp_server_ = std::make_shared<tcp_server>(port_, InspectorSocketServer::SocketConnectedCallback, this);
+      self->tcp_server_ = std::make_shared<tcp_server>(self->port_, InspectorSocketServer::SocketConnectedCallback, self.get());
     }
 
-    tcp_server_->run();
+    self->tcp_server_->run();
   }).detach();
   return true;
 }

--- a/src/inspector/inspector_socket_server.h
+++ b/src/inspector/inspector_socket_server.h
@@ -38,7 +38,7 @@ class InspectorAgentDelegate {
 // HTTP Server, writes messages requested as TransportActions, and responds
 // to HTTP requests and WS upgrades.
 
-class InspectorSocketServer {
+class InspectorSocketServer : public std::enable_shared_from_this<InspectorSocketServer> {
 public:
   InspectorSocketServer(std::unique_ptr<InspectorAgentDelegate>&& delegate, int port,
     FILE* out = stderr);

--- a/src/inspector/inspector_socket_server.h
+++ b/src/inspector/inspector_socket_server.h
@@ -83,6 +83,7 @@ private:
 
   std::mutex mutex_tcp_server_;
   std::shared_ptr<tcp_server> tcp_server_;
+  bool tcp_server_stopped_{false};
   
   int next_session_id_;
   FILE* out_;

--- a/src/inspector/inspector_socket_server.h
+++ b/src/inspector/inspector_socket_server.h
@@ -81,6 +81,7 @@ private:
   const std::string host_;
   int port_;
 
+  std::mutex mutex_tcp_server_;
   std::shared_ptr<tcp_server> tcp_server_;
   
   int next_session_id_;

--- a/src/testmain.cpp
+++ b/src/testmain.cpp
@@ -28,6 +28,17 @@ std::vector<facebook::jsi::RuntimeFactory> runtimeGenerators() {
 } // namespace jsi
 } // namespace facebook
 
+TEST(Basic, CreateManyRuntimes) {
+  for(size_t i = 0; i < 100; i++) {
+    v8runtime::V8RuntimeArgs args;
+    args.flags.enableInspector = true;
+    auto runtime = v8runtime::makeV8Runtime(std::move(args));
+
+    runtime->evaluateJavaScript(std::make_unique<facebook::jsi::StringBuffer>("x = 1"), "");
+    EXPECT_EQ(runtime->global().getProperty(*runtime, "x").getNumber(), 1);
+  }
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
If the runtime is quickly created and torn down with inspector enabled we could end up trying to destroy tcp_server before it finishes creating.

This change protects its creation / destruction with a mutex.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/99)