### PR TITLE
Adds createPropNameIDFromSymbol

### DIFF
--- a/android/jsi/decorator.h
+++ b/android/jsi/decorator.h
@@ -176,9 +176,6 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   PropNameID createPropNameIDFromString(const String& str) override {
     return plain_.createPropNameIDFromString(str);
   };
-  PropNameID createPropNameIDFromSymbol(const Symbol& sym) override {
-    return plain_.createPropNameIDFromSymbol(sym);
-  };
   std::string utf8(const PropNameID& id) override {
     return plain_.utf8(id);
   };

--- a/android/jsi/decorator.h
+++ b/android/jsi/decorator.h
@@ -176,6 +176,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   PropNameID createPropNameIDFromString(const String& str) override {
     return plain_.createPropNameIDFromString(str);
   };
+  PropNameID createPropNameIDFromSymbol(const Symbol& sym) override {
+    return plain_.createPropNameIDFromSymbol(sym);
+  };
   std::string utf8(const PropNameID& id) override {
     return plain_.utf8(id);
   };

--- a/android/jsi/jsi.h
+++ b/android/jsi/jsi.h
@@ -274,7 +274,6 @@ class JSI_EXPORT Runtime {
       const uint8_t* utf8,
       size_t length) = 0;
   virtual PropNameID createPropNameIDFromString(const String& str) = 0;
-  virtual PropNameID createPropNameIDFromSymbol(const Symbol& sym) = 0;
   virtual std::string utf8(const PropNameID&) = 0;
   virtual bool compare(const PropNameID&, const PropNameID&) = 0;
 
