### PR TITLE
[0.64] Update to V8 9.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 build
-out
 .vscode
 build.log
 src/version_gen.rc
+
+# outputs
+out
+*.nupkg

--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@ A V8 adapter implemention of the JSI interface for the react-native framework.
 [![Build Status](https://dev.azure.com/ms/v8-jsi/_apis/build/status/microsoft.v8-jsi?branchName=master)](https://dev.azure.com/ms/v8-jsi/_build/latest?definitionId=321&branchName=master)
 
 ## Building
-Run ./localbuild.ps1 in a PowerShell terminal; by default, this will only build the win32 x64 release version of the binary. Edit the file to specify other platforms, architectures or flavors.
+
+#### Windows
+Run `./localbuild.ps1` in a PowerShell terminal; by default, this will only build the win32 x64 debug version of the binary. Edit the file to specify other platforms, architectures or flavors.
+
+#### Android
+From the `android` directory, run `./localbuild.sh` in a bash terminal; by default, this will build the x64 debug version of the binary for Android. To build for other platforms and flavors, supply the `--platform` (or `-p`) and the `--flavor` (or `-f`) flags, like so:
+
+`./localbuild.sh --platform <platform-name> --flavor <flavor-name>`
+
+The following platforms and flavors are supported:
+*   `<platform-name>`: x64 (default), x86, arm, arm64
+*   `<flavor-name>` debug (default), ship
+
+This build requires **Ubuntu 18.04** or below, or **Debian 8** or later.
+
+Currently, the Android version builds an older release of V8 (7.0.276.32) and uses Android NDK r21b and the JSI headers from React Native 0.64.2 (see [build.config](android/build.config)). The Windows version builds V8 9.5 and uses the JSI headers from React Native 0.65.5. Android also currently uses a different V8Runtime ([V8Runtime.h](android/V8Runtime.h)) than Windows ([V8JsiRuntime.h](src/public/V8JsiRuntime.h)). Future Android releases will sync the Android dependencies with Windows and support newer Linux versions.
 
 ### Out-of-sync issues
 Until the JSI headers find a more suitable home, they're currently duplicated between the various repos. Code in jsi\jsi should be synchronized with the matching version of JSI from react-native (from https://github.com/facebook/hermes/tree/master/API/jsi/jsi).

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.64.32",
+    "version": "0.64.33",
     "v8ref": "refs/branch-heads/9.9"
 }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "version": "0.64.32",
-    "v8ref": "refs/branch-heads/9.7"
+    "v8ref": "refs/branch-heads/9.9"
 }

--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -96,3 +96,6 @@ $asioDownload | Expand-Archive -DestinationPath $asioPath -Force
 
 $env:ASIO_ROOT = Join-Path $asioPath "asio-asio-1-18-1\asio\include"
 Write-Host "##vso[task.setvariable variable=ASIO_ROOT;]$env:ASIO_ROOT"
+
+# Remove unused code
+Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\third_party\perfetto")

--- a/scripts/patch/src.diff
+++ b/scripts/patch/src.diff
@@ -1,8 +1,8 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index bca5b5356b..bd31583843 100644
+index 7304e8c3f9..264dd4e4f6 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -1191,7 +1191,7 @@ config("toolchain") {
+@@ -1195,7 +1195,7 @@ config("toolchain") {
    } else if (target_os == "mac") {
      defines += [ "V8_HAVE_TARGET_OS" ]
      defines += [ "V8_TARGET_OS_MACOSX" ]
@@ -11,7 +11,7 @@ index bca5b5356b..bd31583843 100644
      defines += [ "V8_HAVE_TARGET_OS" ]
      defines += [ "V8_TARGET_OS_WIN" ]
    }
-@@ -5152,7 +5152,6 @@ v8_component("v8_libbase") {
+@@ -5179,7 +5179,6 @@ v8_component("v8_libbase") {
      defines += [ "_CRT_RAND_S" ]  # for rand_s()
  
      libs = [
@@ -19,7 +19,7 @@ index bca5b5356b..bd31583843 100644
        "winmm.lib",
        "ws2_32.lib",
      ]
-@@ -6770,3 +6769,9 @@ if (!build_with_chromium && v8_use_perfetto) {
+@@ -6797,3 +6796,9 @@ if (!build_with_chromium && v8_use_perfetto) {
      ]
    }
  }  # if (!build_with_chromium && v8_use_perfetto)
@@ -31,10 +31,10 @@ index bca5b5356b..bd31583843 100644
 +}
 \ No newline at end of file
 diff --git a/DEPS b/DEPS
-index 8d1be4a658..33e03b3def 100644
+index 7ef726b46f..a3dbe02f9a 100644
 --- a/DEPS
 +++ b/DEPS
-@@ -593,4 +593,15 @@ hooks = [
+@@ -597,4 +597,15 @@ hooks = [
        'tools/generate-header-include-checks.py',
      ],
    },
@@ -51,13 +51,13 @@ index 8d1be4a658..33e03b3def 100644
 +  }
  ]
 diff --git a/gni/snapshot_toolchain.gni b/gni/snapshot_toolchain.gni
