### PR TITLE
Remove a folder during build to avoid CG alerts.

### DIFF
--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -89,6 +89,7 @@ if ($AppPlatform -eq "linux") {
 
 # Remove unused code
 Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\test\test262\data\tools")
+Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\third_party\depot_tools\external_bin\gsutil")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\third_party\google_benchmark")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\third_party\perfetto")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\third_party\protobuf")


### PR DESCRIPTION
The folder v8build\v8\third_party\depot_tools\external_bin\gsutil is not used during our builds but is causing Component Governance alerts to get created. This PR adds it to the list of folders we remove during build.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/149)