### PR TITLE
[0.69] Fix CI pipelines (#171)

### DIFF
--- a/.ado/windows-build.yml
+++ b/.ado/windows-build.yml
@@ -27,7 +27,7 @@ steps:
         -AppPlatform:${{parameters.appPlatform}}
 
   - task: PowerShell@2
-    displayName: Actually run the build
+    displayName: Build code
     inputs:
       targetType: filePath
       filePath: $(Build.SourcesDirectory)\scripts\build.ps1
@@ -39,8 +39,12 @@ steps:
         -AppPlatform:${{parameters.appPlatform}}
 
   - powershell: |
-      Write-Host "##vso[task.setvariable variable=GoogleTestAdapterPath]$((Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\" -Directory | Where-Object -FilterScript { Test-Path $_\GoogleTestAdapter.Core.dll}).FullName)"
-      Write-Host "Set environment variable to ($env:GoogleTestAdapterPath)"
+      $vsExtensionPath="${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\";
+      Write-Host "Searching for Google Test Adapter Path in '$vsExtensionPath'"
+      $GoogleTestAdapterPath=(Get-ChildItem $vsExtensionPath -Directory | Where-Object -FilterScript {Test-Path  (Join-Path -Path $_.FullName -ChildPath "GoogleTestAdapter.Core.dll")}).FullName
+      Write-Host "Found:" (Test-Path -Path $GoogleTestAdapterPath)
+      Write-Host "Setting Google Test Adapter Path to '$GoogleTestAdapterPath'"
+      Write-Host "##vso[task.setvariable variable=GoogleTestAdapterPath]$GoogleTestAdapterPath"
     displayName: Set GoogleTestAdapterPath
 
   - task: VSTest@2

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -1,6 +1,6 @@
 jobs:
   - job: V8JsiBuild
-    timeoutInMinutes: 210
+    timeoutInMinutes: 300
     displayName: Build v8jsi.dll
     strategy:
       matrix:

--- a/.ado/windows-pr.yml
+++ b/.ado/windows-pr.yml
@@ -6,7 +6,7 @@ pr:
   - "*-stable"
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-2022'
 
 jobs:
   - template: windows-jobs.yml


### PR DESCRIPTION
Cherry pick PR #171. Original description:

Currently CI pipelines are failing because its image is switched to use VS 2022.
The script cannot find the Google Test Adapter in VS 2019 folder and fails.

In this PR we update the build script to use VS 2022 for PRs and to look for the Google Test Adapter in the VS 2022 folder.

The build job timeout is increased to 5 hours because we see a timeout after 3.5 hours when we build x64 debug for UWP.