@@ -422,11 +421,6 @@ class JSI_EXPORT PropNameID : public Pointer {
   /// Create a PropNameID from a JS string.
   static PropNameID forString(Runtime& runtime, const jsi::String& str) {
     return runtime.createPropNameIDFromString(str);
-  }
-
-  /// Create a PropNameID from a JS symbol.
-  static PropNameID forSymbol(Runtime& runtime, const jsi::Symbol& sym) {
-    return runtime.createPropNameIDFromSymbol(sym);
   }
 
   // Creates a vector of PropNameIDs constructed from given arguments.

--- a/android/jsi/jsi.h
+++ b/android/jsi/jsi.h
@@ -274,6 +274,7 @@ class JSI_EXPORT Runtime {
       const uint8_t* utf8,
       size_t length) = 0;
   virtual PropNameID createPropNameIDFromString(const String& str) = 0;
+  virtual PropNameID createPropNameIDFromSymbol(const Symbol& sym) = 0;
   virtual std::string utf8(const PropNameID&) = 0;
   virtual bool compare(const PropNameID&, const PropNameID&) = 0;
 
@@ -421,6 +422,11 @@ class JSI_EXPORT PropNameID : public Pointer {
   /// Create a PropNameID from a JS string.
   static PropNameID forString(Runtime& runtime, const jsi::String& str) {
     return runtime.createPropNameIDFromString(str);
+  }
+
+  /// Create a PropNameID from a JS symbol.
+  static PropNameID forSymbol(Runtime& runtime, const jsi::Symbol& sym) {
+    return runtime.createPropNameIDFromSymbol(sym);
   }
 
   // Creates a vector of PropNameIDs constructed from given arguments.

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.65.12",
+    "version": "0.65.13",
     "v8ref": "refs/branch-heads/10.0"
 }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.65.13",
+    "version": "0.69.1",
     "v8ref": "refs/branch-heads/10.0"
 }

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -1037,7 +1037,7 @@ jsi::PropNameID V8Runtime::createPropNameIDFromString(const jsi::String &str) {
 
 jsi::PropNameID V8Runtime::createPropNameIDFromSymbol(const jsi::Symbol &sym) {
   _ISOLATE_CONTEXT_ENTER
-  throw std::logic_error("Not implemented");
+  return make<jsi::PropNameID>(V8SymbolValue::make(v8::Local<v8::Symbol>::Cast(symbolRef(sym))));
 }
 
 std::string V8Runtime::utf8(const jsi::PropNameID &sym) {

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -452,7 +452,7 @@ std::once_flag g_tracingInitialized;
 
 void V8Runtime::initializeTracing() {
 #ifdef _WIN32
-  std::call_once(g_tracingInitialized, [](){ globalInitializeTracing(); });
+  std::call_once(g_tracingInitialized, []() { globalInitializeTracing(); });
 #endif
 
   TRACEV8RUNTIME_VERBOSE("Initializing");
@@ -525,16 +525,16 @@ V8Runtime::V8Runtime(V8RuntimeArgs &&args) : args_(std::move(args)) {
   v8::Context::Scope context_scope(context);
 
 #if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
-  void* inspector_agent = isolate_->GetData(ISOLATE_INSPECTOR_SLOT);
+  void *inspector_agent = isolate_->GetData(ISOLATE_INSPECTOR_SLOT);
   if (inspector_agent) {
-    inspector_agent_ = reinterpret_cast<inspector::Agent*>(inspector_agent)->getShared();
+    inspector_agent_ = reinterpret_cast<inspector::Agent *>(inspector_agent)->getShared();
   } else {
-    inspector_agent_ = std::make_shared<inspector::Agent>(
-        isolate_, args_.inspectorPort);
+    inspector_agent_ = std::make_shared<inspector::Agent>(isolate_, args_.inspectorPort);
     isolate_->SetData(ISOLATE_INSPECTOR_SLOT, inspector_agent_.get());
   }
 
-  const char* context_name = args_.debuggerRuntimeName.empty() ? "JSIRuntime context" : args_.debuggerRuntimeName.c_str();
+  const char *context_name =
+      args_.debuggerRuntimeName.empty() ? "JSIRuntime context" : args_.debuggerRuntimeName.c_str();
   inspector_agent_->addContext(context_.Get(GetIsolate()), context_name);
 
   if (args_.flags.enableInspector) {
@@ -574,7 +574,7 @@ V8Runtime::~V8Runtime() {
   host_object_lifetime_tracker_list_.clear();
 
 #if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
-  if (inspector_agent_){
+  if (inspector_agent_) {
     inspector_agent_.reset();
   }
 #endif
@@ -991,8 +991,8 @@ jsi::Runtime::PointerValue *V8Runtime::cloneSymbol(const jsi::Runtime::PointerVa
 
 std::string V8Runtime::symbolToString(const jsi::Symbol &sym) {
   _ISOLATE_CONTEXT_ENTER
-  return "Symbol(" + JSStringToSTLString(GetIsolate(), v8::Local<v8::String>::Cast(symbolRef(sym)->Description(isolate))) +
-      ")";
+  return "Symbol(" +
+      JSStringToSTLString(GetIsolate(), v8::Local<v8::String>::Cast(symbolRef(sym)->Description(isolate))) + ")";
 }
 
 jsi::PropNameID V8Runtime::createPropNameIDFromAscii(const char *str, size_t length) {
@@ -1031,6 +1031,11 @@ jsi::PropNameID V8Runtime::createPropNameIDFromUtf8(const uint8_t *utf8, size_t 
 jsi::PropNameID V8Runtime::createPropNameIDFromString(const jsi::String &str) {
   _ISOLATE_CONTEXT_ENTER
   return make<jsi::PropNameID>(V8StringValue::make(v8::Local<v8::String>::Cast(stringRef(str))));
+}
+
+jsi::PropNameID V8Runtime::createPropNameIDFromSymbol(const jsi::Symbol &sym) {
+  _ISOLATE_CONTEXT_ENTER
+  throw std::logic_error("Not implemented");
 }
 
 std::string V8Runtime::utf8(const jsi::PropNameID &sym) {
@@ -1613,16 +1618,17 @@ std::unique_ptr<jsi::Runtime> makeV8Runtime() {
 }
 
 #if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
-void openInspector(jsi::Runtime& runtime) {
-  V8Runtime& v8Runtime = reinterpret_cast<V8Runtime&>(runtime);
-  std::shared_ptr<inspector::Agent> inspector_agent =
-      v8Runtime.getInspectorAgent();
+void openInspector(jsi::Runtime &runtime) {
+  V8Runtime &v8Runtime = reinterpret_cast<V8Runtime &>(runtime);
+  std::shared_ptr<inspector::Agent> inspector_agent = v8Runtime.getInspectorAgent();
   if (inspector_agent) {
     inspector_agent->start();
   }
 }
 
-void openInspectors_toberemoved() { inspector::Agent::startAll(); }
+void openInspectors_toberemoved() {
+  inspector::Agent::startAll();
+}
 #endif
 
 } // namespace v8runtime

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -22,8 +22,8 @@
 #include <list>
 #include <mutex>
 #include <sstream>
-#include <unordered_map>
 #include <string_view>
+#include <unordered_map>
 
 #include <cstdlib>
 
@@ -103,9 +103,8 @@ class V8PlatformHolder {
       // process-globals This cannot be worked around, the design of V8 is not currently embedder-friendly
       // v8::V8::Dispose();
 
-      // This used to work until 9.2, but afterwards shutting down the platform permanently breaks the code that creates page allocators (through global statics)
-      // v8::V8::ShutdownPlatform();
-      // platform_s_ = nullptr;
+      // This used to work until 9.2, but afterwards shutting down the platform permanently breaks the code that creates
+      // page allocators (through global statics) v8::V8::ShutdownPlatform(); platform_s_ = nullptr;
     }
   }
 
@@ -148,13 +147,12 @@ class V8Runtime : public facebook::jsi::Runtime {
   V8Runtime(V8RuntimeArgs &&args);
   ~V8Runtime();
 
-  public:  // Used by openInspector public API.
+ public: // Used by openInspector public API.
 #if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
   std::shared_ptr<inspector::Agent> getInspectorAgent() {
     return inspector_agent_;
   }
 #endif
-
 
  public: // Used by NAPI implementation
   v8::Global<v8::Context> &GetContext() {
@@ -180,7 +178,7 @@ class V8Runtime : public facebook::jsi::Runtime {
 
   napi_status NapiGetUniqueUtf8StringRef(napi_env env, const char *str, size_t length, napi_ext_ref *result);
 
- private:  // Used by NAPI implementation
+ private: // Used by NAPI implementation
   static void PromiseRejectCallback(v8::PromiseRejectMessage data);
   void
   SetUnhandledPromise(v8::Local<v8::Promise> promise, v8::Local<v8::Message> message, v8::Local<v8::Value> exception);
@@ -543,6 +541,7 @@ class V8Runtime : public facebook::jsi::Runtime {
   facebook::jsi::PropNameID createPropNameIDFromAscii(const char *str, size_t length) override;
   facebook::jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length) override;
   facebook::jsi::PropNameID createPropNameIDFromString(const facebook::jsi::String &str) override;
+  facebook::jsi::PropNameID createPropNameIDFromSymbol(const facebook::jsi::Symbol &sym) override;
   std::string utf8(const facebook::jsi::PropNameID &) override;
   bool compare(const facebook::jsi::PropNameID &, const facebook::jsi::PropNameID &) override;
 
@@ -609,10 +608,10 @@ class V8Runtime : public facebook::jsi::Runtime {
 
   static void GCEpilogueCallback(v8::Isolate *isolate, v8::GCType type, v8::GCCallbackFlags flags);
 
-  V8RuntimeArgs& runtimeArgs() {
+  V8RuntimeArgs &runtimeArgs() {
     return args_;
   }
- 
+
  private:
   v8::Local<v8::Context> CreateContext(v8::Isolate *isolate);
 

--- a/src/jsi/CMakeLists.txt
+++ b/src/jsi/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
@@ -21,7 +21,10 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   # when they go out of scope due to exceptions.
   list(APPEND jsi_compile_flags "/EHsc")
 endif()
-target_compile_options(jsi PUBLIC ${jsi_compile_flags})
+if (HERMES_ENABLE_BITCODE)
+  list(APPEND jsi_compile_flags "-fembed-bitcode")
+endif ()
+target_compile_options(jsi PRIVATE ${jsi_compile_flags})
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/jsi/" DESTINATION include
   FILES_MATCHING PATTERN "*.h"

--- a/src/jsi/JSIDynamic.cpp
+++ b/src/jsi/JSIDynamic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,72 +17,163 @@ using namespace facebook::jsi;
 namespace facebook {
 namespace jsi {
 
-Value valueFromDynamic(Runtime& runtime, const folly::dynamic& dyn) {
+namespace {
+
+struct FromDynamic {
+  FromDynamic(const folly::dynamic* dynArg, Object objArg)
+      : dyn(dynArg), obj(std::move(objArg)) {}
+
+  const folly::dynamic* dyn;
+  Object obj;
+};
+
+// This converts one element.  If it's a collection, it gets pushed onto
+// the stack for later processing.
+Value valueFromDynamicShallow(
+    Runtime& runtime,
+    std::vector<FromDynamic>& stack,
+    const folly::dynamic& dyn) {
   switch (dyn.type()) {
     case folly::dynamic::NULLT:
       return Value::null();
     case folly::dynamic::ARRAY: {
-      Array ret = Array(runtime, dyn.size());
-      for (size_t i = 0; i < dyn.size(); ++i) {
-        ret.setValueAtIndex(runtime, i, valueFromDynamic(runtime, dyn[i]));
-      }
-      return std::move(ret);
+      Object arr = Array(runtime, dyn.size());
+      Value ret = Value(runtime, arr);
+      stack.emplace_back(&dyn, std::move(arr));
+      return ret;
     }
     case folly::dynamic::BOOL:
-      return dyn.getBool();
+      return Value(dyn.getBool());
     case folly::dynamic::DOUBLE:
       return dyn.getDouble();
     case folly::dynamic::INT64:
-      // Can't use asDouble() here.  If the int64 value is too bit to be
-      // represented precisely as a double, folly will throw an
-      // exception.
-      return (double)dyn.getInt();
+      return Value((double)dyn.getInt());
     case folly::dynamic::OBJECT: {
-      Object ret(runtime);
-      for (const auto& element : dyn.items()) {
-        Value value = valueFromDynamic(runtime, element.second);
-        if (element.first.isNumber() || element.first.isString()) {
-          ret.setProperty(
-              runtime,
-              PropNameID::forUtf8(runtime, element.first.asString()),
-              value);
-        }
-      }
-      return std::move(ret);
+      auto obj = Object(runtime);
+      Value ret = Value(runtime, obj);
+      stack.emplace_back(&dyn, std::move(obj));
+      return ret;
     }
     case folly::dynamic::STRING:
-      return String::createFromUtf8(runtime, dyn.getString());
+      return Value(String::createFromUtf8(runtime, dyn.getString()));
   }
   CHECK(false);
 }
 
-folly::dynamic dynamicFromValue(Runtime& runtime, const Value& value) {
+} // namespace
+
+Value valueFromDynamic(Runtime& runtime, const folly::dynamic& dynInput) {
+  std::vector<FromDynamic> stack;
+
+  Value ret = valueFromDynamicShallow(runtime, stack, dynInput);
+
+  while (!stack.empty()) {
+    auto top = std::move(stack.back());
+    stack.pop_back();
+
+    switch (top.dyn->type()) {
+      case folly::dynamic::ARRAY: {
+        Array arr = std::move(top.obj).getArray(runtime);
+        for (size_t i = 0; i < top.dyn->size(); ++i) {
+          arr.setValueAtIndex(
+              runtime,
+              i,
+              valueFromDynamicShallow(runtime, stack, (*top.dyn)[i]));
+        }
+        break;
+      }
+      case folly::dynamic::OBJECT: {
+        Object obj = std::move(top.obj);
+        for (const auto& element : top.dyn->items()) {
+          if (element.first.isNumber() || element.first.isString()) {
+            obj.setProperty(
+                runtime,
+                PropNameID::forUtf8(runtime, element.first.asString()),
+                valueFromDynamicShallow(runtime, stack, element.second));
+          }
+        }
+        break;
+      }
+      default:
+        CHECK(false);
+    }
+  }
+
+  return ret;
+}
+
+namespace {
+
+struct FromValue {
+  FromValue(folly::dynamic* dynArg, Object objArg)
+      : dyn(dynArg), obj(std::move(objArg)) {}
+
+  folly::dynamic* dyn;
+  Object obj;
+};
+
+// This converts one element.  If it's a collection, it gets pushed
+// onto the stack for later processing.  The output is created by
+// mutating the output argument, because we need its actual pointer to
+// push onto the stack.
+void dynamicFromValueShallow(
+    Runtime& runtime,
+    std::vector<FromValue>& stack,
+    const jsi::Value& value,
+    folly::dynamic& output) {
   if (value.isUndefined() || value.isNull()) {
-    return nullptr;
+    output = nullptr;
   } else if (value.isBool()) {
-    return value.getBool();
+    output = value.getBool();
   } else if (value.isNumber()) {
-    return value.getNumber();
+    output = value.getNumber();
   } else if (value.isString()) {
-    return value.getString(runtime).utf8(runtime);
+    output = value.getString(runtime).utf8(runtime);
   } else {
+    CHECK(value.isObject());
     Object obj = value.getObject(runtime);
     if (obj.isArray(runtime)) {
-      Array array = obj.getArray(runtime);
-      folly::dynamic ret = folly::dynamic::array();
-      for (size_t i = 0; i < array.size(runtime); ++i) {
-        ret.push_back(
-            dynamicFromValue(runtime, array.getValueAtIndex(runtime, i)));
-      }
-      return ret;
+      output = folly::dynamic::array();
     } else if (obj.isFunction(runtime)) {
       throw JSError(runtime, "JS Functions are not convertible to dynamic");
     } else {
-      folly::dynamic ret = folly::dynamic::object();
-      Array names = obj.getPropertyNames(runtime);
+      output = folly::dynamic::object();
+    }
+    stack.emplace_back(&output, std::move(obj));
+  }
+}
+
+} // namespace
+
+folly::dynamic dynamicFromValue(Runtime& runtime, const Value& valueInput) {
+  std::vector<FromValue> stack;
+  folly::dynamic ret;
+
+  dynamicFromValueShallow(runtime, stack, valueInput, ret);
+
+  while (!stack.empty()) {
+    auto top = std::move(stack.back());
+    stack.pop_back();
+
+    if (top.obj.isArray(runtime)) {
+      // Inserting into a dyn can invalidate references into it, so we
+      // need to insert new elements up front, then push stuff onto
+      // the stack.
+      Array array = top.obj.getArray(runtime);
+      size_t arraySize = array.size(runtime);
+      for (size_t i = 0; i < arraySize; ++i) {
+        top.dyn->push_back(nullptr);
+      }
+      for (size_t i = 0; i < arraySize; ++i) {
+        dynamicFromValueShallow(
+            runtime, stack, array.getValueAtIndex(runtime, i), top.dyn->at(i));
+      }
+    } else {
+      Array names = top.obj.getPropertyNames(runtime);
+      std::vector<std::pair<std::string, jsi::Value>> props;
       for (size_t i = 0; i < names.size(runtime); ++i) {
         String name = names.getValueAtIndex(runtime, i).getString(runtime);
-        Value prop = obj.getProperty(runtime, name);
+        Value prop = top.obj.getProperty(runtime, name);
         if (prop.isUndefined()) {
           continue;
         }
@@ -92,12 +183,17 @@ folly::dynamic dynamicFromValue(Runtime& runtime, const Value& value) {
         if (prop.isObject() && prop.getObject(runtime).isFunction(runtime)) {
           prop = Value::null();
         }
-        ret.insert(
-            name.utf8(runtime), dynamicFromValue(runtime, std::move(prop)));
+        props.emplace_back(name.utf8(runtime), std::move(prop));
+        top.dyn->insert(props.back().first, nullptr);
       }
-      return ret;
+      for (const auto& prop : props) {
+        dynamicFromValueShallow(
+            runtime, stack, prop.second, (*top.dyn)[prop.first]);
+      }
     }
   }
+
+  return ret;
 }
 
 } // namespace jsi

--- a/src/jsi/JSIDynamic.h
+++ b/src/jsi/JSIDynamic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/jsi/README.md
+++ b/src/jsi/README.md
@@ -1,0 +1,6 @@
+The JSI folder is matching to https://github.com/facebook/hermes.git
+Commit hash:	993a407ec80359e47d2bfac5b17ac533e58e2ed5
+Author:			Anand Bashyam <kalyanavarathan@fb.com>#mailto:kalyanavarathan@fb.com
+Date:			4/18/2022 10:08:22 AM
+
+Please update the info after the next sync up.

--- a/src/jsi/decorator.h
+++ b/src/jsi/decorator.h
@@ -176,6 +176,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   PropNameID createPropNameIDFromString(const String& str) override {
     return plain_.createPropNameIDFromString(str);
   };
+  PropNameID createPropNameIDFromSymbol(const Symbol& sym) override {
+    return plain_.createPropNameIDFromSymbol(sym);
+  };
   std::string utf8(const PropNameID& id) override {
     return plain_.utf8(id);
   };

--- a/src/jsi/instrumentation.h
+++ b/src/jsi/instrumentation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,8 +7,10 @@
 
 #pragma once
 
+#include <chrono>
 #include <iosfwd>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 
 #include <jsi/jsi.h>
@@ -21,7 +23,7 @@ namespace jsi {
 /// controls the instrumentation of.
 /// None of these functions should return newly created jsi values, nor should
 /// it modify the values of any jsi values in the heap (although GCs are fine).
-class Instrumentation {
+class JSI_EXPORT Instrumentation {
  public:
   virtual ~Instrumentation() = default;
 
@@ -49,15 +51,43 @@ class Instrumentation {
   virtual std::unordered_map<std::string, int64_t> getHeapInfo(
       bool includeExpensive) = 0;
 
-  /// perform a full garbage collection
-  virtual void collectGarbage() = 0;
+  /// Perform a full garbage collection.
+  /// \param cause The cause of this collection, as it should be reported in
+  ///   logs.
+  virtual void collectGarbage(std::string cause) = 0;
+
+  /// A HeapStatsUpdate is a tuple of the fragment index, the number of objects
+  /// in that fragment, and the number of bytes used by those objects.
+  /// A "fragment" is a view of all objects allocated within a time slice.
+  using HeapStatsUpdate = std::tuple<uint64_t, uint64_t, uint64_t>;
 
   /// Start capturing JS stack-traces for all JS heap allocated objects. These
   /// can be accessed via \c ::createSnapshotToFile().
-  virtual void startTrackingHeapObjectStackTraces() = 0;
+  /// \param fragmentCallback If present, invoke this callback every so often
+  ///   with the most recently seen object ID, and a list of fragments that have
+  ///   been updated. This callback will be invoked on the same thread that the
+  ///   runtime is using.
+  virtual void startTrackingHeapObjectStackTraces(
+      std::function<void(
+          uint64_t lastSeenObjectID,
+          std::chrono::microseconds timestamp,
+          std::vector<HeapStatsUpdate> stats)> fragmentCallback) = 0;
 
   /// Stop capture JS stack-traces for JS heap allocated objects.
   virtual void stopTrackingHeapObjectStackTraces() = 0;
+
+  /// Start a heap sampling profiler that will sample heap allocations, and the
+  /// stack trace they were allocated at. Reports a summary of which functions
+  /// allocated the most.
+  /// \param samplingInterval The number of bytes allocated to wait between
+  ///   samples. This will be used as the expected value of a poisson
+  ///   distribution.
+  virtual void startHeapSampling(size_t samplingInterval) = 0;
+
+  /// Turns off the heap sampling profiler previously enabled via
+  /// \c startHeapSampling. Writes the output of the sampling heap profiler to
+  /// \p os. The output is a JSON formatted string.
+  virtual void stopHeapSampling(std::ostream& os) = 0;
 
   /// Captures the heap to a file
   ///

--- a/src/jsi/jsi-inl.h
+++ b/src/jsi/jsi-inl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/jsi/jsi.cpp
+++ b/src/jsi/jsi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -30,6 +30,8 @@ std::string kindToString(const Value& v, Runtime* rt = nullptr) {
     return "a number";
   } else if (v.isString()) {
     return "a string";
+  } else if (v.isSymbol()) {
+    return "a symbol";
   } else {
     assert(v.isObject() && "Expecting object.");
     return rt != nullptr && v.getObject(*rt).isFunction(*rt) ? "a function"
@@ -97,10 +99,17 @@ Instrumentation& Runtime::instrumentation() {
       return std::unordered_map<std::string, int64_t>{};
     }
 
-    void collectGarbage() override {}
+    void collectGarbage(std::string) override {}
 
-    void startTrackingHeapObjectStackTraces() override {}
+    void startTrackingHeapObjectStackTraces(
+        std::function<void(
+            uint64_t,
+            std::chrono::microseconds,
+            std::vector<HeapStatsUpdate>)>) override {}
     void stopTrackingHeapObjectStackTraces() override {}
+
+    void startHeapSampling(size_t) override {}
+    void stopHeapSampling(std::ostream&) override {}
 
     void createSnapshotToFile(const std::string&) override {
       throw JSINativeException(
@@ -272,6 +281,15 @@ bool Value::strictEquals(Runtime& runtime, const Value& a, const Value& b) {
           static_cast<const Object&>(b.data_.pointer));
   }
   return false;
+}
+
+bool Value::asBool() const {
+  if (!isBool()) {
+    throw JSINativeException(
+        "Value is " + kindToString(*this) + ", expected a boolean");
+  }
+
+  return getBool();
 }
 
 double Value::asNumber() const {

--- a/src/jsi/jsi.h
+++ b/src/jsi/jsi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -200,13 +200,13 @@ class JSI_EXPORT Runtime {
   /// Hosts may call this function again to resume the draining if it was
   /// suspended due to either exceptions or the \p maxMicrotasksHint bound.
   /// E.g. a host may repetitively invoke this function until the queue is
-  /// drained to implement the "microtask checkpint" defined in WHATWG HTML
+  /// drained to implement the "microtask checkpoint" defined in WHATWG HTML
   /// event loop: https://html.spec.whatwg.org/C#perform-a-microtask-checkpoint.
   ///
   /// Note that error propagation is only a concern if a host needs to implement
-  /// `queueMicrotask`, a recent API that allows enqueueing aribitary functions
+  /// `queueMicrotask`, a recent API that allows enqueueing arbitrary functions
   /// (hence may throw) as microtasks. Exceptions from ECMA-262 Promise Jobs are
-  /// handled internally to VMs and are never propagrated to hosts.
+  /// handled internally to VMs and are never propagated to hosts.
   ///
   /// This API offers some queue management to hosts at its best effort due to
   /// different behaviors and limitations imposed by different VMs and APIs. By
@@ -407,6 +407,7 @@ class JSI_EXPORT PropNameID : public Pointer {
   }
 
   /// Create a PropNameID from utf8 values.  The data is copied.
+  /// Results are undefined if \p utf8 contains invalid code points.
   static PropNameID
   forUtf8(Runtime& runtime, const uint8_t* utf8, size_t length) {
     return runtime.createPropNameIDFromUtf8(utf8, length);
@@ -414,6 +415,7 @@ class JSI_EXPORT PropNameID : public Pointer {
 
   /// Create a PropNameID from utf8-encoded octets stored in a
   /// std::string.  The string data is transformed and copied.
+  /// Results are undefined if \p utf8 contains invalid code points.
   static PropNameID forUtf8(Runtime& runtime, const std::string& utf8) {
     return runtime.createPropNameIDFromUtf8(
         reinterpret_cast<const uint8_t*>(utf8.data()), utf8.size());
@@ -508,14 +510,16 @@ class JSI_EXPORT String : public Pointer {
   }
 
   /// Create a JS string from utf8-encoded octets.  The string data is
-  /// transformed and copied.
+  /// transformed and copied.  Results are undefined if \p utf8 contains invalid
+  /// code points.
   static String
   createFromUtf8(Runtime& runtime, const uint8_t* utf8, size_t length) {
     return runtime.createStringFromUtf8(utf8, length);
   }
 
   /// Create a JS string from utf8-encoded octets stored in a
-  /// std::string.  The string data is transformed and copied.
+  /// std::string.  The string data is transformed and copied.  Results are
+  /// undefined if \p utf8 contains invalid code points.
   static String createFromUtf8(Runtime& runtime, const std::string& utf8) {
     return runtime.createStringFromUtf8(
         reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length());
@@ -686,7 +690,7 @@ class JSI_EXPORT Object : public Pointer {
   std::shared_ptr<T> getHostObject(Runtime& runtime) const;
 
   /// \return a shared_ptr<T> which refers to the same underlying
-  /// \c HostObject that was used to crete this object. If \c isHostObject<T>
+  /// \c HostObject that was used to create this object. If \c isHostObject<T>
   /// is false, this will throw.
   template <typename T = HostObject>
   std::shared_ptr<T> asHostObject(Runtime& runtime) const;
@@ -988,7 +992,7 @@ class JSI_EXPORT Value {
 
   /// Copies a Symbol lvalue into a new JS value.
   Value(Runtime& runtime, const Symbol& sym) : Value(SymbolKind) {
-    new (&data_.pointer) String(runtime.cloneSymbol(sym.ptr_));
+    new (&data_.pointer) Symbol(runtime.cloneSymbol(sym.ptr_));
   }
 
   /// Copies a String lvalue into a new JS value.
@@ -1073,6 +1077,10 @@ class JSI_EXPORT Value {
     assert(isBool());
     return data_.boolean;
   }
+
+  /// \return the boolean value, or throws JSIException if not a
+  /// boolean.
+  bool asBool() const;
 
   /// \return the number value, or asserts if not a number.
   double getNumber() const {
@@ -1244,11 +1252,13 @@ class JSI_EXPORT JSIException : public std::exception {
   JSIException(std::string what) : what_(std::move(what)){};
 
  public:
+  JSIException(const JSIException&) = default;
+
   virtual const char* what() const noexcept override {
     return what_.c_str();
   }
 
-  virtual ~JSIException();
+  virtual ~JSIException() override;
 
  protected:
   std::string what_;
@@ -1259,6 +1269,8 @@ class JSI_EXPORT JSIException : public std::exception {
 class JSI_EXPORT JSINativeException : public JSIException {
  public:
   JSINativeException(std::string what) : JSIException(std::move(what)) {}
+
+  JSINativeException(const JSINativeException&) = default;
 
   virtual ~JSINativeException();
 };
@@ -1288,6 +1300,8 @@ class JSI_EXPORT JSError : public JSIException {
   /// set to provided message.  This argument order is a bit weird,
   /// but necessary to avoid ambiguity with the above.
   JSError(std::string what, Runtime& rt, Value&& value);
+
+  JSError(const JSError&) = default;
 
   virtual ~JSError();
 

--- a/src/jsi/jsi.h
+++ b/src/jsi/jsi.h
@@ -274,6 +274,7 @@ class JSI_EXPORT Runtime {
       const uint8_t* utf8,
       size_t length) = 0;
   virtual PropNameID createPropNameIDFromString(const String& str) = 0;
+  virtual PropNameID createPropNameIDFromSymbol(const Symbol& sym) = 0;
   virtual std::string utf8(const PropNameID&) = 0;
   virtual bool compare(const PropNameID&, const PropNameID&) = 0;
 
@@ -421,6 +422,11 @@ class JSI_EXPORT PropNameID : public Pointer {
   /// Create a PropNameID from a JS string.
   static PropNameID forString(Runtime& runtime, const jsi::String& str) {
     return runtime.createPropNameIDFromString(str);
+  }
+
+  /// Create a PropNameID from a JS symbol.
+  static PropNameID forSymbol(Runtime& runtime, const jsi::Symbol& sym) {
+    return runtime.createPropNameIDFromSymbol(sym);
   }
 
   // Creates a vector of PropNameIDs constructed from given arguments.

--- a/src/jsi/jsilib-posix.cpp
+++ b/src/jsi/jsilib-posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,15 +17,6 @@
 #include <stdexcept>
 
 #include <jsi/jsilib.h>
-
-#if __APPLE__
-#include <mach/vm_statistics.h>
-#define MAP_TAG VM_MAKE_TAG(VM_MEMORY_APPLICATION_SPECIFIC_16)
-#endif // __APPLE__
-
-#ifndef MAP_TAG
-#define MAP_TAG 0
-#endif
 
 namespace facebook {
 namespace jsi {
@@ -76,8 +67,7 @@ class ScopedFile {
   }
 
   uint8_t* mmap(size_t size) {
-    void* result =
-        ::mmap(nullptr, size, PROT_READ, MAP_PRIVATE | MAP_TAG, fd_, 0);
+    void* result = ::mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd_, 0);
     if (result == MAP_FAILED) {
       throwFormattedError(
           "Could not mmap %s: %s", path_.c_str(), strerror(errno));

--- a/src/jsi/jsilib-windows.cpp
+++ b/src/jsi/jsilib-windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/jsi/jsilib.h
+++ b/src/jsi/jsilib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,7 +15,7 @@ namespace jsi {
 class FileBuffer : public Buffer {
  public:
   FileBuffer(const std::string& path);
-  ~FileBuffer();
+  ~FileBuffer() override;
 
   size_t size() const override {
     return size_;

--- a/src/jsi/test/testlib.cpp
+++ b/src/jsi/test/testlib.cpp
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 #include <jsi/test/testlib.h>
+
 #include <gtest/gtest.h>
 #include <jsi/decorator.h>
 #include <jsi/jsi.h>
@@ -392,6 +393,23 @@ TEST_P(JSITest, HostObjectTest) {
   EXPECT_FALSE(hasOwnPropertyName
                    .call(rt, howpn, String::createFromAscii(rt, "not_existing"))
                    .getBool());
+}
+
+TEST_P(JSITest, HostObjectProtoTest) {
+  class ProtoHostObject : public HostObject {
+    Value get(Runtime& rt, const PropNameID&) override {
+      return String::createFromAscii(rt, "phoprop");
+    }
+  };
+
+  rt.global().setProperty(
+      rt,
+      "pho",
+      Object::createFromHostObject(rt, std::make_shared<ProtoHostObject>()));
+
+  EXPECT_EQ(
+      eval("({__proto__: pho})[Symbol.toPrimitive]").getString(rt).utf8(rt),
+      "phoprop");
 }
 
 TEST_P(JSITest, ArrayTest) {
@@ -835,6 +853,8 @@ TEST_P(JSITest, ValueTest) {
   EXPECT_EQ(eval("'str'").getString(rt).utf8(rt), "str");
   EXPECT_TRUE(eval("[]").getObject(rt).isArray(rt));
 
+  EXPECT_TRUE(eval("true").asBool());
+  EXPECT_THROW(eval("123").asBool(), JSIException);
   EXPECT_EQ(eval("456").asNumber(), 456);
   EXPECT_THROW(eval("'word'").asNumber(), JSIException);
   EXPECT_EQ(
@@ -1409,7 +1429,7 @@ TEST_P(JSITest, MultilevelDecoratedHostObject) {
   EXPECT_EQ(1, RD2::numGets);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Runtimes,
     JSITest,
     ::testing::ValuesIn(runtimeGenerators()));

--- a/src/jsi/test/testlib.h
+++ b/src/jsi/test/testlib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/jsi/threadsafe.h
+++ b/src/jsi/threadsafe.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/public/NapiJsiRuntime.cpp
+++ b/src/public/NapiJsiRuntime.cpp
@@ -92,6 +92,7 @@ struct NapiJsiRuntime : facebook::jsi::Runtime {
   facebook::jsi::PropNameID createPropNameIDFromAscii(const char *str, size_t length) override;
   facebook::jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length) override;
   facebook::jsi::PropNameID createPropNameIDFromString(const facebook::jsi::String &str) override;
+  facebook::jsi::PropNameID createPropNameIDFromSymbol(const facebook::jsi::Symbol &sym) override;
   std::string utf8(const facebook::jsi::PropNameID &id) override;
   bool compare(const facebook::jsi::PropNameID &lhs, const facebook::jsi::PropNameID &rhs) override;
 
@@ -626,6 +627,11 @@ facebook::jsi::PropNameID NapiJsiRuntime::createPropNameIDFromString(const faceb
   return MakePointer<facebook::jsi::PropNameID>(uniqueStr);
 }
 
+facebook::jsi::PropNameID NapiJsiRuntime::createPropNameIDFromSymbol(const facebook::jsi::Symbol &sym) {
+  CHECK_ELSE_CRASH(false, "Not implemented");
+  throw;
+}
+
 std::string NapiJsiRuntime::utf8(const facebook::jsi::PropNameID &id) {
   EnvScope envScope{m_env};
   return PropertyIdToStdString(GetNapiValue(id));
@@ -1144,7 +1150,7 @@ size_t NapiJsiRuntime::JsiValueViewArgs::Size() const noexcept {
 //===========================================================================
 
 NapiJsiRuntime::PropNameIDView::PropNameIDView(NapiJsiRuntime *runtime, napi_value propertyId) noexcept
-    : m_propertyId{make<facebook::jsi::PropNameID>(new (std::addressof(m_pointerStore))
+    : m_propertyId{make<facebook::jsi::PropNameID>(new(std::addressof(m_pointerStore))
                                                        NapiPointerValueView{runtime, propertyId})} {}
 
 NapiJsiRuntime::PropNameIDView::operator facebook::jsi::PropNameID const &() const noexcept {
@@ -1833,14 +1839,15 @@ T NapiJsiRuntime::MakePointer(TValue value) const {
 
 } // namespace napijsi
 
-namespace Microsoft { namespace JSI {
+namespace Microsoft {
+namespace JSI {
 
 //===========================================================================
 // NapiJsiRuntime factory function.
 //===========================================================================
-std::unique_ptr<facebook::jsi::Runtime> __cdecl MakeNapiJsiRuntime(napi_env env) noexcept
-{
+std::unique_ptr<facebook::jsi::Runtime> __cdecl MakeNapiJsiRuntime(napi_env env) noexcept {
   return std::make_unique<napijsi::NapiJsiRuntime>(env);
 }
 
-}} // nampespace Microsoft::JSI
+} // namespace JSI
+} // namespace Microsoft

--- a/src/public/NapiJsiRuntime.cpp
+++ b/src/public/NapiJsiRuntime.cpp
@@ -417,6 +417,7 @@ struct NapiJsiRuntime : facebook::jsi::Runtime {
   napi_ext_ref GetPropertyIdFromName(string_view value) const;
   napi_ext_ref GetPropertyIdFromName(const uint8_t *data, size_t length) const;
   napi_ext_ref GetPropertyIdFromName(napi_value str) const;
+  napi_ext_ref GetPropertyIdFromSymbol(napi_value sym) const;
   std::string PropertyIdToStdString(napi_value propertyId);
   napi_value CreateSymbol(string_view symbolDescription) const;
   std::string SymbolToStdString(napi_value symbolValue);
@@ -628,8 +629,9 @@ facebook::jsi::PropNameID NapiJsiRuntime::createPropNameIDFromString(const faceb
 }
 
 facebook::jsi::PropNameID NapiJsiRuntime::createPropNameIDFromSymbol(const facebook::jsi::Symbol &sym) {
-  CHECK_ELSE_CRASH(false, "Not implemented");
-  throw;
+  EnvScope envScope{m_env};
+  napi_ext_ref propSym = GetPropertyIdFromSymbol(GetNapiValue(sym));
+  return MakePointer<facebook::jsi::PropNameID>(propSym);
 }
 
 std::string NapiJsiRuntime::utf8(const facebook::jsi::PropNameID &id) {
@@ -1150,7 +1152,7 @@ size_t NapiJsiRuntime::JsiValueViewArgs::Size() const noexcept {
 //===========================================================================
 
 NapiJsiRuntime::PropNameIDView::PropNameIDView(NapiJsiRuntime *runtime, napi_value propertyId) noexcept
-    : m_propertyId{make<facebook::jsi::PropNameID>(new(std::addressof(m_pointerStore))
+    : m_propertyId{make<facebook::jsi::PropNameID>(new (std::addressof(m_pointerStore))
                                                        NapiPointerValueView{runtime, propertyId})} {}
 
 NapiJsiRuntime::PropNameIDView::operator facebook::jsi::PropNameID const &() const noexcept {
@@ -1473,6 +1475,13 @@ napi_ext_ref NapiJsiRuntime::GetPropertyIdFromName(const uint8_t *data, size_t l
 napi_ext_ref NapiJsiRuntime::GetPropertyIdFromName(napi_value str) const {
   napi_ext_ref ref{};
   CHECK_NAPI(napi_ext_get_unique_string_ref(m_env, str, &ref));
+  return ref;
+}
+
+// Gets or creates a unique string value from napi_value string.
+napi_ext_ref NapiJsiRuntime::GetPropertyIdFromSymbol(napi_value sym) const {
+  napi_ext_ref ref{};
+  CHECK_NAPI(napi_ext_create_reference(m_env, sym, &ref));
   return ref;
 }
 

--- a/src/public/NapiJsiRuntime.h
+++ b/src/public/NapiJsiRuntime.h
@@ -23,10 +23,10 @@
 #endif // _MSC_VER
 #endif // !defined(V8JSI_EXPORT)
 
-namespace Microsoft { namespace JSI {
+namespace Microsoft::JSI {
 
 V8JSI_EXPORT std::unique_ptr<facebook::jsi::Runtime> __cdecl MakeNapiJsiRuntime(napi_env env) noexcept;
 
-}} // namespace Microsoft::JSI
+} // namespace Microsoft::JSI
 
 #endif // SRC_PUBLIC_NAPIJSIRUNTIME_H_


### PR DESCRIPTION
Paired PR to https://github.com/microsoft/hermes-windows/pull/94, 
TDLR: Adds in createPropNameIDFromSymbol to match facebook/hermes JSI

Updated all JSI files to match to https://github.com/facebook/hermes.git
Commit hash:	993a407ec80359e47d2bfac5b17ac533e58e2ed5
Author:		Anand Bashyam <kalyanavarathan@fb.com>#mailto:kalyanavarathan@fb.com
Date:		4/18/2022 10:08:22 AM

A new README.md file is added in the JSI folder about the matching Hermes commit.

Other related changes:

* Fixed HostObjectProxy to work with Symbol PropID and with the prototype chain.
* Formatted code in the changed files.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/121)