### PR TITLE
[0.65] Implement PreparedScriptStore for V8 Node-API

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.65.14",
+    "version": "0.65.15",
     "v8ref": "refs/branch-heads/10.0"
 }

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -176,6 +176,11 @@ class V8Runtime : public facebook::jsi::Runtime {
 
   napi_status NapiGetUniqueUtf8StringRef(napi_env env, const char *str, size_t length, napi_ext_ref *result);
 
+  // Methods to compile and execute JS script
+  v8::Local<v8::Value>
+  ExecuteString(const v8::Local<v8::String> &source, const std::string &sourceURL, std::uint64_t hash);
+  v8::Local<v8::String> loadJavaScript(const std::shared_ptr<const facebook::jsi::Buffer> &buffer, std::uint64_t &hash);
+
  private: // Used by NAPI implementation
   static void PromiseRejectCallback(v8::PromiseRejectMessage data);
   void
@@ -608,11 +613,6 @@ class V8Runtime : public facebook::jsi::Runtime {
 
  private:
   v8::Local<v8::Context> CreateContext(v8::Isolate *isolate);
-
-  // Methods to compile and execute JS script
-  facebook::jsi::Value
-  ExecuteString(const v8::Local<v8::String> &source, const std::string &sourceURL, std::uint64_t hash);
-  v8::Local<v8::String> loadJavaScript(const std::shared_ptr<const facebook::jsi::Buffer> &buffer, std::uint64_t &hash);
 
   void ReportException(v8::TryCatch *try_catch);
 

--- a/src/napi/js_native_ext_api_v8.cpp
+++ b/src/napi/js_native_ext_api_v8.cpp
@@ -29,7 +29,6 @@
 
 #include "env-inl.h"
 
-#include "MurmurHash.h"
 #include "V8JsiRuntime_impl.h"
 #include "js_native_api_v8.h"
 #include "js_native_ext_api.h"

--- a/src/public/NapiJsiRuntime.h
+++ b/src/public/NapiJsiRuntime.h
@@ -27,6 +27,54 @@ namespace Microsoft::JSI {
 
 V8JSI_EXPORT std::unique_ptr<facebook::jsi::Runtime> __cdecl MakeNapiJsiRuntime(napi_env env) noexcept;
 
+template <typename T>
+struct NativeObjectWrapper;
+
+template <typename T>
+struct NativeObjectWrapper<std::unique_ptr<T>> {
+  static napi_ext_native_data Wrap(std::unique_ptr<T> &&obj) noexcept {
+    napi_ext_native_data nativeData{};
+    nativeData.data = obj.release();
+    nativeData.finalize_cb = [](napi_env /*env*/, void *data, void * /*finalizeHint*/) {
+      std::unique_ptr<T> obj{reinterpret_cast<T *>(data)};
+    };
+    return nativeData;
+  }
+
+  static T *Unwrap(napi_ext_native_data &nativeData) noexcept {
+    return reinterpret_cast<T *>(nativeData.data);
+  }
+};
+
+template <typename T>
+struct NativeObjectWrapper<std::shared_ptr<T>> {
+  static napi_ext_native_data Wrap(std::shared_ptr<T> &&obj) noexcept {
+    static_assert(
+        sizeof(SharedPtrHolder) == sizeof(std::shared_ptr<T>), "std::shared_ptr expected to have size of two pointers");
+    SharedPtrHolder ptrHolder;
+    new (std::addressof(ptrHolder)) std::shared_ptr(std::move(obj));
+    napi_ext_native_data nativeData{};
+    nativeData.data = ptrHolder.ptr1;
+    nativeData.finalize_hint = ptrHolder.ptr2;
+    nativeData.finalize_cb = [](napi_env /*env*/, void *data, void *finalizeHint) {
+      SharedPtrHolder ptrHolder{data, finalizeHint};
+      std::shared_ptr<T> obj(std::move(*reinterpret_cast<std::shared_ptr<T> *>(std::addressof(ptrHolder))));
+    };
+    return nativeData;
+  }
+
+  static std::shared_ptr<T> Unwrap(napi_ext_native_data &nativeData) noexcept {
+    SharedPtrHolder ptrHolder{nativeData.data, nativeData.finalize_hint};
+    return *reinterpret_cast<std::shared_ptr<T> *>(std::addressof(ptrHolder));
+  }
+
+ private:
+  struct SharedPtrHolder {
+    void *ptr1;
+    void *ptr2;
+  };
+};
+
 } // namespace Microsoft::JSI
 
 #endif // SRC_PUBLIC_NAPIJSIRUNTIME_H_

--- a/src/public/js_native_ext_api.h
+++ b/src/public/js_native_ext_api.h
@@ -6,7 +6,7 @@
 #include "js_native_api.h"
 
 //
-// N-API extensions required for JavaScript engine hosting.
+// Node API extensions required for JavaScript engine hosting.
 //
 // It is a very early version of the APIs which we consider to be experimental.
 // These APIs are not stable yet and are subject to change while we continue
@@ -42,7 +42,53 @@ typedef void(__cdecl *napi_ext_schedule_task_callback)(
     napi_finalize finalize_cb,
     void *finalize_hint);
 
-typedef struct _napi_ext_env_settings {
+// Wraps up native data and its finalizer method to be called when it is not needed anymore.
+// This struct is planned to be replaced by node_api_native_data defined in this PR:
+// https://github.com/nodejs/node/pull/42651
+typedef struct {
+  void *data;
+  napi_finalize finalize_cb; // Callback to be called when finished using data
+  void *finalize_hint;
+} napi_ext_native_data;
+
+// Wraps up native buffer.
+typedef struct {
+  napi_ext_native_data buffer_object;
+  const uint8_t *data;
+  size_t byte_size;
+} napi_ext_buffer;
+
+// Meta data associated with a cached script.
+typedef struct {
+  const char *source_url;
+  uint64_t source_hash;
+  const char *runtime_name;
+  uint64_t runtime_version;
+  const char *tag;
+} napi_ext_cached_script_metadata;
+
+// Forward declaration
+typedef struct napi_ext_script_cache napi_ext_script_cache;
+
+typedef napi_status(__cdecl *napi_ext_load_cached_script)(
+    napi_env env,
+    napi_ext_script_cache *script_cache,
+    napi_ext_cached_script_metadata *script_metadata,
+    napi_ext_buffer *result);
+
+typedef napi_status(__cdecl *napi_ext_store_cached_script)(
+    napi_env env,
+    napi_ext_script_cache *script_cache,
+    napi_ext_cached_script_metadata *script_metadata,
+    const napi_ext_buffer *result);
+
+typedef struct napi_ext_script_cache {
+  napi_ext_native_data cache_object;
+  napi_ext_load_cached_script load_cached_script;
+  napi_ext_store_cached_script store_cached_script;
+} napi_ext_script_cache;
+
+typedef struct napi_ext_env_settings {
   // Size of this struct to allow extending it in future.
   size_t this_size;
 
@@ -96,6 +142,8 @@ typedef struct _napi_ext_env_settings {
     } flags;
     uint32_t _flagspad{0};
   };
+
+  napi_ext_script_cache *script_cache;
 
 } napi_ext_env_settings;
 
@@ -196,5 +244,13 @@ NAPI_EXTERN napi_status __cdecl napi_ext_reference_unref(napi_env env, napi_ext_
 
 // Gets the referenced value.
 NAPI_EXTERN napi_status __cdecl napi_ext_get_reference_value(napi_env env, napi_ext_ref ref, napi_value *result);
+
+// Run the script with the source map that can be used for the script debugging.
+// TODO: Add points for extension
+NAPI_EXTERN napi_status __cdecl napi_ext_run_script_buffer(
+    napi_env env,
+    napi_ext_buffer *script_buffer,
+    const char *source_url,
+    napi_value *result);
 
 EXTERN_C_END

--- a/src/public/js_native_ext_api.h
+++ b/src/public/js_native_ext_api.h
@@ -246,7 +246,6 @@ NAPI_EXTERN napi_status __cdecl napi_ext_reference_unref(napi_env env, napi_ext_
 NAPI_EXTERN napi_status __cdecl napi_ext_get_reference_value(napi_env env, napi_ext_ref ref, napi_value *result);
 
 // Run the script with the source map that can be used for the script debugging.
-// TODO: Add points for extension
 NAPI_EXTERN napi_status __cdecl napi_ext_run_script_buffer(
     napi_env env,
     napi_ext_buffer *script_buffer,


### PR DESCRIPTION
In this PR we add new Node-API extension capability to run JavaScript functions that can use the prepared script store. 
The solution consists of the following parts:

- new function `napi_ext_run_script_buffer` that can run JavaScript from the provided buffer.
- the `napi_ext_env_settings` struct is extended with a new field `script_cache` of type `napi_ext_script_cache`.
- new `napi_ext_script_cache` struct that represents the prepared script store.
- new `napi_ext_cached_script_metadata` struct with JavaScript metadata that used for validating byte code cache.
- new `napi_ext_buffer` struct to represent script text or binary buffer.
- new `napi_ext_native_data` struct as a base type to control lifetime of an external object.

The implementation wraps up the `napi_ext_script_cache` into `NodeApiPreparedScriptStore` class that implements `facebook::jsi::PreparedScriptStore` interface, which then passed to the internal `V8Runtime` instance.
Then, the `napi_ext_run_script_buffer` calls the `V8Runtime::loadJavaScript` and `V8Runtime::ExecuteString` methods to evaluate the script that internally relies on the `NodeApiPreparedScriptStore`.

The `V8Runtime::ExecuteString` is modified to return `v8::Local<v8::Value>` instead of `facebook::jsi::Value` to use the result for the Node-API `napi_value`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/130)