### PR TITLE
Update handling of HTTP requests for debug targets

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.71.11",
+    "version":  "0.71.12",
     "v8ref":  "refs/branch-heads/11.8",
     "buildNumber":  "172"
 }

--- a/src/inspector/inspector_socket_server.cpp
+++ b/src/inspector/inspector_socket_server.cpp
@@ -95,7 +95,7 @@ namespace {
   const char* MatchPathSegment(const char* path, const char* expected) {
     size_t len = strlen(expected);
     if (utils::StringEqualNoCaseN(path, expected, len)) {
-      if (path[len] == '/') return path + len + 1;
+      if (path[len] == '/' || path[len] == '?') return path + len + 1;
       if (path[len] == '\0') return path + len;
     }
     return nullptr;


### PR DESCRIPTION
A recent Edge update (118.0.2088.46) appears to have altered how Chrome Dev Tools request debug targets:
Instead of an HTTP "GET /json/list" request, the dev tools now send "GET /json/list?for_tab". The code change here is intended to alter the URL parser within V8's inspector code to detect the "list" path element when it's being followed by a query URL part.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/186)