### PR TITLE
Implement PreparedScriptStore for V8 Node-API

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.69.3",
+    "version": "0.69.4",
     "v8ref": "refs/branch-heads/10.0"
 }

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -176,6 +176,11 @@ class V8Runtime : public facebook::jsi::Runtime {
 
   napi_status NapiGetUniqueUtf8StringRef(napi_env env, const char *str, size_t length, napi_ext_ref *result);
 
+  // Methods to compile and execute JS script
+  v8::Local<v8::Value>
+  ExecuteString(const v8::Local<v8::String> &source, const std::string &sourceURL, std::uint64_t hash);
+  v8::Local<v8::String> loadJavaScript(const std::shared_ptr<const facebook::jsi::Buffer> &buffer, std::uint64_t &hash);
+
  private: // Used by NAPI implementation
   static void PromiseRejectCallback(v8::PromiseRejectMessage data);
   void
@@ -631,11 +636,6 @@ class V8Runtime : public facebook::jsi::Runtime {
 
  private:
   v8::Local<v8::Context> CreateContext(v8::Isolate *isolate);
-
-  // Methods to compile and execute JS script
-  facebook::jsi::Value
-  ExecuteString(const v8::Local<v8::String> &source, const std::string &sourceURL, std::uint64_t hash);
-  v8::Local<v8::String> loadJavaScript(const std::shared_ptr<const facebook::jsi::Buffer> &buffer, std::uint64_t &hash);
 
   void ReportException(v8::TryCatch *try_catch);
 

--- a/src/napi/js_native_ext_api_v8.cpp
+++ b/src/napi/js_native_ext_api_v8.cpp
@@ -32,6 +32,7 @@
 #include "V8JsiRuntime_impl.h"
 #include "js_native_api_v8.h"
 #include "js_native_ext_api.h"
+#include "public/NapiJsiRuntime.h"
 #include "public/ScriptStore.h"
 
 namespace v8impl {
@@ -166,7 +167,7 @@ struct V8RuntimeHolder : protected v8impl::RefTracker {
 
 } // namespace v8impl
 
-static struct EnvScope {
+struct EnvScope {
   EnvScope(napi_env env)
       : env_{env},
         isolate_scope_{new v8::Isolate::Scope(env->isolate)},
@@ -243,6 +244,80 @@ struct NapiJSITaskRunner : v8runtime::JSITaskRunner {
   napi_ext_schedule_task_callback scheduler_;
 };
 
+struct NodeApiJsiBuffer : facebook::jsi::Buffer {
+  static std::shared_ptr<const facebook::jsi::Buffer> CreateJsiBuffer(napi_ext_buffer *buffer) {
+    if (buffer && buffer->data) {
+      return std::shared_ptr<const facebook::jsi::Buffer>(new NodeApiJsiBuffer(buffer));
+    } else {
+      return {};
+    }
+  }
+
+  NodeApiJsiBuffer(napi_ext_buffer *buffer) noexcept : buffer_(*buffer) {}
+
+  ~NodeApiJsiBuffer() override {
+    if (buffer_.buffer_object.finalize_cb) {
+      buffer_.buffer_object.finalize_cb(nullptr, buffer_.buffer_object.data, buffer_.buffer_object.finalize_hint);
+    }
+  }
+
+  const uint8_t *data() const override {
+    return buffer_.data;
+  }
+
+  size_t size() const override {
+    return buffer_.byte_size;
+  }
+
+ private:
+  napi_ext_buffer buffer_;
+};
+
+struct NodeApiPreparedScriptStore : facebook::jsi::PreparedScriptStore {
+  NodeApiPreparedScriptStore(napi_ext_script_cache *scriptCache) noexcept : scriptCache_(*scriptCache) {}
+
+  std::shared_ptr<const facebook::jsi::Buffer> tryGetPreparedScript(
+      const facebook::jsi::ScriptSignature &scriptSignature,
+      const facebook::jsi::JSRuntimeSignature &runtimeMetadata,
+      const char *prepareTag) noexcept override {
+    napi_ext_cached_script_metadata metadata = initScriptMetadata(scriptSignature, runtimeMetadata, prepareTag);
+    napi_ext_buffer buffer{};
+    scriptCache_.load_cached_script(nullptr, &scriptCache_, &metadata, &buffer);
+    return NodeApiJsiBuffer::CreateJsiBuffer(&buffer);
+  }
+
+  void persistPreparedScript(
+      std::shared_ptr<const facebook::jsi::Buffer> preparedScript,
+      const facebook::jsi::ScriptSignature &scriptSignature,
+      const facebook::jsi::JSRuntimeSignature &runtimeMetadata,
+      const char *prepareTag) noexcept override {
+    napi_ext_cached_script_metadata metadata = initScriptMetadata(scriptSignature, runtimeMetadata, prepareTag);
+    napi_ext_buffer buffer{};
+    buffer.data = preparedScript->data();
+    buffer.byte_size = preparedScript->size();
+    buffer.buffer_object = Microsoft::JSI::NativeObjectWrapper<std::shared_ptr<const facebook::jsi::Buffer>>::Wrap(
+        std::move(preparedScript));
+    scriptCache_.store_cached_script(nullptr, &scriptCache_, &metadata, &buffer);
+  }
+
+ private:
+  napi_ext_cached_script_metadata initScriptMetadata(
+      const facebook::jsi::ScriptSignature &scriptSignature,
+      const facebook::jsi::JSRuntimeSignature &runtimeMetadata,
+      const char *prepareTag) noexcept {
+    napi_ext_cached_script_metadata metadata{};
+    metadata.source_url = scriptSignature.url.c_str();
+    metadata.source_hash = scriptSignature.version;
+    metadata.runtime_name = runtimeMetadata.runtimeName.c_str();
+    metadata.runtime_version = runtimeMetadata.version;
+    metadata.tag = prepareTag;
+    return metadata;
+  }
+
+ private:
+  napi_ext_script_cache scriptCache_;
+};
+
 napi_status napi_ext_create_env(napi_ext_env_settings *settings, napi_env *env) {
   v8runtime::V8RuntimeArgs args;
 
@@ -265,6 +340,10 @@ napi_status napi_ext_create_env(napi_ext_env_settings *settings, napi_env *env) 
 
   auto taskRunner = std::make_shared<NapiJSITaskRunner>(*env, settings->foreground_scheduler);
   args.foreground_task_runner = taskRunner;
+
+  if (settings->script_cache) {
+    args.preparedScriptStore = std::make_unique<NodeApiPreparedScriptStore>(settings->script_cache);
+  }
 
   auto runtime = std::make_unique<v8runtime::V8Runtime>(std::move(args));
 
@@ -357,6 +436,26 @@ napi_status napi_ext_run_script(napi_env env, napi_value source, const char *sou
   CHECK_MAYBE_EMPTY(env, script_result, napi_generic_failure);
 
   *result = v8impl::JsValueFromV8LocalValue(script_result.ToLocalChecked());
+  return GET_RETURN_STATUS(env);
+}
+
+napi_status __cdecl napi_ext_run_script_buffer(
+    napi_env env,
+    napi_ext_buffer *script_buffer,
+    const char *source_url,
+    napi_value *result) {
+  NAPI_PREAMBLE(env);
+  CHECK_ARG(env, script_buffer);
+  CHECK_ARG(env, result);
+
+  std::shared_ptr<const facebook::jsi::Buffer> buffer{NodeApiJsiBuffer::CreateJsiBuffer(script_buffer)};
+  auto runtime = v8runtime::V8Runtime::GetCurrent(env->context());
+
+  std::uint64_t hash{0};
+  v8::Local<v8::String> sourceV8String = runtime->loadJavaScript(buffer, hash);
+  v8::Local<v8::Value> res = runtime->ExecuteString(sourceV8String, std::string(source_url ? source_url : ""), hash);
+
+  *result = v8impl::JsValueFromV8LocalValue(res);
   return GET_RETURN_STATUS(env);
 }
 

--- a/src/public/NapiJsiRuntime.h
+++ b/src/public/NapiJsiRuntime.h
@@ -27,6 +27,54 @@ namespace Microsoft::JSI {
 
 V8JSI_EXPORT std::unique_ptr<facebook::jsi::Runtime> __cdecl MakeNapiJsiRuntime(napi_env env) noexcept;
 
+template <typename T>
+struct NativeObjectWrapper;
+
+template <typename T>
+struct NativeObjectWrapper<std::unique_ptr<T>> {
+  static napi_ext_native_data Wrap(std::unique_ptr<T> &&obj) noexcept {
+    napi_ext_native_data nativeData{};
+    nativeData.data = obj.release();
+    nativeData.finalize_cb = [](napi_env /*env*/, void *data, void * /*finalizeHint*/) {
+      std::unique_ptr<T> obj{reinterpret_cast<T *>(data)};
+    };
+    return nativeData;
+  }
+
+  static T *Unwrap(napi_ext_native_data &nativeData) noexcept {
+    return reinterpret_cast<T *>(nativeData.data);
+  }
+};
+
+template <typename T>
+struct NativeObjectWrapper<std::shared_ptr<T>> {
+  static napi_ext_native_data Wrap(std::shared_ptr<T> &&obj) noexcept {
+    static_assert(
+        sizeof(SharedPtrHolder) == sizeof(std::shared_ptr<T>), "std::shared_ptr expected to have size of two pointers");
+    SharedPtrHolder ptrHolder;
+    new (std::addressof(ptrHolder)) std::shared_ptr(std::move(obj));
+    napi_ext_native_data nativeData{};
+    nativeData.data = ptrHolder.ptr1;
+    nativeData.finalize_hint = ptrHolder.ptr2;
+    nativeData.finalize_cb = [](napi_env /*env*/, void *data, void *finalizeHint) {
+      SharedPtrHolder ptrHolder{data, finalizeHint};
+      std::shared_ptr<T> obj(std::move(*reinterpret_cast<std::shared_ptr<T> *>(std::addressof(ptrHolder))));
+    };
+    return nativeData;
+  }
+
+  static std::shared_ptr<T> Unwrap(napi_ext_native_data &nativeData) noexcept {
+    SharedPtrHolder ptrHolder{nativeData.data, nativeData.finalize_hint};
+    return *reinterpret_cast<std::shared_ptr<T> *>(std::addressof(ptrHolder));
+  }
+
+ private:
+  struct SharedPtrHolder {
+    void *ptr1;
+    void *ptr2;
+  };
+};
+
 } // namespace Microsoft::JSI
 
 #endif // SRC_PUBLIC_NAPIJSIRUNTIME_H_


### PR DESCRIPTION
Cherry pick PR #130:

In this PR we add new Node-API extension capability to run JavaScript functions that can use the prepared script store. 
The solution consists of the following parts:

- new function `napi_ext_run_script_buffer` that can run JavaScript from the provided buffer.
- the `napi_ext_env_settings` struct is extended with a new field `script_cache` of type `napi_ext_script_cache`.
- new `napi_ext_script_cache` struct that represents the prepared script store.
- new `napi_ext_cached_script_metadata` struct with JavaScript metadata that used for validating byte code cache.
- new `napi_ext_buffer` struct to represent script text or binary buffer.
- new `napi_ext_native_data` struct as a base type to control lifetime of an external object.

The implementation wraps up the `napi_ext_script_cache` into `NodeApiPreparedScriptStore` class that implements `facebook::jsi::PreparedScriptStore` interface, which then passed to the internal `V8Runtime` instance.
Then, the `napi_ext_run_script_buffer` calls the `V8Runtime::loadJavaScript` and `V8Runtime::ExecuteString` methods to evaluate the script that internally relies on the `NodeApiPreparedScriptStore`.

The `V8Runtime::ExecuteString` is modified to return `v8::Local<v8::Value>` instead of `facebook::jsi::Value` to use the result for the Node-API `napi_value`.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/131)