### PR TITLE
[0.65] Fix isAscii and prepareJavaScript

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.65.13",
+    "version": "0.65.14",
     "v8ref": "refs/branch-heads/10.0"
 }

--- a/src/MurmurHash.cpp
+++ b/src/MurmurHash.cpp
@@ -37,8 +37,7 @@ FORCE_INLINE uint64_t fmix64(uint64_t k) {
 }
 
 bool isAscii(uint64_t k) {
-  return ((unsigned char)(k & 0xff) <= 127) && ((unsigned char)((k >> 8) & 0xff) <= 127) &&
-      ((unsigned char)((k >> 16) & 0xff) <= 127) && ((unsigned char)(k >> 24) <= 127);
+  return (k & 0x8080808080808080) == 0ull;
 }
 
 bool MurmurHash3_x64_128(const void *key, const int len, const uint32_t seed, void *out) {

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -613,6 +613,7 @@ class V8Runtime : public facebook::jsi::Runtime {
 
   // Methods to compile and execute JS script
   facebook::jsi::Value ExecuteString(const v8::Local<v8::String> &source, const std::string &sourceURL, std::uint64_t hash);
+  v8::Local<v8::String> loadJavaScript(const std::shared_ptr<const facebook::jsi::Buffer> &buffer, std::uint64_t& hash);
 
   void ReportException(v8::TryCatch *try_catch);
 


### PR DESCRIPTION
- isAscii was checking only 4 of the 8 bytes;
- update prepareJavaScript / evaluatePreparedJavaScript to use the hashing functionality as well;

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/127)