### PR TITLE
Implement hash for script versioning

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.69.1",
+    "version": "0.69.2",
     "v8ref": "refs/branch-heads/10.0"
 }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -30,6 +30,8 @@ target("shared_library", "v8jsi") {
     "V8JsiRuntime_impl.h",
     "V8JsiRuntime.cpp",
     "IsolateData.h",
+    "MurmurHash.h",
+    "MurmurHash.cpp",
   ]
 
   if (is_win) {

--- a/src/MurmurHash.cpp
+++ b/src/MurmurHash.cpp
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// This code was adapted from https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.h
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+#include "MurmurHash.h"
+#include <stdlib.h>
+
+#if defined(_MSC_VER)
+
+#define FORCE_INLINE __forceinline
+#define ROTL64(x, y) _rotl64(x, y)
+#define BIG_CONSTANT(x) (x)
+
+#else // defined(_MSC_VER)
+
+#define FORCE_INLINE inline __attribute__((always_inline))
+inline uint64_t rotl64(uint64_t x, int8_t r) {
+  return (x << r) | (x >> (64 - r));
+}
+#define ROTL64(x, y) rotl64(x, y)
+#define BIG_CONSTANT(x) (x##LLU)
+
+#endif // !defined(_MSC_VER)
+
+using namespace std;
+
+FORCE_INLINE uint64_t fmix64(uint64_t k) {
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+  k ^= k >> 33;
+
+  return k;
+}
+
+bool isAscii(uint64_t k) {
+  return ((unsigned char)(k & 0xff) <= 127) && ((unsigned char)((k >> 8) & 0xff) <= 127) &&
+      ((unsigned char)((k >> 16) & 0xff) <= 127) && ((unsigned char)(k >> 24) <= 127);
+}
+
+bool MurmurHash3_x64_128(const void *key, const int len, const uint32_t seed, void *out) {
+  const uint8_t *data = (const uint8_t *)key;
+  const int nblocks = len / 16;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  const uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  const uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  //----------
+  // body
+
+  const uint64_t *blocks = (const uint64_t *)(data);
+
+  bool isAsciiString{true};
+  for (int i = 0; i < nblocks; i++) {
+    uint64_t k1 = blocks[i * 2 + 0];
+    uint64_t k2 = blocks[i * 2 + 1];
+
+    isAsciiString &= isAscii(k1) && isAscii(k2);
+
+    k1 *= c1;
+    k1 = ROTL64(k1, 31);
+    k1 *= c2;
+    h1 ^= k1;
+
+    h1 = ROTL64(h1, 27);
+    h1 += h2;
+    h1 = h1 * 5 + 0x52dce729;
+
+    k2 *= c2;
+    k2 = ROTL64(k2, 33);
+    k2 *= c1;
+    h2 ^= k2;
+
+    h2 = ROTL64(h2, 31);
+    h2 += h1;
+    h2 = h2 * 5 + 0x38495ab5;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t *tail = (const uint8_t *)(data + nblocks * 16);
+
+  for (auto i = 0; i < len % 16; i++) {
+    if (tail[i] > 127) {
+      isAsciiString = false;
+      break;
+    }
+  }
+
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch (len & 15) {
+    case 15:
+      k2 ^= ((uint64_t)tail[14]) << 48;
+    case 14:
+      k2 ^= ((uint64_t)tail[13]) << 40;
+    case 13:
+      k2 ^= ((uint64_t)tail[12]) << 32;
+    case 12:
+      k2 ^= ((uint64_t)tail[11]) << 24;
+    case 11:
+      k2 ^= ((uint64_t)tail[10]) << 16;
+    case 10:
+      k2 ^= ((uint64_t)tail[9]) << 8;
+    case 9:
+      k2 ^= ((uint64_t)tail[8]) << 0;
+      k2 *= c2;
+      k2 = ROTL64(k2, 33);
+      k2 *= c1;
+      h2 ^= k2;
+
+    case 8:
+      k1 ^= ((uint64_t)tail[7]) << 56;
+    case 7:
+      k1 ^= ((uint64_t)tail[6]) << 48;
+    case 6:
+      k1 ^= ((uint64_t)tail[5]) << 40;
+    case 5:
+      k1 ^= ((uint64_t)tail[4]) << 32;
+    case 4:
+      k1 ^= ((uint64_t)tail[3]) << 24;
+    case 3:
+      k1 ^= ((uint64_t)tail[2]) << 16;
+    case 2:
+      k1 ^= ((uint64_t)tail[1]) << 8;
+    case 1:
+      k1 ^= ((uint64_t)tail[0]) << 0;
+      k1 *= c1;
+      k1 = ROTL64(k1, 31);
+      k1 *= c2;
+      h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len;
+  h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  ((uint64_t *)out)[0] = h1;
+  ((uint64_t *)out)[1] = h2;
+
+  return isAsciiString;
+}
+
+bool murmurhash(const uint8_t *key, size_t length, uint64_t& hash) {
+  uint64_t hashes[2];
+
+  bool isAscii = MurmurHash3_x64_128(key, length, 31, &hashes);
+
+  hash = hashes[0];
+
+  return isAscii;
+}

--- a/src/MurmurHash.h
+++ b/src/MurmurHash.h
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+#pragma once
+
+#include <stdint.h>
+
+// Computes the hash of key using MurmurHash3 algorithm, the value is planced in the "hash" output parameter
+// The function returns whether or not key is comprised of only ASCII characters (<=127)
+bool murmurhash(const uint8_t *key, size_t length, uint64_t& hash);

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -6,6 +6,7 @@
 #include "v8.h"
 
 #include "IsolateData.h"
+#include "MurmurHash.h"
 #include "napi/js_native_api_v8.h"
 #include "public/ScriptStore.h"
 #include "public/js_native_api.h"
@@ -603,18 +604,8 @@ jsi::Value V8Runtime::evaluateJavaScript(
   constexpr std::uint64_t P1 {7};
   constexpr std::uint64_t P2 {31};
 
-  std::uint64_t hash {P1};
-  bool isAscii {true};
-
-  const char* p = reinterpret_cast<const char *>(buffer->data());
-  for (size_t i=0; i < buffer->size(); p++, i++) {
-    hash = hash * P2 + *p;
-
-    if (static_cast<unsigned char>(*p) > 127)
-    {
-      isAscii = false;
-    }
-  }
+  std::uint64_t hash {0};
+  bool isAscii = murmurhash(buffer->data(), buffer->size(), hash);
 
   v8::Local<v8::String> sourceV8String;
   if (isAscii) {

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -361,13 +361,6 @@ struct SameCodeObjects {
 v8::Isolate *V8Runtime::CreateNewIsolate() {
   TRACEV8RUNTIME_VERBOSE("CreateNewIsolate", TraceLoggingString("start", "op"));
 
-  /*if (args_.custom_snapshot_blob) {
-    custom_snapshot_startup_data_ = {
-        reinterpret_cast<const char *>(args_.custom_snapshot_blob->data()),
-        static_cast<int>(args_.custom_snapshot_blob->size())};
-    create_params_.snapshot_blob = &custom_snapshot_startup_data_;
-  }*/
-
   // One per each runtime.
   create_params_.array_buffer_allocator = v8::ArrayBuffer::Allocator::NewDefaultAllocator();
 

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -640,7 +640,7 @@ class V8Runtime : public facebook::jsi::Runtime {
   v8::Local<v8::Context> CreateContext(v8::Isolate *isolate);
 
   // Methods to compile and execute JS script
-  facebook::jsi::Value ExecuteString(const v8::Local<v8::String> &source, const std::string &sourceURL);
+  facebook::jsi::Value ExecuteString(const v8::Local<v8::String> &source, const std::string &sourceURL, std::uint64_t hash);
 
   void ReportException(v8::TryCatch *try_catch);
 

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -75,8 +75,6 @@ class CounterCollection {
 
 using CounterMap = std::unordered_map<std::string, Counter *>;
 
-enum class CacheType { NoCache, CodeCache, FullCodeCache };
-
 class V8PlatformHolder {
  public:
   V8PlatformHolder() {}
@@ -629,12 +627,7 @@ class V8Runtime : public facebook::jsi::Runtime {
   static size_t NearHeapLimitCallback(void *raw_state, size_t current_heap_limit, size_t initial_heap_limit);
 
   static void GCPrologueCallback(v8::Isolate *isolate, v8::GCType type, v8::GCCallbackFlags flags);
-
   static void GCEpilogueCallback(v8::Isolate *isolate, v8::GCType type, v8::GCCallbackFlags flags);
-
-  V8RuntimeArgs &runtimeArgs() {
-    return args_;
-  }
 
  private:
   v8::Local<v8::Context> CreateContext(v8::Isolate *isolate);
@@ -687,10 +680,8 @@ class V8Runtime : public facebook::jsi::Runtime {
   v8::Global<v8::Context> context_;
   v8runtime::IsolateData *isolate_data_{nullptr};
 
-  v8::StartupData startup_data_;
   v8::Isolate::CreateParams create_params_;
 
-  v8::Persistent<v8::FunctionTemplate> host_function_template_;
   v8::Persistent<v8::Function> host_object_constructor_;
 
   std::list<std::shared_ptr<HostObjectLifetimeTracker>> host_object_lifetime_tracker_list_;
@@ -700,9 +691,6 @@ class V8Runtime : public facebook::jsi::Runtime {
   static thread_local uint16_t tls_isolate_usage_counter_;
 
   V8PlatformHolder platform_holder_;
-  v8::StartupData custom_snapshot_startup_data_;
-
-  std::vector<std::unique_ptr<ExternalOwningOneByteStringResource>> owned_external_string_resources_;
 
   bool ignore_unhandled_promises_{false};
   std::unique_ptr<UnhandledPromiseRejection> last_unhandled_promise_;


### PR DESCRIPTION
Since we hardcode the script version to "1" we could get into a state where we're using bytecode / script cache from an older bundle version. This change implements a simple hashing algorithm to version the scripts.

Bonus knowing the script is Ascii lets us skip a copy, and some generic cleanup.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/124)