### PR TITLE
patch: updated v8-jsi android with RN68 jsi headers

### DIFF
--- a/android/build.config
+++ b/android/build.config
@@ -1,4 +1,4 @@
 V8_TAG="7.0.276.32"
-RN_VERSION="0.66.0-stable"
+RN_VERSION="0.68-stable"
 NDK_VERSION="r21b"
-NUGET_PKG_VERSION="0.66.0-stable-v3"
+NUGET_PKG_VERSION="0.68-stable-v1"

--- a/android/jsi/CMakeLists.txt
+++ b/android/jsi/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/android/jsi/JSIDynamic.cpp
+++ b/android/jsi/JSIDynamic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/android/jsi/JSIDynamic.h
+++ b/android/jsi/JSIDynamic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/android/jsi/decorator.h
+++ b/android/jsi/decorator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/android/jsi/instrumentation.h
+++ b/android/jsi/instrumentation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/android/jsi/jsi-inl.h
+++ b/android/jsi/jsi-inl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/android/jsi/jsi.cpp
+++ b/android/jsi/jsi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/android/jsi/jsi.h
+++ b/android/jsi/jsi.h
@@ -966,7 +966,9 @@ class JSI_EXPORT Value {
             std::is_base_of<String, T>::value ||
             std::is_base_of<Object, T>::value,
         "Value cannot be implicitly move-constructed from this type");
+#ifndef __clang_analyzer__ // TODO(macOS GH#774) Disable [bugprone-move-forwarding-reference] when running clang static analysis
     new (&data_.pointer) T(std::move(other));
+#endif // __clang_analyzer__
   }
 
   /// Value("foo") will treat foo as a bool.  This makes doing that a

--- a/android/jsi/jsi.h
+++ b/android/jsi/jsi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -200,13 +200,13 @@ class JSI_EXPORT Runtime {
   /// Hosts may call this function again to resume the draining if it was
   /// suspended due to either exceptions or the \p maxMicrotasksHint bound.
   /// E.g. a host may repetitively invoke this function until the queue is
-  /// drained to implement the "microtask checkpint" defined in WHATWG HTML
+  /// drained to implement the "microtask checkpoint" defined in WHATWG HTML
   /// event loop: https://html.spec.whatwg.org/C#perform-a-microtask-checkpoint.
   ///
   /// Note that error propagation is only a concern if a host needs to implement
-  /// `queueMicrotask`, a recent API that allows enqueueing aribitary functions
+  /// `queueMicrotask`, a recent API that allows enqueueing arbitrary functions
   /// (hence may throw) as microtasks. Exceptions from ECMA-262 Promise Jobs are
-  /// handled internally to VMs and are never propagrated to hosts.
+  /// handled internally to VMs and are never propagated to hosts.
   ///
   /// This API offers some queue management to hosts at its best effort due to
   /// different behaviors and limitations imposed by different VMs and APIs. By
@@ -680,7 +680,7 @@ class JSI_EXPORT Object : public Pointer {
   std::shared_ptr<T> getHostObject(Runtime& runtime) const;
 
   /// \return a shared_ptr<T> which refers to the same underlying
-  /// \c HostObject that was used to crete this object. If \c isHostObject<T>
+  /// \c HostObject that was used to create this object. If \c isHostObject<T>
   /// is false, this will throw.
   template <typename T = HostObject>
   std::shared_ptr<T> asHostObject(Runtime& runtime) const;
@@ -966,9 +966,7 @@ class JSI_EXPORT Value {
             std::is_base_of<String, T>::value ||
             std::is_base_of<Object, T>::value,
         "Value cannot be implicitly move-constructed from this type");
-#ifndef __clang_analyzer__ // TODO(macOS GH#774) Disable [bugprone-move-forwarding-reference] when running clang static analysis
     new (&data_.pointer) T(std::move(other));
-#endif // __clang_analyzer__
   }
 
   /// Value("foo") will treat foo as a bool.  This makes doing that a

--- a/android/jsi/jsilib-posix.cpp
+++ b/android/jsi/jsilib-posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/android/jsi/jsilib-windows.cpp
+++ b/android/jsi/jsilib-windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/android/jsi/jsilib.h
+++ b/android/jsi/jsilib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/android/jsi/test/testlib.cpp
+++ b/android/jsi/test/testlib.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/android/jsi/test/testlib.h
+++ b/android/jsi/test/testlib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/android/jsi/threadsafe.h
+++ b/android/jsi/threadsafe.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Updated headers for Android with RN68 JSI

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/141)