### PR TITLE
Remove package.json and package-lock.json before build.

### DIFF
--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -95,3 +95,5 @@ Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\third_party\perfett
 Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\third_party\protobuf")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\tools\clusterfuzz")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\tools\turbolizer")
+Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\tools\package.json")
+Remove-Item -Recurse -Force (Join-Path $workpath "v8build\v8\tools\package-lock.json")


### PR DESCRIPTION
package.json and package-lock.json under build\v8build\v8\tools are not used during build. We remove them before build to prevent component governance issues.