### PR TITLE
Fix v8_api bugs after testing code in applications

### DIFF
--- a/src/napi/v8_api.cpp
+++ b/src/napi/v8_api.cpp
@@ -107,8 +107,11 @@ class V8RuntimeEnv : public v8runtime::V8Runtime, public napi_env__ {
     return napi_ok;
   }
 
-  napi_status drainMicrotasks(int32_t /*maxCountHint*/, bool * /*result*/) {
+  napi_status drainMicrotasks(int32_t /*maxCountHint*/, bool *result) {
     // V8 drains microtasks automatically after each call.
+    if (result) {
+      *result = true;
+    }
     return napi_ok;
   }
 
@@ -353,7 +356,9 @@ class V8ScriptCache : public facebook::jsi::PreparedScriptStore {
         &bufferSize,
         &bufferDeleteCallback,
         &bufferDeleterData);
-    return std::make_shared<V8JsiBuffer>(buffer, bufferSize, bufferDeleteCallback, bufferDeleterData);
+    return (buffer && bufferSize)
+        ? std::make_shared<V8JsiBuffer>(buffer, bufferSize, bufferDeleteCallback, bufferDeleterData)
+        : nullptr;
   }
 
   void persistPreparedScript(


### PR DESCRIPTION
This PR fixes two issues in the new v8_api.cpp:
- `drainMicrotasks` was returning undefined value
- `tryGetPreparedScript` was retuning non-null even if prepared script is not found in the cache.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/v8-jsi/pull/180&drop=dogfoodAlpha