### PR TITLE
Update to V8 10.9

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.65.21",
-    "v8ref": "refs/branch-heads/10.6"
+    "version": "0.65.22",
+    "v8ref": "refs/branch-heads/10.9"
 }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -54,9 +54,13 @@ if ($Platform -like "?64") {
     $gnargs += ' v8_enable_pointer_compression=true'
 }
 
+# TODO: N-API implementation of external ArrayBuffer doesn't comply with the Sandbox requirements for all memory allocations to be owned by the VM
+$gnargs += ' v8_enable_sandbox=false'
+
 if ($Configuration -like "*ebug*") {
     $gnargs += ' is_debug=true'
-    if ($buildingWindows) {
+    # Building with iterator debugging turned on for ARM64 causes an error with mksnapshot (this MSVC option is no longer supported in upstream)
+    if ($buildingWindows -and ($Platform -ne "arm64")) {
         $gnargs += ' enable_iterator_debugging=true'
     }
 } else {

--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -69,7 +69,7 @@ Write-Host "##vso[task.setvariable variable=V8JSI_VERSION;]$verString"
 
 # Generate the source_link.json file
 (Get-Content "$SourcesPath\src\source_link.json") `
-    -replace ('LOCAL_PATH', $SourcesPath) `
+    -replace ('LOCAL_PATH', "$SourcesPath".Replace('\', '\\')) `
     -replace ('V8JSI_GIT_HASH', $ourGitHash) `
     -replace ('V8JSIVER_V8REF', $v8Version) |`
     Set-Content "$SourcesPath\src\source_link_gen.json"

--- a/scripts/patch/src.diff
+++ b/scripts/patch/src.diff
@@ -1,8 +1,8 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index 83082271b8..4feb02e8a6 100644
+index 78fd8cd2d38..949c3e6e5a9 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -1324,7 +1324,7 @@ config("toolchain") {
+@@ -1239,7 +1239,7 @@ config("toolchain") {
    } else if (target_os == "mac") {
      defines += [ "V8_HAVE_TARGET_OS" ]
      defines += [ "V8_TARGET_OS_MACOS" ]
@@ -11,7 +11,7 @@ index 83082271b8..4feb02e8a6 100644
      defines += [ "V8_HAVE_TARGET_OS" ]
      defines += [ "V8_TARGET_OS_WIN" ]
    }
-@@ -1391,7 +1391,7 @@ config("toolchain") {
+@@ -1302,7 +1302,7 @@ config("toolchain") {
    if (is_win) {
      cflags += [
        "/wd4245",  # Conversion with signed/unsigned mismatch.
@@ -20,7 +20,7 @@ index 83082271b8..4feb02e8a6 100644
        "/wd4324",  # Padding structure due to alignment.
        "/wd4701",  # Potentially uninitialized local variable.
        "/wd4702",  # Unreachable code.
-@@ -1495,14 +1495,14 @@ config("toolchain") {
+@@ -1406,14 +1406,14 @@ config("toolchain") {
  
        "/wd4100",  # Unreferenced formal function parameter.
        "/wd4121",  # Alignment of a member was sensitive to packing.
@@ -38,7 +38,7 @@ index 83082271b8..4feb02e8a6 100644
  
        # These are variable shadowing warnings that are new in VS2015. We
        # should work through these at some point -- they may be removed from
-@@ -1526,7 +1526,7 @@ config("toolchain") {
+@@ -1437,7 +1437,7 @@ config("toolchain") {
        "/wd4245",  # 'conversion' : conversion from 'type1' to 'type2',
                    # signed/unsigned mismatch
  
@@ -47,7 +47,7 @@ index 83082271b8..4feb02e8a6 100644
                    # data
  
        "/wd4305",  # 'identifier' : truncation from 'type1' to 'type2'
-@@ -5645,7 +5645,6 @@ v8_component("v8_libbase") {
+@@ -5574,7 +5574,6 @@ v8_component("v8_libbase") {
      defines += [ "_CRT_RAND_S" ]  # for rand_s()
  
      libs = [
@@ -55,8 +55,8 @@ index 83082271b8..4feb02e8a6 100644
        "winmm.lib",
        "ws2_32.lib",
      ]
-@@ -6363,26 +6362,6 @@ group("v8_python_base") {
-   data = [ ".vpython" ]
+@@ -6291,26 +6290,6 @@ group("v8_python_base") {
+   data = [ ".vpython3" ]
  }
  
 -group("v8_clusterfuzz") {
@@ -82,7 +82,7 @@ index 83082271b8..4feb02e8a6 100644
  # Targets we ensure work with gcc. The aim is to keep this list small to have
  # a fast overall compile time.
  group("v8_gcc_light") {
-@@ -6603,7 +6582,7 @@ v8_executable("d8") {
+@@ -6538,7 +6517,7 @@ v8_executable("d8") {
    }
  
    if (v8_correctness_fuzzer) {
@@ -91,7 +91,7 @@ index 83082271b8..4feb02e8a6 100644
    }
  
    defines = []
-@@ -7313,3 +7292,9 @@ if (!build_with_chromium && v8_use_perfetto) {
+@@ -7248,3 +7227,9 @@ if (!build_with_chromium && v8_use_perfetto) {
      ]
    }
  }  # if (!build_with_chromium && v8_use_perfetto)
@@ -102,10 +102,10 @@ index 83082271b8..4feb02e8a6 100644
 +  ]
 +}
 diff --git a/DEPS b/DEPS
-index e970b84365..8457c145a2 100644
+index ab0a9bf5431..73c6caac972 100644
 --- a/DEPS
 +++ b/DEPS
-@@ -649,4 +649,15 @@ hooks = [
+@@ -616,4 +616,15 @@ hooks = [
      'condition': 'host_os == "win"',
      'action': ['python3', 'build/del_ninja_deps_cache.py'],
    },
@@ -122,7 +122,7 @@ index e970b84365..8457c145a2 100644
 +  }
  ]
 diff --git a/gni/snapshot_toolchain.gni b/gni/snapshot_toolchain.gni
-index 637dcd39c4..80424bdc53 100644
+index 99de816372b..02dd1355a9e 100644
 --- a/gni/snapshot_toolchain.gni
 +++ b/gni/snapshot_toolchain.gni
 @@ -74,6 +74,9 @@ if (v8_snapshot_toolchain == "") {
@@ -134,9 +134,9 @@ index 637dcd39c4..80424bdc53 100644
 +    v8_snapshot_toolchain = host_toolchain
    } else if (host_cpu == "x64") {
      # This is a cross-compile from an x64 host to either a non-Intel target
-     # cpu or a different target OS. Clang will always be used by default on the
+     # cpu or to 32-bit x86 on a different target OS.
 diff --git a/src/base/debug/stack_trace_win.cc b/src/base/debug/stack_trace_win.cc
-index f981bec610..753438fa4a 100644
+index f981bec6101..753438fa4a4 100644
 --- a/src/base/debug/stack_trace_win.cc
 +++ b/src/base/debug/stack_trace_win.cc
 @@ -29,6 +29,35 @@ namespace v8 {
@@ -185,10 +185,10 @@ index f981bec610..753438fa4a 100644
  }  // namespace base
  }  // namespace v8
 diff --git a/src/base/platform/platform-win32.cc b/src/base/platform/platform-win32.cc
-index 89595dbed9..50c5793d42 100644
+index ac44c70e2c5..9533cb0435e 100644
 --- a/src/base/platform/platform-win32.cc
 +++ b/src/base/platform/platform-win32.cc
-@@ -1369,8 +1369,8 @@ bool AddressSpaceReservation::DecommitPages(void* address, size_t size) {
+@@ -1370,8 +1370,8 @@ bool AddressSpaceReservation::DecommitPages(void* address, size_t size) {
  #define VOID void
  #endif
  
@@ -200,10 +200,10 @@ index 89595dbed9..50c5793d42 100644
  using DLL_FUNC_TYPE(SymInitialize) = BOOL(__stdcall*)(IN HANDLE hProcess,
                                                        IN PSTR UserSearchPath,
 diff --git a/src/diagnostics/unwinding-info-win64.cc b/src/diagnostics/unwinding-info-win64.cc
-index 4a70a28478..da7766f0bc 100644
+index 767eb015ab1..47f05a1b946 100644
 --- a/src/diagnostics/unwinding-info-win64.cc
 +++ b/src/diagnostics/unwinding-info-win64.cc
-@@ -536,7 +536,7 @@ void RegisterNonABICompliantCodeRange(void* start, size_t size_in_bytes) {
+@@ -535,7 +535,7 @@ void RegisterNonABICompliantCodeRange(void* start, size_t size_in_bytes) {
    // by the embedder (like Crashpad).
  
    if (RegisterUnwindInfoForExceptionHandlingOnly()) {
@@ -212,7 +212,7 @@ index 4a70a28478..da7766f0bc 100644
      // Windows ARM64 starts since 1709 Windows build, no need to have exception
      // handling only unwind info for compatibility.
      if (unhandled_exception_callback_g) {
-@@ -575,7 +575,7 @@ void UnregisterNonABICompliantCodeRange(void* start) {
+@@ -574,7 +574,7 @@ void UnregisterNonABICompliantCodeRange(void* start) {
    DCHECK(CanRegisterUnwindInfoForNonABICompliantCodeRange());
  
    if (RegisterUnwindInfoForExceptionHandlingOnly()) {
@@ -222,10 +222,10 @@ index 4a70a28478..da7766f0bc 100644
      // handling only unwind info for compatibility.
      if (unhandled_exception_callback_g) {
 diff --git a/src/objects/scope-info.cc b/src/objects/scope-info.cc
-index c70ac7bb06..70a30743d1 100644
+index c0117d27c9f..d4ccf386451 100644
 --- a/src/objects/scope-info.cc
 +++ b/src/objects/scope-info.cc
-@@ -1016,6 +1016,8 @@ int ScopeInfo::ParametersStartIndex() const {
+@@ -1028,6 +1028,8 @@ int ScopeInfo::ParametersStartIndex() const {
  }
  
  int ScopeInfo::FunctionContextSlotIndex(String name) const {
@@ -235,7 +235,7 @@ index c70ac7bb06..70a30743d1 100644
    if (HasContextAllocatedFunctionName()) {
      DCHECK_IMPLIES(HasFunctionName(), FunctionName().IsInternalizedString());
 diff --git a/src/objects/simd.cc b/src/objects/simd.cc
-index 22467cace0..6930650819 100644
+index 4fa55e4cc76..6a6d7ab414c 100644
 --- a/src/objects/simd.cc
 +++ b/src/objects/simd.cc
 @@ -23,7 +23,7 @@
@@ -248,7 +248,7 @@ index 22467cace0..6930650819 100644
  // types are not available). Note that ARM64 is guaranteed to have Neon.
  #define NEON64
 diff --git a/src/snapshot/embedded/platform-embedded-file-writer-base.cc b/src/snapshot/embedded/platform-embedded-file-writer-base.cc
-index e0602edc7e..4123b90e1b 100644
+index e0602edc7e1..4123b90e1b7 100644
 --- a/src/snapshot/embedded/platform-embedded-file-writer-base.cc
 +++ b/src/snapshot/embedded/platform-embedded-file-writer-base.cc
 @@ -138,7 +138,7 @@ EmbeddedTargetOs ToEmbeddedTargetOs(const char* s) {
@@ -261,10 +261,10 @@ index e0602edc7e..4123b90e1b 100644
    } else if (string == "starboard") {
      return EmbeddedTargetOs::kStarboard;
 diff --git a/src/trap-handler/handler-inside-win.cc b/src/trap-handler/handler-inside-win.cc
-index fcccc78ee5..42d8d190ba 100644
+index 3d7a2c416aa..9a48c27d66e 100644
 --- a/src/trap-handler/handler-inside-win.cc
 +++ b/src/trap-handler/handler-inside-win.cc
-@@ -60,6 +60,7 @@ extern "C" char v8_probe_memory_continuation[];
+@@ -62,6 +62,7 @@ extern "C" char v8_probe_memory_continuation[];
  #endif  // V8_TRAP_HANDLER_VIA_SIMULATOR
  
  bool TryHandleWasmTrap(EXCEPTION_POINTERS* exception) {
@@ -272,7 +272,7 @@ index fcccc78ee5..42d8d190ba 100644
    // VectoredExceptionHandlers need extreme caution. Do as little as possible
    // to determine if the exception should be handled or not. Exceptions can be
    // thrown very early in a threads life, before the thread has even completed
-@@ -120,6 +121,9 @@ bool TryHandleWasmTrap(EXCEPTION_POINTERS* exception) {
+@@ -122,6 +123,9 @@ bool TryHandleWasmTrap(EXCEPTION_POINTERS* exception) {
    // We will return to wasm code, so restore the g_thread_in_wasm_code flag.
    g_thread_in_wasm_code = true;
    return true;
@@ -283,10 +283,10 @@ index fcccc78ee5..42d8d190ba 100644
  
  LONG HandleWasmTrap(EXCEPTION_POINTERS* exception) {
 diff --git a/src/trap-handler/handler-outside-simulator.cc b/src/trap-handler/handler-outside-simulator.cc
-index 179eab0659..9dbcdf0397 100644
+index 5e58719e7fc..301bd942de6 100644
 --- a/src/trap-handler/handler-outside-simulator.cc
 +++ b/src/trap-handler/handler-outside-simulator.cc
-@@ -11,6 +11,12 @@
+@@ -14,6 +14,12 @@
  #define SYMBOL(name) #name
  #endif  // !V8_OS_DARWIN
  
@@ -299,30 +299,18 @@ index 179eab0659..9dbcdf0397 100644
  // Define the ProbeMemory function declared in trap-handler-simulators.h.
  asm(
      ".globl " SYMBOL(ProbeMemory) "                 \n"
-@@ -35,3 +41,5 @@ asm(
-     SYMBOL(v8_probe_memory_continuation) ":         \n"
-     // If the trap handler continues here, it wrote the landing pad in %rax.
+@@ -40,3 +46,5 @@ asm(
      "  ret                                          \n");
+ 
+ #endif
 +
 +#endif
-diff --git a/src/trap-handler/trap-handler.h b/src/trap-handler/trap-handler.h
-index 84ffdbd056..1aa7a305c7 100644
---- a/src/trap-handler/trap-handler.h
-+++ b/src/trap-handler/trap-handler.h
-@@ -27,7 +27,7 @@ namespace trap_handler {
- #define V8_TRAP_HANDLER_SUPPORTED true
- // Arm64 simulator on x64 on Linux, Mac, or Windows.
- #elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_X64 && \
--    (V8_OS_LINUX || V8_OS_DARWIN || V8_OS_WIN)
-+    (V8_OS_LINUX || V8_OS_DARWIN)
- #define V8_TRAP_HANDLER_VIA_SIMULATOR
- #define V8_TRAP_HANDLER_SUPPORTED true
- // Everything else is unsupported.
+\ No newline at end of file
 diff --git a/src/utils/allocation.cc b/src/utils/allocation.cc
-index 34a87ca0e8..3f1ee174e9 100644
+index a585bfed680..cfdb0424773 100644
 --- a/src/utils/allocation.cc
 +++ b/src/utils/allocation.cc
-@@ -80,8 +80,10 @@ const int kAllocationTries = 2;
+@@ -64,8 +64,10 @@ const int kAllocationTries = 2;
  }  // namespace
  
  v8::PageAllocator* GetPlatformPageAllocator() {
@@ -336,7 +324,7 @@ index 34a87ca0e8..3f1ee174e9 100644
  
  v8::VirtualAddressSpace* GetPlatformVirtualAddressSpace() {
 diff --git a/third_party/googletest/BUILD.gn b/third_party/googletest/BUILD.gn
-index bc82c635da..648972c77a 100644
+index bc82c635da3..648972c77a2 100644
 --- a/third_party/googletest/BUILD.gn
 +++ b/third_party/googletest/BUILD.gn
 @@ -88,8 +88,8 @@ source_set("gtest") {
@@ -351,7 +339,7 @@ index bc82c635da..648972c77a 100644
    # V8-only workaround for http://crbug.com/chromium/1191946. Ensures that
    # googletest is compiled with the same visibility such as the rest of V8, see
 diff --git a/tools/v8windbg/BUILD.gn b/tools/v8windbg/BUILD.gn
-index 5516a6109f..d6cde0082c 100644
+index 5516a6109f2..d6cde0082c6 100644
 --- a/tools/v8windbg/BUILD.gn
 +++ b/tools/v8windbg/BUILD.gn
 @@ -26,7 +26,7 @@ source_set("v8windbg_base") {

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -72,7 +72,7 @@ target("shared_library", "v8jsi") {
 
   include_dirs = [ ".", "../include", "jsi", "public", getenv("ASIO_ROOT") ]
 
-  configs += [ "//:internal_config_base", "//build/config/compiler:exceptions" ]
+  configs += [ "//:toolchain", "//:internal_config_base", "//build/config/compiler:exceptions" ]
   configs -= [ "//build/config/compiler:no_exceptions" ]
 
   if (is_win) {
@@ -164,7 +164,7 @@ target("executable", "jsitests") {
     "//testing/gtest",
   ]
 
-  configs += [ "//:internal_config_base", "//build/config/compiler:exceptions", "//build/config/compiler:rtti" ]
+  configs += [ "//:toolchain", "//:internal_config_base", "//build/config/compiler:exceptions", "//build/config/compiler:rtti" ]
   configs -= [ "//build/config/compiler:no_exceptions", "//build/config/compiler:no_rtti" ]
 
   if (is_win) {


### PR DESCRIPTION
- Update to V8 10.9;
- Disable iterator debugging in debug builds of ARM64 (MSVC compatibility issue);
- Include the toolchain config (needed because we're building with c++17 while V8 / Chromium switched the defaults to c++20 already (JSI code doesn't build in c++20);
- Also fix #156 (use double backslashes for directory separators);

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/157)