### PR TITLE
Remove JSI JSError::setStack method

### DIFF
--- a/src/jsi/jsi.h
+++ b/src/jsi/jsi.h
@@ -1318,13 +1318,6 @@ class JSI_EXPORT JSError : public JSIException {
     return *value_;
   }
 
-  /// In V8's case, creating an Error object in JS doesn't record the callstack
-  /// To preserve it, we need a way to manually add the stack here and on the JS side
-  void setStack(std::string stack) {
-    stack_ = std::move(stack);
-    what_ = message_ + "\n\n" + stack_;
-  }
-
  private:
   // This initializes the value_ member and does some other
   // validation, so it must be called by every branch through the


### PR DESCRIPTION
### The issue

The JSI `JSError::setStack` method is a custom extension to JSI API.
It is required to record V8 error stack.
Since it is better to keep JSI public files to be the same as they are defined in Hermes and ReactNative, we need to find a way to remove it.

### Solution

In this PR we remove `JSError::setStack` method by using special private field accessors for the `jsi::JSError` class.
It is based on the technique described in this article:
http://bloglitb.blogspot.com/2010/07/access-to-private-members-thats-easy.html
 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/125)