### PR TITLE
update ci agent to valid agent

### DIFF
--- a/.ado/android-ci.yml
+++ b/.ado/android-ci.yml
@@ -13,7 +13,7 @@ trigger:
       - .ado/android-jobs.yml
       - .ado/android-pr.yml
 
-pool: Azure-Pipelines-EO-Ubuntu18.04-Office
+pool: Azure-Pipelines-EO-Ubuntu20.04-Office
 
 variables:
   - group: InfoSec-SecurityResults


### PR DESCRIPTION
18.04 is no longer a valid ubuntu agent

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/162)