### PR TITLE
Use 0.70 jsi headers

### DIFF
--- a/android/V8Runtime_impl.h
+++ b/android/V8Runtime_impl.h
@@ -282,6 +282,19 @@ namespace facebook { namespace v8runtime {
       friend class V8Runtime;
     };
 
+    class V8BigIntValue final : public PointerValue {
+      V8BigIntValue(v8::Local<v8::BigInt> obj);
+
+      ~V8BigIntValue();
+
+      void invalidate() override;
+
+      v8::Persistent<v8::BigInt> v8BigInt_;
+
+    protected:
+      friend class V8Runtime;
+    };
+
     class ExternalOwningOneByteStringResource
       : public v8::String::ExternalOneByteStringResource {
     public:
@@ -303,6 +316,7 @@ namespace facebook { namespace v8runtime {
     PointerValue *cloneSymbol(const PointerValue *) override;
     PointerValue* cloneObject(const Runtime::PointerValue* pv) override;
     PointerValue* clonePropNameID(const Runtime::PointerValue* pv) override;
+    PointerValue* cloneBigInt(const PointerValue* pv) override;
 
     jsi::PropNameID createPropNameIDFromAscii(const char* str, size_t length)
       override;
@@ -369,6 +383,7 @@ namespace facebook { namespace v8runtime {
       size_t count) override;
 
     bool strictEquals(const jsi::String& a, const jsi::String& b) const override;
+    bool strictEquals(const jsi::BigInt& a, const jsi::BigInt& b) const override;
     bool strictEquals(const jsi::Object& a, const jsi::Object& b) const override;
     bool strictEquals(const jsi::Symbol& a, const jsi::Symbol& b) const override;
 
@@ -405,6 +420,7 @@ namespace facebook { namespace v8runtime {
     static v8::Local<v8::String> stringRef(const jsi::String& str);
     static v8::Local<v8::Value> valueRef(const jsi::PropNameID& sym);
     static v8::Local<v8::Object> objectRef(const jsi::Object& obj);
+    static v8::Local<v8::BigInt> bigIntRef(const jsi::BigInt& bigInt);
 
     v8::Local<v8::Value> valueRef(const jsi::Value& value);
     jsi::Value createValue(v8::Local<v8::Value> value) const;
@@ -413,10 +429,12 @@ namespace facebook { namespace v8runtime {
     jsi::String createString(v8::Local<v8::String> stringRef) const;
     jsi::PropNameID createPropNameID(v8::Local<v8::Value> propValRef);
     jsi::Object createObject(v8::Local<v8::Object> objectRef) const;
+    jsi::BigInt createBigInt(v8::Local<v8::BigInt> bigIntRef) const;
 
     // Used by factory methods and clone methods
     jsi::Runtime::PointerValue* makeStringValue(v8::Local<v8::String> str) const;
     jsi::Runtime::PointerValue* makeObjectValue(v8::Local<v8::Object> obj) const;
+    jsi::Runtime::PointerValue* makeBigIntValue(v8::Local<v8::BigInt> bigInt) const;
 
     v8::Isolate* isolate_;
     std::unique_ptr<IsolateData> isolate_data_;

--- a/android/build.config
+++ b/android/build.config
@@ -1,4 +1,4 @@
 V8_TAG="7.0.276.32"
-RN_VERSION="0.69-stable"
+RN_VERSION="0.70-stable"
 NDK_VERSION="r21b"
-NUGET_PKG_VERSION="0.69-stable-v2"
+NUGET_PKG_VERSION="0.70-stable-v1"

--- a/android/jsi/decorator.h
+++ b/android/jsi/decorator.h
@@ -154,6 +154,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   Runtime::PointerValue* cloneSymbol(const Runtime::PointerValue* pv) override {
     return plain_.cloneSymbol(pv);
   };
+  Runtime::PointerValue* cloneBigInt(const Runtime::PointerValue* pv) override {
+    return plain_.cloneBigInt(pv);
+  };
   Runtime::PointerValue* cloneString(const Runtime::PointerValue* pv) override {
     return plain_.cloneString(pv);
   };
@@ -313,6 +316,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   }
 
   bool strictEquals(const Symbol& a, const Symbol& b) const override {
+    return plain_.strictEquals(a, b);
+  };
+  bool strictEquals(const BigInt& a, const BigInt& b) const override {
     return plain_.strictEquals(a, b);
   };
   bool strictEquals(const String& a, const String& b) const override {

--- a/android/jsi/jsi-inl.h
+++ b/android/jsi/jsi-inl.h
@@ -56,7 +56,12 @@ inline PropNameID&& toPropNameID(Runtime&, PropNameID&& name) {
   return std::move(name);
 }
 
-void throwJSError(Runtime&, const char* msg);
+/// Helper to throw while still compiling with exceptions turned off.
+template <typename E, typename... Args>
+[[noreturn]] inline void throwOrDie(Args&&... args) {
+  std::rethrow_exception(
+      std::make_exception_ptr(E{std::forward<Args>(args)...}));
+}
 
 } // namespace detail
 
@@ -184,7 +189,8 @@ inline std::shared_ptr<T> Object::getHostObject(Runtime& runtime) const {
 template <typename T>
 inline std::shared_ptr<T> Object::asHostObject(Runtime& runtime) const {
   if (!isHostObject<T>(runtime)) {
-    detail::throwJSError(runtime, "Object is not a HostObject of desired type");
+    detail::throwOrDie<JSINativeException>(
+        "Object is not a HostObject of desired type");
   }
   return std::static_pointer_cast<T>(runtime.getHostObject(*this));
 }

--- a/android/jsi/jsi.cpp
+++ b/android/jsi/jsi.cpp
@@ -32,6 +32,8 @@ std::string kindToString(const Value& v, Runtime* rt = nullptr) {
     return "a string";
   } else if (v.isSymbol()) {
     return "a symbol";
+  } else if (v.isBigInt()) {
+    return "a bigint";
   } else {
     assert(v.isObject() && "Expecting object.");
     return rt != nullptr && v.getObject(*rt).isFunction(*rt) ? "a function"
@@ -61,14 +63,6 @@ Value callGlobalFunction(Runtime& runtime, const char* name, const Value& arg) {
 }
 
 } // namespace
-
-namespace detail {
-
-void throwJSError(Runtime& rt, const char* msg) {
-  throw JSError(rt, msg);
-}
-
-} // namespace detail
 
 Buffer::~Buffer() = default;
 
@@ -242,6 +236,8 @@ Value::Value(Runtime& runtime, const Value& other) : Value(other.kind_) {
     data_.number = other.data_.number;
   } else if (kind_ == SymbolKind) {
     new (&data_.pointer) Pointer(runtime.cloneSymbol(other.data_.pointer.ptr_));
+  } else if (kind_ == BigIntKind) {
+    new (&data_.pointer) Pointer(runtime.cloneBigInt(other.data_.pointer.ptr_));
   } else if (kind_ == StringKind) {
     new (&data_.pointer) Pointer(runtime.cloneString(other.data_.pointer.ptr_));
   } else if (kind_ >= ObjectKind) {
@@ -271,6 +267,10 @@ bool Value::strictEquals(Runtime& runtime, const Value& a, const Value& b) {
       return runtime.strictEquals(
           static_cast<const Symbol&>(a.data_.pointer),
           static_cast<const Symbol&>(b.data_.pointer));
+    case BigIntKind:
+      return runtime.strictEquals(
+          static_cast<const BigInt&>(a.data_.pointer),
+          static_cast<const BigInt&>(b.data_.pointer));
     case StringKind:
       return runtime.strictEquals(
           static_cast<const String&>(a.data_.pointer),
@@ -336,6 +336,24 @@ Symbol Value::asSymbol(Runtime& rt) && {
   }
 
   return std::move(*this).getSymbol(rt);
+}
+
+BigInt Value::asBigInt(Runtime& rt) const& {
+  if (!isBigInt()) {
+    throw JSError(
+        rt, "Value is " + kindToString(*this, &rt) + ", expected a BigInt");
+  }
+
+  return getBigInt(rt);
+}
+
+BigInt Value::asBigInt(Runtime& rt) && {
+  if (!isBigInt()) {
+    throw JSError(
+        rt, "Value is " + kindToString(*this, &rt) + ", expected a BigInt");
+  }
+
+  return std::move(*this).getBigInt(rt);
 }
 
 String Value::asString(Runtime& rt) const& {


### PR DESCRIPTION
Bump JSI headers to 0.70-stable and add big int support

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/165)