### PR TITLE
Populate a real runtime signature for PreparedScriptStore

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.64.28",
+    "version": "0.64.29",
     "v8ref": "refs/branch-heads/9.7"
 }

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -700,7 +700,7 @@ jsi::Value V8Runtime::ExecuteString(const v8::Local<v8::String> &source, const s
   std::shared_ptr<const jsi::Buffer> cache;
   if (args_.preparedScriptStore) {
     jsi::ScriptSignature scriptSignature = {sourceURL, 1};
-    jsi::JSRuntimeSignature runtimeSignature = {"V8", 76};
+    jsi::JSRuntimeSignature runtimeSignature = {"V8", V8_MAJOR_VERSION * 10000 + V8_MINOR_VERSION * 1000 + V8_BUILD_NUMBER};
     cache = args_.preparedScriptStore->tryGetPreparedScript(scriptSignature, runtimeSignature, "perf");
   }
 
@@ -736,7 +736,7 @@ jsi::Value V8Runtime::ExecuteString(const v8::Local<v8::String> &source, const s
         v8::ScriptCompiler::CachedData *codeCache = v8::ScriptCompiler::CreateCodeCache(script->GetUnboundScript());
 
         jsi::ScriptSignature scriptSignature = {sourceURL, 1};
-        jsi::JSRuntimeSignature runtimeSignature = {"V8", 76};
+        jsi::JSRuntimeSignature runtimeSignature = {"V8", V8_MAJOR_VERSION * 10000 + V8_MINOR_VERSION * 1000 + V8_BUILD_NUMBER};
 
         args_.preparedScriptStore->persistPreparedScript(
             std::make_shared<ByteArrayBuffer>(codeCache->data, codeCache->length),


### PR DESCRIPTION
Use the V8 build number to compose a "runtime signature" for use by the script cache; this would ensure we won't try to load script caches from potentially incompatible V8 builds.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/100)