### PR TITLE
Fix prepared script creation

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "version": "0.71.7",
+    "version": "0.71.8",
     "v8ref": "refs/branch-heads/11.5"
 }

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -825,9 +825,6 @@ std::shared_ptr<const facebook::jsi::PreparedJavaScript> V8Runtime::prepareJavaS
     cached_data = new v8::ScriptCompiler::CachedData(cache->data(), static_cast<int>(cache->size()));
     options = v8::ScriptCompiler::CompileOptions::kConsumeCodeCache;
   } else if (args_.preparedScriptStore) {
-    // Eager compile so that we will write it to disk.
-    options = v8::ScriptCompiler::CompileOptions::kEagerCompile;
-  } else {
     options = v8::ScriptCompiler::CompileOptions::kNoCompileOptions;
   }
 


### PR DESCRIPTION
Using the `CompileOptions::kEagerCompile` for the prepared script creation causes crashes in V8 for some scripts.
In this PR we remove this option for the ABI-safe API.
Current non-ABI-safe also does not use this option.

The option worked just fine for the test cases, but it fails for the RN foundation bundle.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/182)