### PR TITLE
fix: added RN66 blobs fix

### DIFF
--- a/android/V8Runtime_impl.h
+++ b/android/V8Runtime_impl.h
@@ -147,7 +147,7 @@ namespace facebook { namespace v8runtime {
 
       static void Enumerator(const v8::PropertyCallbackInfo<v8::Array>& info)
       {
-        v8::Local<v8::External> data = v8::Local<v8::External>::Cast(info.Data());
+        v8::Local<v8::External> data = v8::Local<v8::External>::Cast(info.This()->GetInternalField(0));
         HostObjectProxy* hostObjectProxy = reinterpret_cast<HostObjectProxy*>(data->Value());
 
         if (hostObjectProxy != nullptr) {

--- a/android/build.config
+++ b/android/build.config
@@ -1,4 +1,4 @@
 V8_TAG="7.0.276.32"
-RN_VERSION="0.66-stable"
+RN_VERSION="0.66.0-stable"
 NDK_VERSION="r21b"
-NUGET_PKG_VERSION="0.66-stable-v1"
+NUGET_PKG_VERSION="0.66.0-stable-v2"


### PR DESCRIPTION
Added the fix in the V8Runtime enumerator for RN66 - this will unblock the blobs work for Feeds Android

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/118)