-index feabd079e0..d9651731e4 100644
+index 39b196521c..f8c8b339ab 100644
 --- a/gni/snapshot_toolchain.gni
 +++ b/gni/snapshot_toolchain.gni
-@@ -70,6 +70,9 @@ if (v8_snapshot_toolchain == "") {
-     # therefore snapshots will need to be built using native mksnapshot
-     # in combination with qemu
-     v8_snapshot_toolchain = current_toolchain
+@@ -74,6 +74,9 @@ if (v8_snapshot_toolchain == "") {
+     # Cross-build from arm64 to intel (likely on an Apple Silicon mac).
+     v8_snapshot_toolchain =
+         "//build/toolchain/${host_os}:clang_arm64_v8_$v8_current_cpu"
 +  } else if (target_os == "winuwp") {
 +    # cross compile UWP Windows with host toolchain (for x64 and x86)
 +    v8_snapshot_toolchain = host_toolchain
@@ -114,10 +114,10 @@ index f981bec610..574602f10b 100644
  }  // namespace base
  }  // namespace v8
 diff --git a/src/base/platform/platform-win32.cc b/src/base/platform/platform-win32.cc
-index 919c3ef4df..e9422a7752 100644
+index 4292f7e728..cba916a46e 100644
 --- a/src/base/platform/platform-win32.cc
 +++ b/src/base/platform/platform-win32.cc
