### PR TITLE
Add unit tests for Inspector Stop

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.64.29",
+    "version": "0.64.30",
     "v8ref": "refs/branch-heads/9.7"
 }

--- a/src/inspector/inspector_socket_server.cpp
+++ b/src/inspector/inspector_socket_server.cpp
@@ -338,10 +338,17 @@ bool InspectorSocketServer::HasTargets() {
 
 bool InspectorSocketServer::Start() {
   state_ = ServerState::kRunning;
-  std::unique_lock<std::mutex> tcp_server_lock(mutex_tcp_server_);
-  std::thread([this, lock = std::move(tcp_server_lock)]() {
-    tcp_server_ = std::make_shared<tcp_server>(
-        port_, InspectorSocketServer::SocketConnectedCallback, this);
+
+  std::thread([this]() {
+    {
+      std::unique_lock<std::mutex> tcp_server_lock(mutex_tcp_server_);
+      if (tcp_server_stopped_) {
+        return;
+      }
+
+      tcp_server_ = std::make_shared<tcp_server>(port_, InspectorSocketServer::SocketConnectedCallback, this);
+    }
+
     tcp_server_->run();
   }).detach();
   return true;
@@ -358,6 +365,7 @@ void InspectorSocketServer::Stop() {
     std::unique_lock<std::mutex> tcp_server_lock(mutex_tcp_server_);
     // This will stop the the server io_context which will result in stopping the server thread as well.
     tcp_server_->stop();
+    tcp_server_stopped_ = true;
   }
 
   if (state_ == ServerState::kStopped) {

--- a/src/inspector/inspector_socket_server.cpp
+++ b/src/inspector/inspector_socket_server.cpp
@@ -339,17 +339,17 @@ bool InspectorSocketServer::HasTargets() {
 bool InspectorSocketServer::Start() {
   state_ = ServerState::kRunning;
 
-  std::thread([this]() {
+  std::thread([self = shared_from_this()]() {
     {
-      std::unique_lock<std::mutex> tcp_server_lock(mutex_tcp_server_);
-      if (tcp_server_stopped_) {
+      std::unique_lock<std::mutex> tcp_server_lock(self->mutex_tcp_server_);
+      if (self->tcp_server_stopped_) {
         return;
       }
 
-      tcp_server_ = std::make_shared<tcp_server>(port_, InspectorSocketServer::SocketConnectedCallback, this);
+      self->tcp_server_ = std::make_shared<tcp_server>(self->port_, InspectorSocketServer::SocketConnectedCallback, self.get());
     }
 
-    tcp_server_->run();
+    self->tcp_server_->run();
   }).detach();
   return true;
 }

--- a/src/inspector/inspector_socket_server.h
+++ b/src/inspector/inspector_socket_server.h
@@ -38,7 +38,7 @@ class InspectorAgentDelegate {
 // HTTP Server, writes messages requested as TransportActions, and responds
 // to HTTP requests and WS upgrades.
 
-class InspectorSocketServer {
+class InspectorSocketServer : public std::enable_shared_from_this<InspectorSocketServer> {
 public:
   InspectorSocketServer(std::unique_ptr<InspectorAgentDelegate>&& delegate, int port,
     FILE* out = stderr);

--- a/src/inspector/inspector_socket_server.h
+++ b/src/inspector/inspector_socket_server.h
@@ -83,6 +83,7 @@ private:
 
   std::mutex mutex_tcp_server_;
   std::shared_ptr<tcp_server> tcp_server_;
+  bool tcp_server_stopped_{false};
   
   int next_session_id_;
   FILE* out_;

--- a/src/testmain.cpp
+++ b/src/testmain.cpp
@@ -28,6 +28,17 @@ std::vector<facebook::jsi::RuntimeFactory> runtimeGenerators() {
 } // namespace jsi
 } // namespace facebook
 
+TEST(Basic, CreateManyRuntimes) {
+  for(size_t i = 0; i < 100; i++) {
+    v8runtime::V8RuntimeArgs args;
+    args.flags.enableInspector = true;
+    auto runtime = v8runtime::makeV8Runtime(std::move(args));
+
+    runtime->evaluateJavaScript(std::make_unique<facebook::jsi::StringBuffer>("x = 1"), "");
+    EXPECT_EQ(runtime->global().getProperty(*runtime, "x").getNumber(), 1);
+  }
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
- Fix the locking code in InspectorSocketServer Start / Stop
- Add unit test for the issue of rapid instance creation / destruction

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/101)