### PR TITLE
Bump android jsi to 0.69-stable headers

### DIFF
--- a/android/V8Runtime_impl.h
+++ b/android/V8Runtime_impl.h
@@ -309,6 +309,7 @@ namespace facebook { namespace v8runtime {
     jsi::PropNameID createPropNameIDFromUtf8(const uint8_t* utf8, size_t length)
       override;
     jsi::PropNameID createPropNameIDFromString(const jsi::String& str) override;
+    jsi::PropNameID createPropNameIDFromSymbol(const jsi::Symbol& sym) override;
     std::string utf8(const jsi::PropNameID&) override;
     bool compare(const jsi::PropNameID&, const jsi::PropNameID&) override;
 

--- a/android/V8Runtime_shared.cpp
+++ b/android/V8Runtime_shared.cpp
@@ -417,6 +417,10 @@ namespace facebook { namespace v8runtime {
     return createPropNameID(stringRef(str));
   }
 
+  jsi::PropNameID V8Runtime::createPropNameIDFromSymbol(const jsi::Symbol& sym) {
+    throw jsi::JSINativeException("V8Runtime::createPropNameIDFromSymbol is not implemented!");
+  }
+
   std::string V8Runtime::utf8(const jsi::PropNameID& sym) {
     _ISOLATE_CONTEXT_ENTER
     return JSStringToSTLString(GetIsolate(), v8::Local<v8::String>::Cast(valueRef(sym)));

--- a/android/build.config
+++ b/android/build.config
@@ -1,4 +1,4 @@
 V8_TAG="7.0.276.32"
-RN_VERSION="0.68-stable"
+RN_VERSION="0.69-stable"
 NDK_VERSION="r21b"
-NUGET_PKG_VERSION="0.68-stable-v1"
+NUGET_PKG_VERSION="0.69-stable-v1"

--- a/android/jsi/decorator.h
+++ b/android/jsi/decorator.h
@@ -176,6 +176,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   PropNameID createPropNameIDFromString(const String& str) override {
     return plain_.createPropNameIDFromString(str);
   };
+  PropNameID createPropNameIDFromSymbol(const Symbol& sym) override {
+    return plain_.createPropNameIDFromSymbol(sym);
+  };
   std::string utf8(const PropNameID& id) override {
     return plain_.utf8(id);
   };

--- a/android/jsi/jsi.cpp
+++ b/android/jsi/jsi.cpp
@@ -30,6 +30,8 @@ std::string kindToString(const Value& v, Runtime* rt = nullptr) {
     return "a number";
   } else if (v.isString()) {
     return "a string";
+  } else if (v.isSymbol()) {
+    return "a symbol";
   } else {
     assert(v.isObject() && "Expecting object.");
     return rt != nullptr && v.getObject(*rt).isFunction(*rt) ? "a function"
@@ -279,6 +281,15 @@ bool Value::strictEquals(Runtime& runtime, const Value& a, const Value& b) {
           static_cast<const Object&>(b.data_.pointer));
   }
   return false;
+}
+
+bool Value::asBool() const {
+  if (!isBool()) {
+    throw JSINativeException(
+        "Value is " + kindToString(*this) + ", expected a boolean");
+  }
+
+  return getBool();
 }
 
 double Value::asNumber() const {

--- a/android/jsi/jsi.h
+++ b/android/jsi/jsi.h
@@ -274,6 +274,7 @@ class JSI_EXPORT Runtime {
       const uint8_t* utf8,
       size_t length) = 0;
   virtual PropNameID createPropNameIDFromString(const String& str) = 0;
+  virtual PropNameID createPropNameIDFromSymbol(const Symbol& sym) = 0;
   virtual std::string utf8(const PropNameID&) = 0;
   virtual bool compare(const PropNameID&, const PropNameID&) = 0;
 
@@ -406,6 +407,7 @@ class JSI_EXPORT PropNameID : public Pointer {
   }
 
   /// Create a PropNameID from utf8 values.  The data is copied.
+  /// Results are undefined if \p utf8 contains invalid code points.
   static PropNameID
   forUtf8(Runtime& runtime, const uint8_t* utf8, size_t length) {
     return runtime.createPropNameIDFromUtf8(utf8, length);
@@ -413,6 +415,7 @@ class JSI_EXPORT PropNameID : public Pointer {
 
   /// Create a PropNameID from utf8-encoded octets stored in a
   /// std::string.  The string data is transformed and copied.
+  /// Results are undefined if \p utf8 contains invalid code points.
   static PropNameID forUtf8(Runtime& runtime, const std::string& utf8) {
     return runtime.createPropNameIDFromUtf8(
         reinterpret_cast<const uint8_t*>(utf8.data()), utf8.size());
@@ -421,6 +424,11 @@ class JSI_EXPORT PropNameID : public Pointer {
   /// Create a PropNameID from a JS string.
   static PropNameID forString(Runtime& runtime, const jsi::String& str) {
     return runtime.createPropNameIDFromString(str);
+  }
+
+  /// Create a PropNameID from a JS symbol.
+  static PropNameID forSymbol(Runtime& runtime, const jsi::Symbol& sym) {
+    return runtime.createPropNameIDFromSymbol(sym);
   }
 
   // Creates a vector of PropNameIDs constructed from given arguments.
@@ -502,14 +510,16 @@ class JSI_EXPORT String : public Pointer {
   }
 
   /// Create a JS string from utf8-encoded octets.  The string data is
-  /// transformed and copied.
+  /// transformed and copied.  Results are undefined if \p utf8 contains invalid
+  /// code points.
   static String
   createFromUtf8(Runtime& runtime, const uint8_t* utf8, size_t length) {
     return runtime.createStringFromUtf8(utf8, length);
   }
 
   /// Create a JS string from utf8-encoded octets stored in a
-  /// std::string.  The string data is transformed and copied.
+  /// std::string.  The string data is transformed and copied.  Results are
+  /// undefined if \p utf8 contains invalid code points.
   static String createFromUtf8(Runtime& runtime, const std::string& utf8) {
     return runtime.createStringFromUtf8(
         reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length());
@@ -966,9 +976,7 @@ class JSI_EXPORT Value {
             std::is_base_of<String, T>::value ||
             std::is_base_of<Object, T>::value,
         "Value cannot be implicitly move-constructed from this type");
-#ifndef __clang_analyzer__ // TODO(macOS GH#774) Disable [bugprone-move-forwarding-reference] when running clang static analysis
     new (&data_.pointer) T(std::move(other));
-#endif // __clang_analyzer__
   }
 
   /// Value("foo") will treat foo as a bool.  This makes doing that a
@@ -984,7 +992,7 @@ class JSI_EXPORT Value {
 
   /// Copies a Symbol lvalue into a new JS value.
   Value(Runtime& runtime, const Symbol& sym) : Value(SymbolKind) {
-    new (&data_.pointer) String(runtime.cloneSymbol(sym.ptr_));
+    new (&data_.pointer) Symbol(runtime.cloneSymbol(sym.ptr_));
   }
 
   /// Copies a String lvalue into a new JS value.
@@ -1069,6 +1077,10 @@ class JSI_EXPORT Value {
     assert(isBool());
     return data_.boolean;
   }
+
+  /// \return the boolean value, or throws JSIException if not a
+  /// boolean.
+  bool asBool() const;
 
   /// \return the number value, or asserts if not a number.
   double getNumber() const {
@@ -1240,11 +1252,13 @@ class JSI_EXPORT JSIException : public std::exception {
   JSIException(std::string what) : what_(std::move(what)){};
 
  public:
+  JSIException(const JSIException&) = default;
+
   virtual const char* what() const noexcept override {
     return what_.c_str();
   }
 
-  virtual ~JSIException();
+  virtual ~JSIException() override;
 
  protected:
   std::string what_;
@@ -1255,6 +1269,8 @@ class JSI_EXPORT JSIException : public std::exception {
 class JSI_EXPORT JSINativeException : public JSIException {
  public:
   JSINativeException(std::string what) : JSIException(std::move(what)) {}
+
+  JSINativeException(const JSINativeException&) = default;
 
   virtual ~JSINativeException();
 };
@@ -1284,6 +1300,8 @@ class JSI_EXPORT JSError : public JSIException {
   /// set to provided message.  This argument order is a bit weird,
   /// but necessary to avoid ambiguity with the above.
   JSError(std::string what, Runtime& rt, Value&& value);
+
+  JSError(const JSError&) = default;
 
   virtual ~JSError();
 

--- a/android/jsi/jsilib.h
+++ b/android/jsi/jsilib.h
@@ -15,7 +15,7 @@ namespace jsi {
 class FileBuffer : public Buffer {
  public:
   FileBuffer(const std::string& path);
-  ~FileBuffer();
+  ~FileBuffer() override;
 
   size_t size() const override {
     return size_;

--- a/android/jsi/test/testlib.cpp
+++ b/android/jsi/test/testlib.cpp
@@ -849,6 +849,8 @@ TEST_P(JSITest, ValueTest) {
   EXPECT_EQ(eval("'str'").getString(rt).utf8(rt), "str");
   EXPECT_TRUE(eval("[]").getObject(rt).isArray(rt));
 
+  EXPECT_TRUE(eval("true").asBool());
+  EXPECT_THROW(eval("123").asBool(), JSIException);
   EXPECT_EQ(eval("456").asNumber(), 456);
   EXPECT_THROW(eval("'word'").asNumber(), JSIException);
   EXPECT_EQ(
@@ -1423,7 +1425,7 @@ TEST_P(JSITest, MultilevelDecoratedHostObject) {
   EXPECT_EQ(1, RD2::numGets);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Runtimes,
     JSITest,
     ::testing::ValuesIn(runtimeGenerators()));


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/161)