-@@ -1110,8 +1110,8 @@ Win32MemoryMappedFile::~Win32MemoryMappedFile() {
+@@ -1212,8 +1212,8 @@ bool AddressSpaceReservation::DecommitPages(void* address, size_t size) {
  #define VOID void
  #endif
  
@@ -151,10 +151,10 @@ index d50767421a..3d296db7c6 100644
      // handling only unwind info for compatibility.
      if (unhandled_exception_callback_g) {
 diff --git a/src/objects/scope-info.cc b/src/objects/scope-info.cc
-index 08b744e4a2..23f60e2918 100644
+index 982ecbc4d0..d87643eb26 100644
 --- a/src/objects/scope-info.cc
 +++ b/src/objects/scope-info.cc
-@@ -944,6 +944,8 @@ int ScopeInfo::ParametersStartIndex() const {
+@@ -951,6 +951,8 @@ int ScopeInfo::ParametersStartIndex() const {
  }
  
  int ScopeInfo::FunctionContextSlotIndex(String name) const {
@@ -199,7 +199,7 @@ index fcccc78ee5..42d8d190ba 100644
  
  LONG HandleWasmTrap(EXCEPTION_POINTERS* exception) {
 diff --git a/src/trap-handler/handler-outside-simulator.cc b/src/trap-handler/handler-outside-simulator.cc
-index d59debe625..fc35a6e8f6 100644
+index d59debe625..0e48707985 100644
 --- a/src/trap-handler/handler-outside-simulator.cc
 +++ b/src/trap-handler/handler-outside-simulator.cc
 @@ -11,6 +11,12 @@
@@ -236,24 +236,24 @@ index 79ddf56653..d83f88ebb9 100644
  #define V8_TRAP_HANDLER_SUPPORTED true
  // Everything else is unsupported.
 diff --git a/src/utils/allocation.cc b/src/utils/allocation.cc
-index f7bf9af2fb..c4bfd36288 100644
+index 033cdc32f0..590fd5c602 100644
 --- a/src/utils/allocation.cc
 +++ b/src/utils/allocation.cc
-@@ -80,8 +80,10 @@ const int kAllocationTries = 2;
+@@ -82,8 +82,10 @@ const int kAllocationTries = 2;
  }  // namespace
  
  v8::PageAllocator* GetPlatformPageAllocator() {
 -  DCHECK_NOT_NULL(GetPageAllocatorInitializer()->page_allocator());
 -  return GetPageAllocatorInitializer()->page_allocator();
-+  // DCHECK_NOT_NULL(GetPageAllocatorInitializer()->page_allocator());
-+  // return GetPageAllocatorInitializer()->page_allocator();
++  //DCHECK_NOT_NULL(GetPageAllocatorInitializer()->page_allocator());
++  //return GetPageAllocatorInitializer()->page_allocator();
 +
 +  return V8::GetCurrentPlatform()->GetPageAllocator();
  }
  
- #ifdef V8_VIRTUAL_MEMORY_CAGE
+ v8::VirtualAddressSpace* GetPlatformVirtualAddressSpace() {
 diff --git a/src/wasm/wasm-module-builder.h b/src/wasm/wasm-module-builder.h
-index 7ba140775d..0de10ba95c 100644
+index ca4ed582df..308a7bf7ea 100644
 --- a/src/wasm/wasm-module-builder.h
 +++ b/src/wasm/wasm-module-builder.h
 @@ -438,7 +438,7 @@ class V8_EXPORT_PRIVATE WasmModuleBuilder : public ZoneObject {

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -1574,17 +1574,6 @@ void V8Runtime::SetIsEnvDeleted() noexcept {
 }
 
 //=============================================================================
-// StringViewHash implementation
-//=============================================================================
-
-size_t StringViewHash::operator()(napijsi::string_view view) const noexcept {
-  return s_classic_collate.hash(view.begin(), view.end());
-}
-
-/*static*/ const std::collate<char> &StringViewHash::s_classic_collate =
-    std::use_facet<std::collate<char>>(std::locale::classic());
-
-//=============================================================================
 // NapiUniqueString implementation
 //=============================================================================
 
@@ -1592,8 +1581,8 @@ NapiUniqueString::NapiUniqueString(napi_env env, std::string value) noexcept : e
 
 NapiUniqueString::~NapiUniqueString() noexcept {}
 
-napijsi::string_view NapiUniqueString::GetView() const noexcept {
-  return napijsi::string_view{value_};
+std::string_view NapiUniqueString::GetView() const noexcept {
+  return std::string_view{value_};
 }
 
 napi_ext_ref NapiUniqueString::GetRef() const noexcept {

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <sstream>
 #include <unordered_map>
+#include <string_view>
 
 #include <cstdlib>
 
@@ -122,16 +123,6 @@ struct UnhandledPromiseRejection {
   v8::Global<v8::Value> value;
 };
 
-// To satisfy the string_view requirement to have the same has result as std::string
-// we use the std::collate<char> for classic code page to calculate hash.
-// This code must be removed when we switch to C++17.
-struct StringViewHash {
-  size_t operator()(napijsi::string_view view) const noexcept;
-
- private:
-  static const std::collate<char> &s_classic_collate;
-};
-
 // We use unique strings for property names to allow their comparison by address.
 struct NapiUniqueString {
   NapiUniqueString(napi_env env, std::string value) noexcept;
@@ -141,7 +132,7 @@ struct NapiUniqueString {
 
   ~NapiUniqueString() noexcept;
 
-  napijsi::string_view GetView() const noexcept;
+  std::string_view GetView() const noexcept;
   napi_ext_ref GetRef() const noexcept;
   void SetRef(napi_ext_ref ref) noexcept;
 
@@ -689,7 +680,7 @@ class V8Runtime : public facebook::jsi::Runtime {
 
   bool ignore_unhandled_promises_{false};
   std::unique_ptr<UnhandledPromiseRejection> last_unhandled_promise_;
-  std::unordered_map<napijsi::string_view, std::unique_ptr<NapiUniqueString>, StringViewHash> unique_strings_;
+  std::unordered_map<std::string_view, std::unique_ptr<NapiUniqueString>> unique_strings_;
 
   bool is_env_deleted_{false};
 

--- a/src/public/NapiJsiRuntime.cpp
+++ b/src/public/NapiJsiRuntime.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <memory>
 #include <sstream>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 #include "compat.h"
@@ -51,6 +52,9 @@
 namespace napijsi {
 // Make the whole implementation local.
 namespace {
+
+using std::string_view;
+using namespace std::literals;
 
 // Implementation of N-API JSI Runtime
 struct NapiJsiRuntime : facebook::jsi::Runtime {
@@ -498,26 +502,26 @@ struct NapiJsiRuntime : facebook::jsi::Runtime {
 
 NapiJsiRuntime::NapiJsiRuntime(napi_env env) noexcept : m_env{env} {
   EnvScope envScope{m_env};
-  m_propertyId.Error = NapiRefHolder{this, GetPropertyIdFromName("Error"_sv)};
-  m_propertyId.Object = NapiRefHolder{this, GetPropertyIdFromName("Object"_sv)};
-  m_propertyId.Proxy = NapiRefHolder{this, GetPropertyIdFromName("Proxy"_sv)};
-  m_propertyId.Symbol = NapiRefHolder{this, GetPropertyIdFromName("Symbol"_sv)};
-  m_propertyId.byteLength = NapiRefHolder{this, GetPropertyIdFromName("byteLength"_sv)};
-  m_propertyId.configurable = NapiRefHolder{this, GetPropertyIdFromName("configurable"_sv)};
-  m_propertyId.enumerable = NapiRefHolder{this, GetPropertyIdFromName("enumerable"_sv)};
-  m_propertyId.get = NapiRefHolder{this, GetPropertyIdFromName("get"_sv)};
-  m_propertyId.getOwnPropertyDescriptor = NapiRefHolder{this, GetPropertyIdFromName("getOwnPropertyDescriptor"_sv)};
-  m_propertyId.hostFunctionSymbol = NapiRefHolder{this, CreateSymbol("hostFunctionSymbol"_sv)};
-  m_propertyId.hostObjectSymbol = NapiRefHolder{this, CreateSymbol("hostObjectSymbol"_sv)};
-  m_propertyId.length = NapiRefHolder{this, GetPropertyIdFromName("length"_sv)};
-  m_propertyId.message = NapiRefHolder{this, GetPropertyIdFromName("message"_sv)};
-  m_propertyId.ownKeys = NapiRefHolder{this, GetPropertyIdFromName("ownKeys"_sv)};
-  m_propertyId.propertyIsEnumerable = NapiRefHolder{this, GetPropertyIdFromName("propertyIsEnumerable"_sv)};
-  m_propertyId.prototype = NapiRefHolder{this, GetPropertyIdFromName("prototype"_sv)};
-  m_propertyId.set = NapiRefHolder{this, GetPropertyIdFromName("set"_sv)};
-  m_propertyId.toString = NapiRefHolder{this, GetPropertyIdFromName("toString"_sv)};
-  m_propertyId.value = NapiRefHolder{this, GetPropertyIdFromName("value"_sv)};
-  m_propertyId.writable = NapiRefHolder{this, GetPropertyIdFromName("writable"_sv)};
+  m_propertyId.Error = NapiRefHolder{this, GetPropertyIdFromName("Error"sv)};
+  m_propertyId.Object = NapiRefHolder{this, GetPropertyIdFromName("Object"sv)};
+  m_propertyId.Proxy = NapiRefHolder{this, GetPropertyIdFromName("Proxy"sv)};
+  m_propertyId.Symbol = NapiRefHolder{this, GetPropertyIdFromName("Symbol"sv)};
+  m_propertyId.byteLength = NapiRefHolder{this, GetPropertyIdFromName("byteLength"sv)};
+  m_propertyId.configurable = NapiRefHolder{this, GetPropertyIdFromName("configurable"sv)};
+  m_propertyId.enumerable = NapiRefHolder{this, GetPropertyIdFromName("enumerable"sv)};
+  m_propertyId.get = NapiRefHolder{this, GetPropertyIdFromName("get"sv)};
+  m_propertyId.getOwnPropertyDescriptor = NapiRefHolder{this, GetPropertyIdFromName("getOwnPropertyDescriptor"sv)};
+  m_propertyId.hostFunctionSymbol = NapiRefHolder{this, CreateSymbol("hostFunctionSymbol"sv)};
+  m_propertyId.hostObjectSymbol = NapiRefHolder{this, CreateSymbol("hostObjectSymbol"sv)};
+  m_propertyId.length = NapiRefHolder{this, GetPropertyIdFromName("length"sv)};
+  m_propertyId.message = NapiRefHolder{this, GetPropertyIdFromName("message"sv)};
+  m_propertyId.ownKeys = NapiRefHolder{this, GetPropertyIdFromName("ownKeys"sv)};
+  m_propertyId.propertyIsEnumerable = NapiRefHolder{this, GetPropertyIdFromName("propertyIsEnumerable"sv)};
+  m_propertyId.prototype = NapiRefHolder{this, GetPropertyIdFromName("prototype"sv)};
+  m_propertyId.set = NapiRefHolder{this, GetPropertyIdFromName("set"sv)};
+  m_propertyId.toString = NapiRefHolder{this, GetPropertyIdFromName("toString"sv)};
+  m_propertyId.value = NapiRefHolder{this, GetPropertyIdFromName("value"sv)};
+  m_propertyId.writable = NapiRefHolder{this, GetPropertyIdFromName("writable"sv)};
 
   m_value.Undefined = NapiRefHolder{this, GetUndefined()};
   m_value.Null = NapiRefHolder{this, GetNull()};
@@ -1233,7 +1237,7 @@ void NapiJsiRuntime::RewriteErrorMessage(napi_value jsError) const {
   } else if (TypeOf(message) == napi_string) {
     // JSI unit tests expect V8- or JSC-like messages for the stack overflow.
     if (StringToStdString(message) == "Out of stack space") {
-      SetProperty(jsError, m_propertyId.message, CreateStringUtf8("RangeError : Maximum call stack size exceeded"_sv));
+      SetProperty(jsError, m_propertyId.message, CreateStringUtf8("RangeError : Maximum call stack size exceeded"sv));
     }
   }
 }

--- a/src/public/compat.h
+++ b/src/public/compat.h
@@ -9,9 +9,6 @@
 // They must be removed after we switch the toolset to the newer C++ language version.
 
 #include <string>
-#ifdef __cpp_lib_string_view
-#include <string_view>
-#endif
 #ifdef __cpp_lib_span
 #include <span>
 #endif
@@ -56,78 +53,6 @@ struct span {
   size_t size_;
 };
 #endif // __cpp_lib_span
-
-#if __cpp_lib_string_view
-using std::string_view;
-#else
-/**
- * @brief A minimal subset of std::string_view.
- *
- * In C++17 we must replace it with std::string_view.
- */
-struct string_view {
-  constexpr string_view() noexcept = default;
-  constexpr string_view(const string_view &other) noexcept = default;
-  string_view(const char *data) noexcept : data_{data}, size_{std::char_traits<char>::length(data)} {}
-  string_view(const char *data, size_t size) noexcept : data_{data}, size_{size} {}
-  string_view(const std::string &str) noexcept : data_{str.data()}, size_{str.size()} {}
-
-  constexpr string_view &operator=(const string_view &view) noexcept = default;
-
-  [[nodiscard]] constexpr const char *begin() const noexcept {
-    return data_;
-  }
-
-  [[nodiscard]] constexpr const char *end() const noexcept {
-    return data_ + size_;
-  }
-
-  [[nodiscard]] constexpr const char &operator[](size_t pos) const noexcept {
-    return *(data_ + pos);
-  }
-
-  [[nodiscard]] constexpr const char *data() const noexcept {
-    return data_;
-  }
-
-  [[nodiscard]] constexpr size_t size() const noexcept {
-    return size_;
-  }
-
-  [[nodiscard]] constexpr bool empty() const noexcept {
-    return size_ == 0;
-  }
-
-  int compare(string_view other) const noexcept {
-    int result = std::char_traits<char>::compare(data_, other.data_, std::min(size_, other.size_));
-    if (result == 0) {
-      if (size_ < other.size_) {
-        result = -1;
-      } else if (size_ > other.size_) {
-        result = 1;
-      }
-    }
-    return result;
-  }
-
- private:
-  const char *data_{nullptr};
-  size_t size_{0};
-};
-
-inline string_view operator"" _sv(const char *str, std::size_t len) noexcept {
-  return string_view(str, len);
-}
-
-inline bool operator==(string_view left, string_view right) noexcept {
-  return left.compare(right) == 0;
-}
-
-inline bool operator!=(string_view left, string_view right) noexcept {
-  return left.compare(right) != 0;
-}
-
-#endif // __cpp_lib_string_view
 
 } // namespace napijsi
 


### PR DESCRIPTION
Google switched to using C++17 for this release, so we can clean up some of the compat code as well (string_view native).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/112)