### PR TITLE
Update to V8 12.1 and improve bytecode versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Until the JSI headers find a more suitable home, they're currently duplicated be
 
 ### Build script patches
 To regenerate after manual fix-ups, run:
-* `git diff --output=..\..\..\..\scripts\patch\build.diff --ignore-cr-at-eol` from `\build\v8\build\`.
-* `git diff --output=..\..\..\scripts\patch\src.diff --ignore-cr-at-eol` from `\build\v8\`.
-* `git diff --output=..\..\..\..\..\scripts\patch\zlib.diff --ignore-cr-at-eol` from `\build\v8\third_party\zlib\`.
+* `git diff --output=..\..\..\scripts\patch\build.diff --ignore-cr-at-eol` from `\build\v8\build\`.
+* `git diff --output=..\..\scripts\patch\src.diff --ignore-cr-at-eol` from `\build\v8\`.
+* `git diff --output=..\..\..\..\scripts\patch\zlib.diff --ignore-cr-at-eol` from `\build\v8\third_party\zlib\`.
 
 ## Contributing
 See [Contributing guidelines](./docs/CONTRIBUTING.md) for how to setup your fork of the repo and start a PR to contribute to React Native V8 JSI adapter.

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.71.14",
+    "version":  "0.71.13",
     "v8ref":  "refs/branch-heads/12.1",
     "buildNumber":  "285"
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.71.12",
-    "v8ref":  "refs/branch-heads/11.8",
-    "buildNumber":  "172"
+    "version":  "0.71.14",
+    "v8ref":  "refs/branch-heads/12.1",
+    "buildNumber":  "285"
 }

--- a/scripts/patch/build.diff
+++ b/scripts/patch/build.diff
@@ -1,8 +1,8 @@
 diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
-index 06812fb9c..76ac198d3 100644
+index de1cd6efc..ed87ccb75 100644
 --- a/config/compiler/BUILD.gn
 +++ b/config/compiler/BUILD.gn
-@@ -1671,7 +1671,7 @@ config("default_warnings") {
+@@ -1758,7 +1758,7 @@ config("default_warnings") {
        # TODO(thakis): Remove this once
        # https://swiftshader-review.googlesource.com/c/SwiftShader/+/57968 has
        # rolled into angle.
@@ -11,7 +11,7 @@ index 06812fb9c..76ac198d3 100644
      }
    } else {
      if (is_apple && !is_nacl) {
-@@ -1965,7 +1965,7 @@ config("no_chromium_code") {
+@@ -2045,7 +2045,7 @@ config("no_chromium_code") {
      }
      cflags += [
        "/wd4800",  # Disable warning when forcing value to bool.
@@ -19,12 +19,12 @@ index 06812fb9c..76ac198d3 100644
 +      # "/wd4267",  # TODO(jschuh): size_t to int.
      ]
    } else {
-     # GCC may emit unsuppressible warnings so don't add -Werror for no chromium
+     if (is_clang && !is_nacl) {
 diff --git a/config/win/BUILD.gn b/config/win/BUILD.gn
-index 497d47989..fcdf1e9b0 100644
+index 6e1417aa4..4079a06c8 100644
 --- a/config/win/BUILD.gn
 +++ b/config/win/BUILD.gn
-@@ -479,16 +479,16 @@ config("default_crt") {
+@@ -486,16 +486,16 @@ config("default_crt") {
      # Component mode: dynamic CRT. Since the library is shared, it requires
      # exceptions or will give errors about things not matching, so keep
      # exceptions on.
@@ -44,7 +44,7 @@ index 497d47989..fcdf1e9b0 100644
      }
    }
  }
-@@ -682,3 +682,11 @@ config("lean_and_mean") {
+@@ -689,3 +689,11 @@ config("lean_and_mean") {
  config("nominmax") {
    defines = [ "NOMINMAX" ]
  }
@@ -58,7 +58,7 @@ index 497d47989..fcdf1e9b0 100644
 +}
 \ No newline at end of file
 diff --git a/toolchain/win/setup_toolchain.py b/toolchain/win/setup_toolchain.py
-index d2f5798ce..3a7ffccc1 100644
+index 521c24398..3677b5a2f 100644
 --- a/toolchain/win/setup_toolchain.py
 +++ b/toolchain/win/setup_toolchain.py
 @@ -186,6 +186,8 @@ def _LoadToolchainEnv(cpu, toolchain_root, sdk_dir, target_store):

--- a/scripts/patch/src.diff
+++ b/scripts/patch/src.diff
@@ -1,8 +1,8 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index dd97c4f922..53948090e1 100644
+index f0976f97e5..c4f6a026cf 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -1490,7 +1490,7 @@ config("toolchain") {
+@@ -1511,7 +1511,7 @@ config("toolchain") {
    if (is_win) {
      cflags += [
        "/wd4245",  # Conversion with signed/unsigned mismatch.
@@ -11,7 +11,7 @@ index dd97c4f922..53948090e1 100644
        "/wd4324",  # Padding structure due to alignment.
        "/wd4701",  # Potentially uninitialized local variable.
        "/wd4702",  # Unreachable code.
-@@ -1594,14 +1594,14 @@ config("toolchain") {
+@@ -1615,14 +1615,14 @@ config("toolchain") {
  
        "/wd4100",  # Unreferenced formal function parameter.
        "/wd4121",  # Alignment of a member was sensitive to packing.
@@ -29,7 +29,7 @@ index dd97c4f922..53948090e1 100644
  
        # These are variable shadowing warnings that are new in VS2015. We
        # should work through these at some point -- they may be removed from
-@@ -1625,7 +1625,7 @@ config("toolchain") {
+@@ -1646,7 +1646,7 @@ config("toolchain") {
        "/wd4245",  # 'conversion' : conversion from 'type1' to 'type2',
                    # signed/unsigned mismatch
  
@@ -38,7 +38,7 @@ index dd97c4f922..53948090e1 100644
                    # data
  
        "/wd4305",  # 'identifier' : truncation from 'type1' to 'type2'
-@@ -6932,26 +6932,6 @@ group("v8_python_base") {
+@@ -7147,26 +7147,6 @@ group("v8_python_base") {
    data = [ ".vpython3" ]
  }
  
@@ -65,7 +65,7 @@ index dd97c4f922..53948090e1 100644
  # Targets we ensure work with gcc. The aim is to keep this list small to have
  # a fast overall compile time.
  group("v8_gcc_light") {
-@@ -7186,7 +7166,7 @@ v8_executable("d8") {
+@@ -7401,7 +7381,7 @@ v8_executable("d8") {
    }
  
    if (v8_correctness_fuzzer) {
@@ -74,7 +74,7 @@ index dd97c4f922..53948090e1 100644
    }
  
    defines = []
-@@ -7881,3 +7861,9 @@ if (!build_with_chromium && v8_use_perfetto) {
+@@ -8096,3 +8076,9 @@ if (!build_with_chromium && v8_use_perfetto) {
      ]
    }
  }  # if (!build_with_chromium && v8_use_perfetto)
@@ -85,12 +85,12 @@ index dd97c4f922..53948090e1 100644
 +  ]
 +}
 diff --git a/DEPS b/DEPS
-index 5cffcad442..f8264e6c44 100644
+index 529f54b59f..f0ecac5c0c 100644
 --- a/DEPS
 +++ b/DEPS
-@@ -680,4 +680,15 @@ hooks = [
-     'condition': 'host_os == "win"',
-     'action': ['python3', 'build/del_ninja_deps_cache.py'],
+@@ -708,4 +708,15 @@ hooks = [
+                '--quiet',
+                ],
    },
 +  {
 +    'name': 'rc_win',
@@ -102,29 +102,29 @@ index 5cffcad442..f8264e6c44 100644
 +                '--bucket', 'chromium-browser-clang/rc',
 +                '-s', 'build/toolchain/win/rc/win/rc.exe.sha1',
 +    ],
-+  }
++  },
  ]
 diff --git a/src/maglev/maglev-ir.h b/src/maglev/maglev-ir.h
-index 888944b606..7bf2c4c7e5 100644
+index 68a751b775..75277e0f7e 100644
 --- a/src/maglev/maglev-ir.h
 +++ b/src/maglev/maglev-ir.h
-@@ -2258,8 +2258,8 @@ class NodeTMixin : public Base {
+@@ -2335,8 +2335,8 @@ class NodeTMixin : public Base {
    template <typename... Args>
    explicit NodeTMixin(uint64_t bitfield, Args&&... args)
        : Base(bitfield, std::forward<Args>(args)...) {
--    DCHECK_EQ(NodeBase::opcode(), NodeBase::opcode_of<Derived>);
--    DCHECK_EQ(NodeBase::properties(), Derived::kProperties);
-+    //DCHECK_EQ(NodeBase::opcode(), NodeBase::opcode_of<Derived>);
-+    //DCHECK_EQ(NodeBase::properties(), Derived::kProperties);
+-    DCHECK_EQ(this->NodeBase::opcode(), NodeBase::opcode_of<Derived>);
+-    DCHECK_EQ(this->NodeBase::properties(), Derived::kProperties);
++    //DCHECK_EQ(this->NodeBase::opcode(), NodeBase::opcode_of<Derived>);
++    //DCHECK_EQ(this->NodeBase::properties(), Derived::kProperties);
    }
  };
  
-@@ -2326,7 +2326,7 @@ class FixedInputNodeTMixin : public NodeTMixin<Base, Derived> {
+@@ -2403,7 +2403,7 @@ class FixedInputNodeTMixin : public NodeTMixin<Base, Derived> {
    template <typename... Args>
    explicit FixedInputNodeTMixin(uint64_t bitfield, Args&&... args)
        : NodeTMixin<Base, Derived>(bitfield, std::forward<Args>(args)...) {
--    DCHECK_EQ(NodeBase::input_count(), kInputCount);
-+    //DCHECK_EQ(NodeBase::input_count(), kInputCount);
+-    DCHECK_EQ(this->NodeBase::input_count(), kInputCount);
++    //DCHECK_EQ(this->NodeBase::input_count(), kInputCount);
    }
  };
  
@@ -146,7 +146,7 @@ index dc8a3696fa..50bcba0a3b 100644
  
  v8::VirtualAddressSpace* GetPlatformVirtualAddressSpace() {
 diff --git a/third_party/googletest/BUILD.gn b/third_party/googletest/BUILD.gn
-index bc82c635da..648972c77a 100644
+index 1cf84b3d8f..d5c5ec9521 100644
 --- a/third_party/googletest/BUILD.gn
 +++ b/third_party/googletest/BUILD.gn
 @@ -88,8 +88,8 @@ source_set("gtest") {
@@ -161,10 +161,10 @@ index bc82c635da..648972c77a 100644
    # V8-only workaround for http://crbug.com/chromium/1191946. Ensures that
    # googletest is compiled with the same visibility such as the rest of V8, see
 diff --git a/tools/v8windbg/BUILD.gn b/tools/v8windbg/BUILD.gn
-index 5516a6109f..d6cde0082c 100644
+index 3bb1ee25e6..b1c31172d4 100644
 --- a/tools/v8windbg/BUILD.gn
 +++ b/tools/v8windbg/BUILD.gn
-@@ -26,7 +26,7 @@ source_set("v8windbg_base") {
+@@ -23,7 +23,7 @@ source_set("v8windbg_base") {
      "DbgEng.lib",
      "DbgModel.lib",
      "RuntimeObject.lib",

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -1166,7 +1166,7 @@ jsi::Object V8Runtime::createObject(std::shared_ptr<jsi::HostObject> hostobject)
 
 std::shared_ptr<jsi::HostObject> V8Runtime::getHostObject(const jsi::Object &obj) {
   IsolateLocker isolate_locker(this);
-  v8::Local<v8::External> internalField = v8::Local<v8::External>::Cast(objectRef(obj)->GetInternalField(0));
+  v8::Local<v8::External> internalField = v8::Local<v8::External>::Cast(objectRef(obj)->GetInternalField(0).As<v8::Value>());
   HostObjectProxy *hostObjectProxy = reinterpret_cast<HostObjectProxy *>(internalField->Value());
   return hostObjectProxy->getHostObject();
 }
@@ -1248,7 +1248,7 @@ bool V8Runtime::isHostObject(const jsi::Object &obj) const {
     return false;
   }
 
-  auto internalFieldRef = objectRef(obj)->GetInternalField(0);
+  auto internalFieldRef = objectRef(obj)->GetInternalField(0).As<v8::Value>();
   if (internalFieldRef.IsEmpty()) {
     return false;
   }

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -25,8 +25,6 @@ using namespace facebook;
 
 namespace v8runtime {
 
-constexpr uint64_t c_V8BuildVersion{V8_MAJOR_VERSION * 10000 + V8_MINOR_VERSION * 1000 + V8_BUILD_NUMBER};
-
 thread_local uint16_t V8Runtime::tls_isolate_usage_counter_ = 0;
 
 struct ContextEmbedderIndex {
@@ -694,7 +692,7 @@ V8Runtime::ExecuteString(const v8::Local<v8::String> &source, const std::string 
   v8::ScriptCompiler::CompileOptions options = v8::ScriptCompiler::CompileOptions::kNoCompileOptions;
   v8::ScriptCompiler::CachedData *cached_data = nullptr;
 
-  jsi::JSRuntimeVersion_t runtimeVersion = c_V8BuildVersion;
+  jsi::JSRuntimeVersion_t runtimeVersion = v8::ScriptCompiler::CachedDataVersionTag();
 
   std::shared_ptr<const jsi::Buffer> cache;
   if (args_.preparedScriptStore) {
@@ -787,7 +785,7 @@ std::shared_ptr<const facebook::jsi::PreparedJavaScript> V8Runtime::prepareJavaS
 
     auto prepared = std::make_shared<V8PreparedJavaScript>();
     prepared->scriptSignature = {sourceURL, hash};
-    prepared->runtimeSignature = {"V8", c_V8BuildVersion};
+    prepared->runtimeSignature = {"V8", v8::ScriptCompiler::CachedDataVersionTag()};
     prepared->buffer.assign(codeCache->data, codeCache->data + codeCache->length);
     prepared->sourceBuffer = buffer;
     return prepared;
@@ -813,7 +811,7 @@ std::shared_ptr<const facebook::jsi::PreparedJavaScript> V8Runtime::prepareJavaS
   v8::ScriptCompiler::CompileOptions options = v8::ScriptCompiler::CompileOptions::kNoCompileOptions;
   v8::ScriptCompiler::CachedData *cached_data = nullptr;
 
-  jsi::JSRuntimeVersion_t runtimeVersion = c_V8BuildVersion;
+  jsi::JSRuntimeVersion_t runtimeVersion = v8::ScriptCompiler::CachedDataVersionTag();
   jsi::ScriptSignature scriptSignature = {sourceURL, hash};
   jsi::JSRuntimeSignature runtimeSignature = {"V8", runtimeVersion};
 
@@ -900,7 +898,7 @@ facebook::jsi::Value V8Runtime::evaluatePreparedJavaScript(
     throw jsi::JSINativeException("Prepared JavaScript cache is invalid (Hash mismatch)");
   }
 
-  if (prepared->runtimeSignature.version != c_V8BuildVersion) {
+  if (prepared->runtimeSignature.version != v8::ScriptCompiler::CachedDataVersionTag()) {
     // V8 version mismatch, we need to recompile the source
     throw jsi::JSINativeException("Prepared JavaScript cache is invalid (V8 version mismatch)");
   }

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -329,7 +329,7 @@ class V8Runtime : public facebook::jsi::Runtime {
         v8::Local<v8::Value> proto = obj->GetPrototype();
         obj = v8::Local<v8::Object>::Cast(proto);
       }
-      v8::Local<v8::Value> externalValue = obj->GetInternalField(0);
+      v8::Local<v8::Value> externalValue = obj->GetInternalField(0).As<v8::Value>();
 
       v8::Local<v8::External> data = v8::Local<v8::External>::Cast(externalValue);
       HostObjectProxy *hostObjectProxy = reinterpret_cast<HostObjectProxy *>(data->Value());
@@ -397,7 +397,7 @@ class V8Runtime : public facebook::jsi::Runtime {
     }
 
     static void Enumerator(const v8::PropertyCallbackInfo<v8::Array> &info) {
-      v8::Local<v8::External> data = v8::Local<v8::External>::Cast(info.This()->GetInternalField(0));
+      v8::Local<v8::External> data = v8::Local<v8::External>::Cast(info.This()->GetInternalField(0).As<v8::Value>());
       HostObjectProxy *hostObjectProxy = reinterpret_cast<HostObjectProxy *>(data->Value());
 
       if (hostObjectProxy != nullptr) {

--- a/src/napi/js_native_api_v8.cc
+++ b/src/napi/js_native_api_v8.cc
@@ -814,8 +814,7 @@ napi_status napi_define_class(napi_env env,
         property_name,
         getter_tpl,
         setter_tpl,
-        attributes,
-        v8::AccessControl::DEFAULT);
+        attributes);
     } else if (p->method != nullptr) {
       v8::Local<v8::FunctionTemplate> t;
       STATUS_CALL(v8impl::FunctionCallbackWrapper::NewTemplate(


### PR DESCRIPTION
1. Update to V8 version 12.1;

1. Instead of rolling our own script versioning, use the official [CachedDataVersionTag](https://source.chromium.org/chromium/chromium/src/+/main:v8/include/v8-script.h;l=766?q=CachedDataVersionTag&sq=&ss=chromium%2Fchromium%2Fsrc), which hashes additional data like the complete V8 version and compiler flags.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/188)