### PR TITLE
Update to 0.71 JSI API (stubs only)

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.70.1",
+    "version": "0.71.1",
     "v8ref": "refs/branch-heads/10.6"
 }

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -1375,7 +1375,7 @@ bool V8Runtime::strictEquals(const jsi::Symbol &a, const jsi::Symbol &b) const {
 
 bool V8Runtime::strictEquals(const jsi::BigInt &a, const jsi::BigInt &b) const {
   IsolateLocker isolate_locker(this);
-  return bigIntlRef(a)->StrictEquals(bigIntlRef(b));
+  return bigIntRef(a)->StrictEquals(bigIntRef(b));
 }
 
 bool V8Runtime::instanceOf(const jsi::Object &o, const jsi::Function &f) {
@@ -1403,6 +1403,8 @@ jsi::Value V8Runtime::createValue(v8::Local<v8::Value> value) const {
     return make<jsi::Object>(V8ObjectValue::make(GetIsolate(), v8::Local<v8::Object>::Cast(value)));
   } else if (value->IsSymbol()) {
     return make<jsi::Symbol>(V8PointerValue<v8::Symbol>::make(GetIsolate(), v8::Local<v8::Symbol>::Cast(value)));
+  } else if (value->IsBigInt()) {
+    return make<jsi::BigInt>(V8PointerValue<v8::BigInt>::make(GetIsolate(), v8::Local<v8::BigInt>::Cast(value)));
   } else {
     // What are you?
     std::abort();
@@ -1426,6 +1428,8 @@ v8::Local<v8::Value> V8Runtime::valueReference(const jsi::Value &value) {
     return handle_scope.Escape(objectRef(value.getObject(*this)));
   } else if (value.isSymbol()) {
     return handle_scope.Escape(symbolRef(value.getSymbol(*this)));
+  } else if (value.isBigInt()) {
+    return handle_scope.Escape(bigIntRef(value.getBigInt(*this)));
   } else {
     // What are you?
     std::abort();

--- a/src/jsi/JSIDynamic.cpp
+++ b/src/jsi/JSIDynamic.cpp
@@ -129,8 +129,7 @@ void dynamicFromValueShallow(
     output = value.getNumber();
   } else if (value.isString()) {
     output = value.getString(runtime).utf8(runtime);
-  } else {
-    CHECK(value.isObject());
+  } else if (value.isObject()) {
     Object obj = value.getObject(runtime);
     if (obj.isArray(runtime)) {
       output = folly::dynamic::array();
@@ -140,6 +139,12 @@ void dynamicFromValueShallow(
       output = folly::dynamic::object();
     }
     stack.emplace_back(&output, std::move(obj));
+  } else if (value.isBigInt()) {
+    throw JSError(runtime, "JS BigInts are not convertible to dynamic");
+  } else if (value.isSymbol()) {
+    throw JSError(runtime, "JS Symbols are not convertible to dynamic");
+  } else {
+    throw JSError(runtime, "Value is not convertible to dynamic");
   }
 }
 

--- a/src/jsi/README.md
+++ b/src/jsi/README.md
@@ -1,3 +1,3 @@
 The JSI folder is matching to https://github.com/facebook/hermes.git
-tag: hermes-2022-09-14-RNv0.70.1-2a6b111ab289b55d7b78b5fdf105f466ba270fd7
+tag: hermes-2022-11-03-RNv0.71.0-85613e1f9d1216f2cce7e54604be46057092939d
 Please update the info after the next sync up.

--- a/src/jsi/decorator.h
+++ b/src/jsi/decorator.h
@@ -193,6 +193,25 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     return plain_.symbolToString(sym);
   }
 
+  BigInt createBigIntFromInt64(int64_t value) override {
+    return plain_.createBigIntFromInt64(value);
+  }
+  BigInt createBigIntFromUint64(uint64_t value) override {
+    return plain_.createBigIntFromUint64(value);
+  }
+  bool bigintIsInt64(const BigInt& b) override {
+    return plain_.bigintIsInt64(b);
+  }
+  bool bigintIsUint64(const BigInt& b) override {
+    return plain_.bigintIsUint64(b);
+  }
+  uint64_t truncate(const BigInt& b) override {
+    return plain_.truncate(b);
+  }
+  String bigintToString(const BigInt& bigint, int radix) override {
+    return plain_.bigintToString(bigint, radix);
+  }
+
   String createStringFromAscii(const char* str, size_t length) override {
     return plain_.createStringFromAscii(str, length);
   };
@@ -221,6 +240,17 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     // with RTTI.
     return dhf.target<DecoratedHostFunction>()->plainHF_;
   };
+
+  bool hasNativeState(const Object& o) override {
+    return plain_.hasNativeState(o);
+  }
+  std::shared_ptr<NativeState> getNativeState(const Object& o) override {
+    return plain_.getNativeState(o);
+  }
+  void setNativeState(const Object& o, std::shared_ptr<NativeState> state)
+      override {
+    plain_.setNativeState(o, state);
+  }
 
   Value getProperty(const Object& o, const PropNameID& name) override {
     return plain_.getProperty(o, name);
@@ -271,6 +301,10 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
 
   Array createArray(size_t length) override {
     return plain_.createArray(length);
+  };
+  ArrayBuffer createArrayBuffer(
+      std::shared_ptr<MutableBuffer> buffer) override {
+    return plain_.createArrayBuffer(std::move(buffer));
   };
   size_t size(const Array& a) override {
     return plain_.size(a);
@@ -670,6 +704,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
   Array createArray(size_t length) override {
     Around around{with_};
     return RD::createArray(length);
+  };
+  ArrayBuffer createArrayBuffer(
+      std::shared_ptr<MutableBuffer> buffer) override {
+    return RD::createArrayBuffer(std::move(buffer));
   };
   size_t size(const Array& a) override {
     Around around{with_};

--- a/src/jsi/jsi-inl.h
+++ b/src/jsi/jsi-inl.h
@@ -202,6 +202,29 @@ inline std::shared_ptr<HostObject> Object::getHostObject<HostObject>(
   return runtime.getHostObject(*this);
 }
 
+template <typename T>
+inline bool Object::hasNativeState(Runtime& runtime) const {
+  return runtime.hasNativeState(*this) &&
+      std::dynamic_pointer_cast<T>(runtime.getNativeState(*this));
+}
+
+template <>
+inline bool Object::hasNativeState<NativeState>(Runtime& runtime) const {
+  return runtime.hasNativeState(*this);
+}
+
+template <typename T>
+inline std::shared_ptr<T> Object::getNativeState(Runtime& runtime) const {
+  assert(hasNativeState<T>(runtime));
+  return std::static_pointer_cast<T>(runtime.getNativeState(*this));
+}
+
+inline void Object::setNativeState(
+    Runtime& runtime,
+    std::shared_ptr<NativeState> state) const {
+  runtime.setNativeState(*this, state);
+}
+
 inline Array Object::getPropertyNames(Runtime& runtime) const {
   return runtime.getPropertyNames(*this);
 }
@@ -316,6 +339,10 @@ inline Value Function::callAsConstructor(Runtime& runtime, Args&&... args)
     const {
   return callAsConstructor(
       runtime, {detail::toValue(runtime, std::forward<Args>(args))...});
+}
+
+String BigInt::toString(Runtime& runtime, int radix) const {
+  return runtime.bigintToString(*this, radix);
 }
 
 } // namespace jsi

--- a/src/jsi/jsi.cpp
+++ b/src/jsi/jsi.cpp
@@ -66,6 +66,8 @@ Value callGlobalFunction(Runtime& runtime, const char* name, const Value& arg) {
 
 Buffer::~Buffer() = default;
 
+MutableBuffer::~MutableBuffer() = default;
+
 PreparedJavaScript::~PreparedJavaScript() = default;
 
 Value HostObject::get(Runtime&, const PropNameID&) {
@@ -80,6 +82,8 @@ void HostObject::set(Runtime& rt, const PropNameID& name, const Value&) {
 }
 
 HostObject::~HostObject() {}
+
+NativeState::~NativeState() {}
 
 Runtime::~Runtime() {}
 
@@ -377,6 +381,20 @@ String Value::asString(Runtime& rt) && {
 String Value::toString(Runtime& runtime) const {
   Function toString = runtime.global().getPropertyAsFunction(runtime, "String");
   return toString.call(runtime, *this).getString(runtime);
+}
+
+uint64_t BigInt::asUint64(Runtime& runtime) const {
+  if (!isUint64(runtime)) {
+    throw JSError(runtime, "Lossy truncation in BigInt64::asUint64");
+  }
+  return getUint64(runtime);
+}
+
+int64_t BigInt::asInt64(Runtime& runtime) const {
+  if (!isInt64(runtime)) {
+    throw JSError(runtime, "Lossy truncation in BigInt64::asInt64");
+  }
+  return getInt64(runtime);
 }
 
 Array Array::createWithElements(

--- a/src/jsi/jsi.h
+++ b/src/jsi/jsi.h
@@ -31,6 +31,10 @@ class FBJSRuntime;
 namespace facebook {
 namespace jsi {
 
+/// Base class for buffers of data or bytecode that need to be passed to the
+/// runtime. The buffer is expected to be fully immutable, so the result of
+/// size(), data(), and the contents of the pointer returned by data() must not
+/// change after construction.
 class JSI_EXPORT Buffer {
  public:
   virtual ~Buffer();
@@ -50,6 +54,18 @@ class JSI_EXPORT StringBuffer : public Buffer {
 
  private:
   std::string s_;
+};
+
+/// Base class for buffers of data that need to be passed to the runtime. The
+/// result of size() and data() must not change after construction. However, the
+/// region pointed to by data() may be modified by the user or the runtime. The
+/// user must ensure that access to the contents of the buffer is properly
+/// synchronised.
+class JSI_EXPORT MutableBuffer {
+ public:
+  virtual ~MutableBuffer();
+  virtual size_t size() const = 0;
+  virtual uint8_t* data() = 0;
 };
 
 /// PreparedJavaScript is a base class representing JavaScript which is in a
@@ -126,6 +142,13 @@ class JSI_EXPORT HostObject {
   // call this method. If it throws an exception, the call will throw a
   // JS \c Error object. The default implementation returns empty vector.
   virtual std::vector<PropNameID> getPropertyNames(Runtime& rt);
+};
+
+/// Native state (and destructor) that can be attached to any JS object
+/// using setNativeState.
+class JSI_EXPORT NativeState {
+ public:
+  virtual ~NativeState();
 };
 
 /// Represents a JS runtime.  Movable, but not copyable.  Note that
@@ -283,6 +306,13 @@ class JSI_EXPORT Runtime {
 
   virtual std::string symbolToString(const Symbol&) = 0;
 
+  virtual BigInt createBigIntFromInt64(int64_t) = 0;
+  virtual BigInt createBigIntFromUint64(uint64_t) = 0;
+  virtual bool bigintIsInt64(const BigInt&) = 0;
+  virtual bool bigintIsUint64(const BigInt&) = 0;
+  virtual uint64_t truncate(const BigInt&) = 0;
+  virtual String bigintToString(const BigInt&, int) = 0;
+
   virtual String createStringFromAscii(const char* str, size_t length) = 0;
   virtual String createStringFromUtf8(const uint8_t* utf8, size_t length) = 0;
   virtual std::string utf8(const String&) = 0;
@@ -295,6 +325,12 @@ class JSI_EXPORT Runtime {
   virtual Object createObject(std::shared_ptr<HostObject> ho) = 0;
   virtual std::shared_ptr<HostObject> getHostObject(const jsi::Object&) = 0;
   virtual HostFunctionType& getHostFunction(const jsi::Function&) = 0;
+
+  virtual bool hasNativeState(const jsi::Object&) = 0;
+  virtual std::shared_ptr<NativeState> getNativeState(const jsi::Object&) = 0;
+  virtual void setNativeState(
+      const jsi::Object&,
+      std::shared_ptr<NativeState> state) = 0;
 
   virtual Value getProperty(const Object&, const PropNameID& name) = 0;
   virtual Value getProperty(const Object&, const String& name) = 0;
@@ -316,6 +352,8 @@ class JSI_EXPORT Runtime {
   virtual Value lockWeakObject(WeakObject&) = 0;
 
   virtual Array createArray(size_t length) = 0;
+  virtual ArrayBuffer createArrayBuffer(
+      std::shared_ptr<MutableBuffer> buffer) = 0;
   virtual size_t size(const Array&) = 0;
   virtual size_t size(const ArrayBuffer&) = 0;
   virtual uint8_t* data(const ArrayBuffer&) = 0;
@@ -493,6 +531,53 @@ class JSI_EXPORT BigInt : public Pointer {
 
   BigInt(BigInt&& other) = default;
   BigInt& operator=(BigInt&& other) = default;
+
+  /// Create a BigInt representing the signed 64-bit \p value.
+  static BigInt fromInt64(Runtime& runtime, int64_t value) {
+    return runtime.createBigIntFromInt64(value);
+  }
+
+  /// Create a BigInt representing the unsigned 64-bit \p value.
+  static BigInt fromUint64(Runtime& runtime, uint64_t value) {
+    return runtime.createBigIntFromUint64(value);
+  }
+
+  /// \return whether a === b.
+  static bool strictEquals(Runtime& runtime, const BigInt& a, const BigInt& b) {
+    return runtime.strictEquals(a, b);
+  }
+
+  /// \returns This bigint truncated to a signed 64-bit integer.
+  int64_t getInt64(Runtime& runtime) const {
+    return runtime.truncate(*this);
+  }
+
+  /// \returns Whether this bigint can be losslessly converted to int64_t.
+  bool isInt64(Runtime& runtime) const {
+    return runtime.bigintIsInt64(*this);
+  }
+
+  /// \returns This bigint truncated to a signed 64-bit integer. Throws a
+  /// JSIException if the truncation is lossy.
+  int64_t asInt64(Runtime& runtime) const;
+
+  /// \returns This bigint truncated to an unsigned 64-bit integer.
+  uint64_t getUint64(Runtime& runtime) const {
+    return runtime.truncate(*this);
+  }
+
+  /// \returns Whether this bigint can be losslessly converted to uint64_t.
+  bool isUint64(Runtime& runtime) const {
+    return runtime.bigintIsUint64(*this);
+  }
+
+  /// \returns This bigint truncated to an unsigned 64-bit integer. Throws a
+  /// JSIException if the truncation is lossy.
+  uint64_t asUint64(Runtime& runtime) const;
+
+  /// \returns this BigInt converted to a String in base \p radix. Throws a
+  /// JSIException if radix is not in the [2, 36] range.
+  inline String toString(Runtime& runtime, int radix = 10) const;
 
   friend class Runtime;
   friend class Value;
@@ -711,6 +796,25 @@ class JSI_EXPORT Object : public Pointer {
   template <typename T = HostObject>
   std::shared_ptr<T> asHostObject(Runtime& runtime) const;
 
+  /// \return whether this object has native state of type T previously set by
+  /// \c setNativeState.
+  template <typename T = NativeState>
+  bool hasNativeState(Runtime& runtime) const;
+
+  /// \return a shared_ptr to the state previously set by \c setNativeState.
+  /// If \c hasNativeState<T> is false, this will assert. Note that this does a
+  /// type check and will assert if the native state isn't of type \c T
+  template <typename T = NativeState>
+  std::shared_ptr<T> getNativeState(Runtime& runtime) const;
+
+  /// Set the internal native state property of this object, overwriting any old
+  /// value. Creates a new shared_ptr to the object managed by \p state, which
+  /// will live until the value at this property becomes unreachable.
+  ///
+  /// Throws a type error if this object is a proxy or host object.
+  void setNativeState(Runtime& runtime, std::shared_ptr<NativeState> state)
+      const;
+
   /// \return same as \c getProperty(name).asObject(), except with
   /// a better exception message.
   Object getPropertyAsObject(Runtime& runtime, const char* name) const;
@@ -828,6 +932,9 @@ class JSI_EXPORT ArrayBuffer : public Object {
  public:
   ArrayBuffer(ArrayBuffer&&) = default;
   ArrayBuffer& operator=(ArrayBuffer&&) = default;
+
+  ArrayBuffer(Runtime& runtime, std::shared_ptr<MutableBuffer> buffer)
+      : ArrayBuffer(runtime.createArrayBuffer(std::move(buffer))) {}
 
   /// \return the size of the ArrayBuffer, according to its byteLength property.
   /// (C++ naming convention)

--- a/src/jsi/test/testlib.cpp
+++ b/src/jsi/test/testlib.cpp
@@ -1429,7 +1429,7 @@ TEST_P(JSITest, MultilevelDecoratedHostObject) {
   EXPECT_EQ(1, RD2::numGets);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Runtimes,
     JSITest,
     ::testing::ValuesIn(runtimeGenerators()));

--- a/src/public/NapiJsiRuntime.cpp
+++ b/src/public/NapiJsiRuntime.cpp
@@ -166,6 +166,51 @@ struct NapiJsiRuntime : facebook::jsi::Runtime {
 
   bool instanceOf(const facebook::jsi::Object &obj, const facebook::jsi::Function &func) override;
 
+  // TODO: 0.71 API additions are not yet implemented
+  facebook::jsi::BigInt createBigIntFromInt64(int64_t) override {
+    std::abort();
+  }
+
+  facebook::jsi::BigInt createBigIntFromUint64(uint64_t) override {
+    std::abort();
+  }
+
+  bool bigintIsInt64(const facebook::jsi::BigInt&) override {
+    std::abort();
+  }
+
+  bool bigintIsUint64(const facebook::jsi::BigInt&) override {
+    std::abort();
+  }
+
+  uint64_t truncate(const facebook::jsi::BigInt&) override {
+    std::abort();
+  }
+
+  facebook::jsi::String bigintToString(const facebook::jsi::BigInt&, int) override {
+    std::abort();
+  }
+
+  bool hasNativeState(const facebook::jsi::Object&) override {
+    std::abort();
+  }
+
+  std::shared_ptr<facebook::jsi::NativeState> getNativeState(const facebook::jsi::Object&) override {
+    std::abort();
+  }
+
+  void setNativeState(
+      const facebook::jsi::Object&,
+      std::shared_ptr<facebook::jsi::NativeState>) override {
+    std::abort();
+  }
+
+  facebook::jsi::ArrayBuffer createArrayBuffer(
+      std::shared_ptr<facebook::jsi::MutableBuffer>) override {
+    std::abort();
+  }
+  // end TODO: 0.71 unimplemented functions
+
  private: // Helper types
   // A smart pointer to napi_env
   struct EnvHolder {


### PR DESCRIPTION
Update the JSI APIs to match version 0.71 of React Native;
The APIs aren't actually implemented in this PR, just stubbed (they're not used in RN yet);

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/151)