### PR TITLE
Fix task runner for Node-API (#153)

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.71.2",
+    "version": "0.71.3",
     "v8ref": "refs/branch-heads/10.9"
 }

--- a/src/napi/js_native_ext_api_v8.cpp
+++ b/src/napi/js_native_ext_api_v8.cpp
@@ -550,8 +550,7 @@ napi_status napi_ext_collect_garbage(napi_env env) {
   return napi_status::napi_ok;
 }
 
-NAPI_EXTERN napi_status
-napi_ext_get_unique_string_utf8_ref(napi_env env, const char *str, size_t length, napi_ext_ref *result) {
+napi_status napi_ext_get_unique_string_utf8_ref(napi_env env, const char *str, size_t length, napi_ext_ref *result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, str);
   CHECK_ARG(env, result);
@@ -563,7 +562,7 @@ napi_ext_get_unique_string_utf8_ref(napi_env env, const char *str, size_t length
   return GET_RETURN_STATUS(env);
 }
 
-NAPI_EXTERN napi_status napi_ext_get_unique_string_ref(napi_env env, napi_value str_value, napi_ext_ref *result) {
+napi_status napi_ext_get_unique_string_ref(napi_env env, napi_value str_value, napi_ext_ref *result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, str_value);
   CHECK_ARG(env, result);
@@ -655,7 +654,7 @@ napi_status napi_create_external_buffer(
 }
 
 // Creates new napi_ext_ref with ref counter set to 1.
-NAPI_EXTERN napi_status napi_ext_create_reference(napi_env env, napi_value value, napi_ext_ref *result) {
+napi_status napi_ext_create_reference(napi_env env, napi_value value, napi_ext_ref *result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw JS exceptions.
   CHECK_ENV(env);
   CHECK_ARG(env, value);
@@ -671,7 +670,7 @@ NAPI_EXTERN napi_status napi_ext_create_reference(napi_env env, napi_value value
 
 // Creates new napi_ext_ref and associates native data with the reference.
 // The ref counter is set to 1.
-NAPI_EXTERN napi_status napi_ext_create_reference_with_data(
+napi_status napi_ext_create_reference_with_data(
     napi_env env,
     napi_value value,
     void *native_object,
@@ -693,7 +692,7 @@ NAPI_EXTERN napi_status napi_ext_create_reference_with_data(
   return napi_clear_last_error(env);
 }
 
-NAPI_EXTERN napi_status napi_ext_create_weak_reference(napi_env env, napi_value value, napi_ext_ref *result) {
+napi_status napi_ext_create_weak_reference(napi_env env, napi_value value, napi_ext_ref *result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw JS exceptions.
   CHECK_ENV(env);
   CHECK_ARG(env, value);
@@ -708,7 +707,7 @@ NAPI_EXTERN napi_status napi_ext_create_weak_reference(napi_env env, napi_value 
 }
 
 // Increments the reference count.
-NAPI_EXTERN napi_status napi_ext_reference_ref(napi_env env, napi_ext_ref ref) {
+napi_status napi_ext_reference_ref(napi_env env, napi_ext_ref ref) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw JS exceptions.
   CHECK_ENV(env);
   CHECK_ARG(env, ref);
@@ -722,7 +721,7 @@ NAPI_EXTERN napi_status napi_ext_reference_ref(napi_env env, napi_ext_ref ref) {
 // Decrements the reference count.
 // The provided ref must not be used after this call because it could be deleted
 // if the internal ref counter became zero.
-NAPI_EXTERN napi_status napi_ext_reference_unref(napi_env env, napi_ext_ref ref) {
+napi_status napi_ext_reference_unref(napi_env env, napi_ext_ref ref) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw JS exceptions.
   CHECK_ENV(env);
   CHECK_ARG(env, ref);
@@ -735,7 +734,7 @@ NAPI_EXTERN napi_status napi_ext_reference_unref(napi_env env, napi_ext_ref ref)
 }
 
 // Gets the referenced value.
-NAPI_EXTERN napi_status napi_ext_get_reference_value(napi_env env, napi_ext_ref ref, napi_value *result) {
+napi_status napi_ext_get_reference_value(napi_env env, napi_ext_ref ref, napi_value *result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw JS exceptions.
   CHECK_ENV(env);
   CHECK_ARG(env, ref);

--- a/src/public/js_native_ext_api.h
+++ b/src/public/js_native_ext_api.h
@@ -25,22 +25,27 @@ typedef enum {
 
 typedef struct napi_ext_env_scope__ *napi_ext_env_scope;
 typedef struct napi_ext_ref__ *napi_ext_ref;
+typedef struct v8_task_runner_s *v8_task_runner_t;
+
+// A callback to run task
+typedef void(__cdecl *v8_task_run_cb)(void *task_data);
+
+// A callback to release task
+typedef void(__cdecl *v8_task_release_cb)(void *task_data);
+
+// A callback to post task to the task runner
+typedef void(__cdecl *v8_task_runner_post_task_cb)(
+    void *task_runner_data,
+    void *task_data,
+    v8_task_run_cb task_run_cb,
+    v8_task_release_cb task_release_cb);
+
+// A callback to release task runner
+typedef void(__cdecl *v8_task_runner_release_cb)(void *task_runner_data);
 
 // A callback to return buffer synchronously
 typedef void(
     __cdecl *napi_ext_buffer_callback)(napi_env env, uint8_t const *buffer, size_t buffer_length, void *buffer_hint);
-
-// A callback to run task
-typedef void(__cdecl *napi_ext_task_callback)(napi_env env, void *task_data);
-
-// A callback to schedule a task
-typedef void(__cdecl *napi_ext_schedule_task_callback)(
-    napi_env env,
-    napi_ext_task_callback task_cb,
-    void *task_data,
-    uint32_t delay_in_msec,
-    napi_finalize finalize_cb,
-    void *finalize_hint);
 
 // Wraps up native data and its finalizer method to be called when it is not needed anymore.
 // This struct is planned to be replaced by node_api_native_data defined in this PR:
@@ -92,8 +97,8 @@ typedef struct napi_ext_env_settings {
   // Size of this struct to allow extending it in future.
   size_t this_size;
 
-  // Custom scheduler of the foreground JavaScript tasks.
-  napi_ext_schedule_task_callback foreground_scheduler;
+  // Task runner for the foreground JavaScript tasks.
+  v8_task_runner_t foreground_task_runner;
 
   // The environment attributes.
   napi_ext_env_attributes attributes;
@@ -145,6 +150,12 @@ typedef struct napi_ext_env_settings {
   napi_ext_script_cache *script_cache;
 
 } napi_ext_env_settings;
+
+// Creates new task runner.
+NAPI_EXTERN v8_task_runner_t __cdecl v8_create_task_runner(
+    void *task_runner_data,
+    v8_task_runner_post_task_cb task_runner_post_task_cb,
+    v8_task_runner_release_cb task_runner_release_cb);
 
 // Creates a new napi_env with ref count 1.
 NAPI_EXTERN napi_status __cdecl napi_ext_create_env(napi_ext_env_settings *settings, napi_env *env);


### PR DESCRIPTION
Cherry pick PR #153 to the main branch.

### Original PR description:

Currently the Node-API foreground task runner lifetime is depending on the `napi_env` lifetime.
This is wrong because some tasks must be run after the `napi_env` is destroyed.
This issue causes a crash in React Native for Windows when we do direct debugging.

In this PR we are fixing this issue by implementing a new task runner:
- Client code must call `v8_create_task_runner` function to create a new task runner and then pass it to `napi_ext_env_settings` when creating new `napi_env`. The code that internally uses `v8runtime::JSITaskRunner` is responsible for deleting it.
- The `v8_create_task_runner` captures external task scheduler and functions to run tasks and to destroy the external task scheduler.
- This is [a PR in RNW](https://github.com/microsoft/react-native-windows/pull/10966) that implements the new API.

An additional change in this PR: removed `NAPI_EXTERN` from all implementations as it may cause issues if the function signature is not the same in the .h and .cpp files. This issue was observed while working on the new `v8_create_task_runner` function.

Note that the new code has prefix `v8_` instead of previously used `napi_ext_`. The reason is that these functions are V8 JS Engine specific and will be never accepted as a part of the Node-API in Node.JS. Thus, the proposal is to use the `v8_` prefix instead. Ideally, we should replace `js_native_ext_api.h` with a new `v8_api.h` where all declarations will have the `v8_` prefix.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/168)