### PR TITLE
[0.70] Fix task runner for Node-API (#153)

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.70.2",
+    "version": "0.70.3",
     "v8ref": "refs/branch-heads/10.9"
 }

--- a/src/napi/js_native_ext_api_v8.cpp
+++ b/src/napi/js_native_ext_api_v8.cpp
@@ -168,8 +168,7 @@ struct V8RuntimeHolder : protected v8impl::RefTracker {
 } // namespace v8impl
 
 struct EnvScope {
-  EnvScope(napi_env env) : env_{env}
-  {
+  EnvScope(napi_env env) : env_{env} {
     if (napi_env_use_lockers(env)) {
       locker_ = std::make_unique<v8::Locker>(env->isolate);
     }
@@ -213,7 +212,7 @@ struct EnvScope {
 
  private:
   napi_env env_;
-  std::unique_ptr<v8::Locker> locker_ {};
+  std::unique_ptr<v8::Locker> locker_{};
   std::unique_ptr<v8::Isolate::Scope> isolate_scope_{};
   std::unique_ptr<v8::Context::Scope> context_scope_{};
   napi_handle_scope handle_scope_{};
@@ -375,7 +374,7 @@ napi_status napi_ext_env_ref(napi_env env) {
 
 napi_status napi_ext_env_unref(napi_env env) {
   CHECK_ENV(env);
-  v8runtime::V8Runtime* runtime;
+  v8runtime::V8Runtime *runtime;
   {
     EnvScope scope(env);
     runtime = v8runtime::V8Runtime::GetCurrent(env->context());

--- a/src/napi/js_native_ext_api_v8.cpp
+++ b/src/napi/js_native_ext_api_v8.cpp
@@ -219,35 +219,31 @@ struct EnvScope {
   napi_handle_scope handle_scope_{};
 };
 
-struct NapiJSITaskRunner : v8runtime::JSITaskRunner {
-  NapiJSITaskRunner(napi_env env, napi_ext_schedule_task_callback scheduler) : env_{env}, scheduler_{scheduler} {}
+struct V8TaskRunner : v8runtime::JSITaskRunner {
+  V8TaskRunner(
+      void *task_runner_data,
+      v8_task_runner_post_task_cb task_runner_post_task_cb,
+      v8_task_runner_release_cb task_runner_release_cb)
+      : task_runner_data_(task_runner_data),
+        task_runner_post_task_cb_(task_runner_post_task_cb),
+        task_runner_release_cb_(task_runner_release_cb) {}
+
+  ~V8TaskRunner() override {
+    task_runner_release_cb_(task_runner_data_);
+  }
 
   void postTask(std::unique_ptr<v8runtime::JSITask> task) override {
-    postDelayedTask(std::move(task), 0);
-  }
-
-  void postDelayedTask(std::unique_ptr<v8runtime::JSITask> task, double delay_in_seconds) /*override*/ {
-    scheduler_(
-        env_,
-        [](napi_env env, void *task_data) {
-          auto task = static_cast<v8runtime::JSITask *>(task_data);
-          task->run();
-        },
+    task_runner_post_task_cb_(
+        task_runner_data_,
         static_cast<void *>(task.release()),
-        delay_in_seconds * 1000,
-        [](napi_env env, void *finalize_data, void *finalize_hint) {
-          std::unique_ptr<v8runtime::JSITask> task{static_cast<v8runtime::JSITask *>(finalize_data)};
-        },
-        nullptr);
-  }
-
-  void setEnv(napi_env env) {
-    env_ = env;
+        [](void *task_data) { static_cast<v8runtime::JSITask *>(task_data)->run(); },
+        [](void *task_data) { delete static_cast<v8runtime::JSITask *>(task_data); });
   }
 
  private:
-  napi_env env_;
-  napi_ext_schedule_task_callback scheduler_;
+  void *task_runner_data_;
+  v8_task_runner_post_task_cb task_runner_post_task_cb_;
+  v8_task_runner_release_cb task_runner_release_cb_;
 };
 
 struct NodeApiJsiBuffer : facebook::jsi::Buffer {
@@ -324,6 +320,14 @@ struct NodeApiPreparedScriptStore : facebook::jsi::PreparedScriptStore {
   napi_ext_script_cache scriptCache_;
 };
 
+v8_task_runner_t __cdecl v8_create_task_runner(
+    void *task_runner_data,
+    v8_task_runner_post_task_cb task_runner_post_task_cb,
+    v8_task_runner_release_cb task_runner_release_cb) {
+  return reinterpret_cast<v8_task_runner_t>(
+      new V8TaskRunner(task_runner_data, task_runner_post_task_cb, task_runner_release_cb));
+}
+
 napi_status napi_ext_create_env(napi_ext_env_settings *settings, napi_env *env) {
   v8runtime::V8RuntimeArgs args;
 
@@ -345,8 +349,8 @@ napi_status napi_ext_create_env(napi_ext_env_settings *settings, napi_env *env) 
   args.flags.thread_pool_size = settings->flags.thread_pool_size;
   args.flags.enableMultiThread = settings->flags.enable_multi_thread;
 
-  auto taskRunner = std::make_shared<NapiJSITaskRunner>(*env, settings->foreground_scheduler);
-  args.foreground_task_runner = taskRunner;
+  args.foreground_task_runner =
+      std::shared_ptr<V8TaskRunner>(reinterpret_cast<V8TaskRunner *>(settings->foreground_task_runner));
 
   if (settings->script_cache) {
     args.preparedScriptStore = std::make_unique<NodeApiPreparedScriptStore>(settings->script_cache);
@@ -356,7 +360,6 @@ napi_status napi_ext_create_env(napi_ext_env_settings *settings, napi_env *env) 
 
   auto context = v8impl::PersistentToLocal::Strong(runtime->GetContext());
   *env = new napi_env__(context, settings->flags.enable_multi_thread);
-  taskRunner->setEnv(*env);
 
   // Let the runtime exists. It can be accessed from the Context.
   new v8impl::V8RuntimeHolder(*env, runtime.release());
@@ -548,8 +551,7 @@ napi_status napi_ext_collect_garbage(napi_env env) {
   return napi_status::napi_ok;
 }
 
-NAPI_EXTERN napi_status
-napi_ext_get_unique_string_utf8_ref(napi_env env, const char *str, size_t length, napi_ext_ref *result) {
+napi_status napi_ext_get_unique_string_utf8_ref(napi_env env, const char *str, size_t length, napi_ext_ref *result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, str);
   CHECK_ARG(env, result);
@@ -561,7 +563,7 @@ napi_ext_get_unique_string_utf8_ref(napi_env env, const char *str, size_t length
   return GET_RETURN_STATUS(env);
 }
 
-NAPI_EXTERN napi_status napi_ext_get_unique_string_ref(napi_env env, napi_value str_value, napi_ext_ref *result) {
+napi_status napi_ext_get_unique_string_ref(napi_env env, napi_value str_value, napi_ext_ref *result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, str_value);
   CHECK_ARG(env, result);
@@ -653,7 +655,7 @@ napi_status napi_create_external_buffer(
 }
 
 // Creates new napi_ext_ref with ref counter set to 1.
-NAPI_EXTERN napi_status napi_ext_create_reference(napi_env env, napi_value value, napi_ext_ref *result) {
+napi_status napi_ext_create_reference(napi_env env, napi_value value, napi_ext_ref *result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw JS exceptions.
   CHECK_ENV(env);
   CHECK_ARG(env, value);
@@ -669,7 +671,7 @@ NAPI_EXTERN napi_status napi_ext_create_reference(napi_env env, napi_value value
 
 // Creates new napi_ext_ref and associates native data with the reference.
 // The ref counter is set to 1.
-NAPI_EXTERN napi_status napi_ext_create_reference_with_data(
+napi_status napi_ext_create_reference_with_data(
     napi_env env,
     napi_value value,
     void *native_object,
@@ -691,7 +693,7 @@ NAPI_EXTERN napi_status napi_ext_create_reference_with_data(
   return napi_clear_last_error(env);
 }
 
-NAPI_EXTERN napi_status napi_ext_create_weak_reference(napi_env env, napi_value value, napi_ext_ref *result) {
+napi_status napi_ext_create_weak_reference(napi_env env, napi_value value, napi_ext_ref *result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw JS exceptions.
   CHECK_ENV(env);
   CHECK_ARG(env, value);
@@ -706,7 +708,7 @@ NAPI_EXTERN napi_status napi_ext_create_weak_reference(napi_env env, napi_value 
 }
 
 // Increments the reference count.
-NAPI_EXTERN napi_status napi_ext_reference_ref(napi_env env, napi_ext_ref ref) {
+napi_status napi_ext_reference_ref(napi_env env, napi_ext_ref ref) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw JS exceptions.
   CHECK_ENV(env);
   CHECK_ARG(env, ref);
@@ -720,7 +722,7 @@ NAPI_EXTERN napi_status napi_ext_reference_ref(napi_env env, napi_ext_ref ref) {
 // Decrements the reference count.
 // The provided ref must not be used after this call because it could be deleted
 // if the internal ref counter became zero.
-NAPI_EXTERN napi_status napi_ext_reference_unref(napi_env env, napi_ext_ref ref) {
+napi_status napi_ext_reference_unref(napi_env env, napi_ext_ref ref) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw JS exceptions.
   CHECK_ENV(env);
   CHECK_ARG(env, ref);
@@ -733,7 +735,7 @@ NAPI_EXTERN napi_status napi_ext_reference_unref(napi_env env, napi_ext_ref ref)
 }
 
 // Gets the referenced value.
-NAPI_EXTERN napi_status napi_ext_get_reference_value(napi_env env, napi_ext_ref ref, napi_value *result) {
+napi_status napi_ext_get_reference_value(napi_env env, napi_ext_ref ref, napi_value *result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw JS exceptions.
   CHECK_ENV(env);
   CHECK_ARG(env, ref);

--- a/src/public/js_native_ext_api.h
+++ b/src/public/js_native_ext_api.h
@@ -25,22 +25,27 @@ typedef enum {
 
 typedef struct napi_ext_env_scope__ *napi_ext_env_scope;
 typedef struct napi_ext_ref__ *napi_ext_ref;
+typedef struct v8_task_runner_s *v8_task_runner_t;
+
+// A callback to run task
+typedef void(__cdecl *v8_task_run_cb)(void *task_data);
+
+// A callback to release task
+typedef void(__cdecl *v8_task_release_cb)(void *task_data);
+
+// A callback to post task to the task runner
+typedef void(__cdecl *v8_task_runner_post_task_cb)(
+    void *task_runner_data,
+    void *task_data,
+    v8_task_run_cb task_run_cb,
+    v8_task_release_cb task_release_cb);
+
+// A callback to release task runner
+typedef void(__cdecl *v8_task_runner_release_cb)(void *task_runner_data);
 
 // A callback to return buffer synchronously
 typedef void(
     __cdecl *napi_ext_buffer_callback)(napi_env env, uint8_t const *buffer, size_t buffer_length, void *buffer_hint);
-
-// A callback to run task
-typedef void(__cdecl *napi_ext_task_callback)(napi_env env, void *task_data);
-
-// A callback to schedule a task
-typedef void(__cdecl *napi_ext_schedule_task_callback)(
-    napi_env env,
-    napi_ext_task_callback task_cb,
-    void *task_data,
-    uint32_t delay_in_msec,
-    napi_finalize finalize_cb,
-    void *finalize_hint);
 
 // Wraps up native data and its finalizer method to be called when it is not needed anymore.
 // This struct is planned to be replaced by node_api_native_data defined in this PR:
@@ -92,8 +97,8 @@ typedef struct napi_ext_env_settings {
   // Size of this struct to allow extending it in future.
   size_t this_size;
 
-  // Custom scheduler of the foreground JavaScript tasks.
-  napi_ext_schedule_task_callback foreground_scheduler;
+  // Task runner for the foreground JavaScript tasks.
+  v8_task_runner_t foreground_task_runner;
 
   // The environment attributes.
   napi_ext_env_attributes attributes;
@@ -145,6 +150,12 @@ typedef struct napi_ext_env_settings {
   napi_ext_script_cache *script_cache;
 
 } napi_ext_env_settings;
+
+// Creates new task runner.
+NAPI_EXTERN v8_task_runner_t __cdecl v8_create_task_runner(
+    void *task_runner_data,
+    v8_task_runner_post_task_cb task_runner_post_task_cb,
+    v8_task_runner_release_cb task_runner_release_cb);
 
 // Creates a new napi_env with ref count 1.
 NAPI_EXTERN napi_status __cdecl napi_ext_create_env(napi_ext_env_settings *settings, napi_env *env);


### PR DESCRIPTION
Cherry pick PR #153 to the main branch.

### Original PR description:

Currently the Node-API foreground task runner lifetime is depending on the `napi_env` lifetime.
This is wrong because some tasks must be run after the `napi_env` is destroyed.
This issue causes a crash in React Native for Windows when we do direct debugging.

In this PR we are fixing this issue by implementing a new task runner:
- Client code must call `v8_create_task_runner` function to create a new task runner and then pass it to `napi_ext_env_settings` when creating new `napi_env`. The code that internally uses `v8runtime::JSITaskRunner` is responsible for deleting it.
- The `v8_create_task_runner` captures external task scheduler and functions to run tasks and to destroy the external task scheduler.
- This is [a PR in RNW](https://github.com/microsoft/react-native-windows/pull/10966) that implements the new API.

An additional change in this PR: removed `NAPI_EXTERN` from all implementations as it may cause issues if the function signature is not the same in the .h and .cpp files. This issue was observed while working on the new `v8_create_task_runner` function.

Note that the new code has prefix `v8_` instead of previously used `napi_ext_`. The reason is that these functions are V8 JS Engine specific and will be never accepted as a part of the Node-API in Node.JS. Thus, the proposal is to use the `v8_` prefix instead. Ideally, we should replace `js_native_ext_api.h` with a new `v8_api.h` where all declarations will have the `v8_` prefix.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/v8-jsi/pull/169)