### PR TITLE
Remove the CETCompat flag

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.69.5",
+    "version": "0.69.6",
     "v8ref": "refs/branch-heads/10.3"
 }

--- a/scripts/patch/build.diff
+++ b/scripts/patch/build.diff
@@ -44,7 +44,7 @@ index 3a6dc1e54..74942f30b 100644
      }
    }
  }
-@@ -592,3 +592,15 @@ config("lean_and_mean") {
+@@ -592,3 +592,11 @@ config("lean_and_mean") {
  config("nominmax") {
    defines = [ "NOMINMAX" ]
  }
@@ -54,10 +54,6 @@ index 3a6dc1e54..74942f30b 100644
 +  if (!is_clang && !is_debug) {
 +    cflags = [ "/guard:cf", "/Qspectre", "/W3" ]
 +    ldflags = [ "/guard:cf" ]
-+
-+    if (current_cpu != "arm64") {
-+      ldflags += [ "/CETCOMPAT" ]
-+    }
 +  }
 +}
 diff --git a/toolchain/win/setup_toolchain.py b/toolchain/win/setup_toolchain.py


### PR DESCRIPTION
- Remove the CETCompat flag which causes issues on certain Intel machines
- The stack shouldn't include the message as well. Addresses #136

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/137)