### PR TITLE
Update to 0.70 JSI headers

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.69.9",
-    "v8ref": "refs/branch-heads/10.6"
+    "version": "0.70.1",
+    "v8ref": "refs/branch-heads/10.7"
 }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "version": "0.70.1",
-    "v8ref": "refs/branch-heads/10.7"
+    "v8ref": "refs/branch-heads/10.6"
 }

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -954,6 +954,16 @@ jsi::Runtime::PointerValue *V8Runtime::cloneSymbol(const jsi::Runtime::PointerVa
   return V8PointerValue<v8::Symbol>::make(GetIsolate(), symbol->get(GetIsolate()));
 }
 
+jsi::Runtime::PointerValue *V8Runtime::cloneBigInt(const jsi::Runtime::PointerValue *pv) {
+  if (!pv) {
+    return nullptr;
+  }
+
+  IsolateLocker isolate_locker(this);
+  const V8PointerValue<v8::BigInt> *bigInt = static_cast<const V8PointerValue<v8::BigInt> *>(pv);
+  return V8PointerValue<v8::BigInt>::make(GetIsolate(), bigInt->get(GetIsolate()));
+}
+
 std::string V8Runtime::symbolToString(const jsi::Symbol &sym) {
   IsolateLocker isolate_locker(this);
   return "Symbol(" +
@@ -1361,6 +1371,11 @@ bool V8Runtime::strictEquals(const jsi::Object &a, const jsi::Object &b) const {
 bool V8Runtime::strictEquals(const jsi::Symbol &a, const jsi::Symbol &b) const {
   IsolateLocker isolate_locker(this);
   return symbolRef(a)->StrictEquals(symbolRef(b));
+}
+
+bool V8Runtime::strictEquals(const jsi::BigInt &a, const jsi::BigInt &b) const {
+  IsolateLocker isolate_locker(this);
+  return bigIntlRef(a)->StrictEquals(bigIntlRef(b));
 }
 
 bool V8Runtime::instanceOf(const jsi::Object &o, const jsi::Function &f) {

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -574,6 +574,7 @@ class V8Runtime : public facebook::jsi::Runtime {
   PointerValue *cloneObject(const PointerValue *pv) override;
   PointerValue *clonePropNameID(const PointerValue *pv) override;
   PointerValue *cloneSymbol(const PointerValue *pv) override;
+  PointerValue* cloneBigInt(const PointerValue *pv) override;
 
   facebook::jsi::PropNameID createPropNameIDFromAscii(const char *str, size_t length) override;
   facebook::jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length) override;
@@ -633,6 +634,7 @@ class V8Runtime : public facebook::jsi::Runtime {
   bool strictEquals(const facebook::jsi::String &a, const facebook::jsi::String &b) const override;
   bool strictEquals(const facebook::jsi::Object &a, const facebook::jsi::Object &b) const override;
   bool strictEquals(const facebook::jsi::Symbol &a, const facebook::jsi::Symbol &b) const override;
+  bool strictEquals(const facebook::jsi::BigInt &a, const facebook::jsi::BigInt &b) const override;
 
   bool instanceOf(const facebook::jsi::Object &o, const facebook::jsi::Function &f) override;
 
@@ -701,6 +703,9 @@ class V8Runtime : public facebook::jsi::Runtime {
   }
   v8::Local<v8::Symbol> symbolRef(const facebook::jsi::Symbol &sym) const {
     return pvRef<v8::Symbol>(getPointerValue(sym));
+  }
+  v8::Local<v8::BigInt> bigIntlRef(const facebook::jsi::BigInt &bigInt) const {
+    return pvRef<v8::BigInt>(getPointerValue(bigInt));
   }
 
   v8::Local<v8::Value> valueReference(const facebook::jsi::Value &value);

--- a/src/jsi/README.md
+++ b/src/jsi/README.md
@@ -1,6 +1,3 @@
 The JSI folder is matching to https://github.com/facebook/hermes.git
-Commit hash:	993a407ec80359e47d2bfac5b17ac533e58e2ed5
-Author:			Anand Bashyam <kalyanavarathan@fb.com>#mailto:kalyanavarathan@fb.com
-Date:			4/18/2022 10:08:22 AM
-
+tag: hermes-2022-09-14-RNv0.70.1-2a6b111ab289b55d7b78b5fdf105f466ba270fd7
 Please update the info after the next sync up.

--- a/src/jsi/decorator.h
+++ b/src/jsi/decorator.h
@@ -154,6 +154,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   Runtime::PointerValue* cloneSymbol(const Runtime::PointerValue* pv) override {
     return plain_.cloneSymbol(pv);
   };
+  Runtime::PointerValue* cloneBigInt(const Runtime::PointerValue* pv) override {
+    return plain_.cloneBigInt(pv);
+  };
   Runtime::PointerValue* cloneString(const Runtime::PointerValue* pv) override {
     return plain_.cloneString(pv);
   };
@@ -313,6 +316,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   }
 
   bool strictEquals(const Symbol& a, const Symbol& b) const override {
+    return plain_.strictEquals(a, b);
+  };
+  bool strictEquals(const BigInt& a, const BigInt& b) const override {
     return plain_.strictEquals(a, b);
   };
   bool strictEquals(const String& a, const String& b) const override {

--- a/src/jsi/jsi-inl.h
+++ b/src/jsi/jsi-inl.h
@@ -56,7 +56,12 @@ inline PropNameID&& toPropNameID(Runtime&, PropNameID&& name) {
   return std::move(name);
 }
 
-void throwJSError(Runtime&, const char* msg);
+/// Helper to throw while still compiling with exceptions turned off.
+template <typename E, typename... Args>
+[[noreturn]] inline void throwOrDie(Args&&... args) {
+  std::rethrow_exception(
+      std::make_exception_ptr(E{std::forward<Args>(args)...}));
+}
 
 } // namespace detail
 
@@ -184,7 +189,8 @@ inline std::shared_ptr<T> Object::getHostObject(Runtime& runtime) const {
 template <typename T>
 inline std::shared_ptr<T> Object::asHostObject(Runtime& runtime) const {
   if (!isHostObject<T>(runtime)) {
-    detail::throwJSError(runtime, "Object is not a HostObject of desired type");
+    detail::throwOrDie<JSINativeException>(
+        "Object is not a HostObject of desired type");
   }
   return std::static_pointer_cast<T>(runtime.getHostObject(*this));
 }

--- a/src/jsi/jsi.cpp
+++ b/src/jsi/jsi.cpp
@@ -32,6 +32,8 @@ std::string kindToString(const Value& v, Runtime* rt = nullptr) {
     return "a string";
   } else if (v.isSymbol()) {
     return "a symbol";
+  } else if (v.isBigInt()) {
+    return "a bigint";
   } else {
     assert(v.isObject() && "Expecting object.");
     return rt != nullptr && v.getObject(*rt).isFunction(*rt) ? "a function"
@@ -61,14 +63,6 @@ Value callGlobalFunction(Runtime& runtime, const char* name, const Value& arg) {
 }
 
 } // namespace
-
-namespace detail {
-
-void throwJSError(Runtime& rt, const char* msg) {
-  throw JSError(rt, msg);
-}
-
-} // namespace detail
 
 Buffer::~Buffer() = default;
 
@@ -242,6 +236,8 @@ Value::Value(Runtime& runtime, const Value& other) : Value(other.kind_) {
     data_.number = other.data_.number;
   } else if (kind_ == SymbolKind) {
     new (&data_.pointer) Pointer(runtime.cloneSymbol(other.data_.pointer.ptr_));
+  } else if (kind_ == BigIntKind) {
+    new (&data_.pointer) Pointer(runtime.cloneBigInt(other.data_.pointer.ptr_));
   } else if (kind_ == StringKind) {
     new (&data_.pointer) Pointer(runtime.cloneString(other.data_.pointer.ptr_));
   } else if (kind_ >= ObjectKind) {
@@ -271,6 +267,10 @@ bool Value::strictEquals(Runtime& runtime, const Value& a, const Value& b) {
       return runtime.strictEquals(
           static_cast<const Symbol&>(a.data_.pointer),
           static_cast<const Symbol&>(b.data_.pointer));
+    case BigIntKind:
+      return runtime.strictEquals(
+          static_cast<const BigInt&>(a.data_.pointer),
+          static_cast<const BigInt&>(b.data_.pointer));
     case StringKind:
       return runtime.strictEquals(
           static_cast<const String&>(a.data_.pointer),
@@ -336,6 +336,24 @@ Symbol Value::asSymbol(Runtime& rt) && {
   }
 
   return std::move(*this).getSymbol(rt);
+}
+
+BigInt Value::asBigInt(Runtime& rt) const& {
+  if (!isBigInt()) {
+    throw JSError(
+        rt, "Value is " + kindToString(*this, &rt) + ", expected a BigInt");
+  }
+
+  return getBigInt(rt);
+}
+
+BigInt Value::asBigInt(Runtime& rt) && {
+  if (!isBigInt()) {
+    throw JSError(
+        rt, "Value is " + kindToString(*this, &rt) + ", expected a BigInt");
+  }
+
+  return std::move(*this).getBigInt(rt);
 }
 
 String Value::asString(Runtime& rt) const& {

--- a/src/jsi/test/testlib.cpp
+++ b/src/jsi/test/testlib.cpp
@@ -1429,7 +1429,7 @@ TEST_P(JSITest, MultilevelDecoratedHostObject) {
   EXPECT_EQ(1, RD2::numGets);
 }
 
-INSTANTIATE_TEST_SUITE_P(
+INSTANTIATE_TEST_CASE_P(
     Runtimes,
     JSITest,
     ::testing::ValuesIn(runtimeGenerators()));

--- a/src/public/NapiJsiRuntime.cpp
+++ b/src/public/NapiJsiRuntime.cpp
@@ -88,6 +88,7 @@ struct NapiJsiRuntime : facebook::jsi::Runtime {
   PointerValue *cloneString(const PointerValue *pointerValue) override;
   PointerValue *cloneObject(const PointerValue *pointerValue) override;
   PointerValue *clonePropNameID(const PointerValue *pointerValue) override;
+  PointerValue *cloneBigInt(const PointerValue *pointerValue) override;
 
   facebook::jsi::PropNameID createPropNameIDFromAscii(const char *str, size_t length) override;
   facebook::jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length) override;
@@ -161,6 +162,7 @@ struct NapiJsiRuntime : facebook::jsi::Runtime {
   bool strictEquals(const facebook::jsi::Symbol &a, const facebook::jsi::Symbol &b) const override;
   bool strictEquals(const facebook::jsi::String &a, const facebook::jsi::String &b) const override;
   bool strictEquals(const facebook::jsi::Object &a, const facebook::jsi::Object &b) const override;
+  bool strictEquals(const facebook::jsi::BigInt &a, const facebook::jsi::BigInt &b) const override;
 
   bool instanceOf(const facebook::jsi::Object &obj, const facebook::jsi::Function &func) override;
 
@@ -609,6 +611,12 @@ facebook::jsi::Runtime::PointerValue *NapiJsiRuntime::clonePropNameID(
   return CloneNapiPointerValue(pointerValue);
 }
 
+facebook::jsi::Runtime::PointerValue *NapiJsiRuntime::cloneBigInt(
+    const facebook::jsi::Runtime::PointerValue *pointerValue) {
+  EnvScope envScope{m_env};
+  return CloneNapiPointerValue(pointerValue);
+}
+
 facebook::jsi::PropNameID NapiJsiRuntime::createPropNameIDFromAscii(const char *str, size_t length) {
   EnvScope envScope{m_env};
   napi_value napiStr = CreateStringLatin1({str, length});
@@ -909,6 +917,11 @@ bool NapiJsiRuntime::strictEquals(const facebook::jsi::String &a, const facebook
 }
 
 bool NapiJsiRuntime::strictEquals(const facebook::jsi::Object &a, const facebook::jsi::Object &b) const {
+  EnvScope envScope{m_env};
+  return StrictEquals(GetNapiValue(a), GetNapiValue(b));
+}
+
+bool NapiJsiRuntime::strictEquals(const facebook::jsi::BigInt &a, const facebook::jsi::BigInt &b) const {
   EnvScope envScope{m_env};
   return StrictEquals(GetNapiValue(a), GetNapiValue(b));
 }


### PR DESCRIPTION
- Created the 0.69-stable branch with the current state, this PR moves the main branch to 0.70;
- Also update V8 version to 10.7;

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/148)