### PR TITLE
[beta] Fixes for 12.2

### DIFF
--- a/.ado/windows-pr.yml
+++ b/.ado/windows-pr.yml
@@ -2,6 +2,7 @@ name: v8jsi_win_pr_0.0.$(Date:yyMM.d)$(Rev:rrr)
 
 trigger: none
 pr:
+  - beta
   - master
   - "*-stable"
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.71.13",
-    "v8ref":  "refs/branch-heads/12.1",
-    "buildNumber":  "285"
+    "version":  "0.0.1",
+    "v8ref":  "refs/branch-heads/12.2",
+    "buildNumber":  "1"
 }

--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -90,7 +90,6 @@ if ($AppPlatform -eq "linux") {
 # Remove unused code
 Remove-Item -Recurse -Force (Join-Path $workpath "v8\test\test262\data\tools")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8\third_party\depot_tools\external_bin\gsutil")
-Remove-Item -Recurse -Force (Join-Path $workpath "v8\third_party\google_benchmark")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8\third_party\perfetto")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8\third_party\protobuf")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8\tools\clusterfuzz")

--- a/scripts/patch/build.diff
+++ b/scripts/patch/build.diff
@@ -1,8 +1,8 @@
 diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
-index de1cd6efc..ed87ccb75 100644
+index 89b4755ac..f358bd78b 100644
 --- a/config/compiler/BUILD.gn
 +++ b/config/compiler/BUILD.gn
-@@ -1758,7 +1758,7 @@ config("default_warnings") {
+@@ -1757,7 +1757,7 @@ config("default_warnings") {
        # TODO(thakis): Remove this once
        # https://swiftshader-review.googlesource.com/c/SwiftShader/+/57968 has
        # rolled into angle.
@@ -10,8 +10,8 @@ index de1cd6efc..ed87ccb75 100644
 +      # cflags += [ "/wd4244" ]
      }
    } else {
-     if (is_apple && !is_nacl) {
-@@ -2045,7 +2045,7 @@ config("no_chromium_code") {
+     if ((is_apple || is_android) && !is_nacl) {
+@@ -2047,7 +2047,7 @@ config("no_chromium_code") {
      }
      cflags += [
        "/wd4800",  # Disable warning when forcing value to bool.

--- a/scripts/patch/src.diff
+++ b/scripts/patch/src.diff
@@ -1,8 +1,8 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index f0976f97e5..c4f6a026cf 100644
+index bc087fd6fe..2755140ab5 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -1511,7 +1511,7 @@ config("toolchain") {
+@@ -1517,7 +1517,7 @@ config("toolchain") {
    if (is_win) {
      cflags += [
        "/wd4245",  # Conversion with signed/unsigned mismatch.
@@ -11,7 +11,7 @@ index f0976f97e5..c4f6a026cf 100644
        "/wd4324",  # Padding structure due to alignment.
        "/wd4701",  # Potentially uninitialized local variable.
        "/wd4702",  # Unreachable code.
-@@ -1615,14 +1615,14 @@ config("toolchain") {
+@@ -1621,14 +1621,14 @@ config("toolchain") {
  
        "/wd4100",  # Unreferenced formal function parameter.
        "/wd4121",  # Alignment of a member was sensitive to packing.
@@ -29,7 +29,7 @@ index f0976f97e5..c4f6a026cf 100644
  
        # These are variable shadowing warnings that are new in VS2015. We
        # should work through these at some point -- they may be removed from
-@@ -1646,7 +1646,7 @@ config("toolchain") {
+@@ -1652,7 +1652,7 @@ config("toolchain") {
        "/wd4245",  # 'conversion' : conversion from 'type1' to 'type2',
                    # signed/unsigned mismatch
  
@@ -38,7 +38,7 @@ index f0976f97e5..c4f6a026cf 100644
                    # data
  
        "/wd4305",  # 'identifier' : truncation from 'type1' to 'type2'
-@@ -7147,26 +7147,6 @@ group("v8_python_base") {
+@@ -7184,26 +7184,6 @@ group("v8_python_base") {
    data = [ ".vpython3" ]
  }
  
@@ -65,7 +65,7 @@ index f0976f97e5..c4f6a026cf 100644
  # Targets we ensure work with gcc. The aim is to keep this list small to have
  # a fast overall compile time.
  group("v8_gcc_light") {
-@@ -7401,7 +7381,7 @@ v8_executable("d8") {
+@@ -7431,7 +7411,7 @@ v8_executable("d8") {
    }
  
    if (v8_correctness_fuzzer) {
@@ -74,7 +74,7 @@ index f0976f97e5..c4f6a026cf 100644
    }
  
    defines = []
-@@ -8096,3 +8076,9 @@ if (!build_with_chromium && v8_use_perfetto) {
+@@ -8126,3 +8106,9 @@ if (!build_with_chromium && v8_use_perfetto) {
      ]
    }
  }  # if (!build_with_chromium && v8_use_perfetto)
@@ -85,11 +85,11 @@ index f0976f97e5..c4f6a026cf 100644
 +  ]
 +}
 diff --git a/DEPS b/DEPS
-index 529f54b59f..f0ecac5c0c 100644
+index badda7719a..c2648d8076 100644
 --- a/DEPS
 +++ b/DEPS
-@@ -708,4 +708,15 @@ hooks = [
-                '--quiet',
+@@ -729,4 +729,15 @@ hooks = [
+                '--skip_remoteexec_cfg_fetch',
                 ],
    },
 +  {
@@ -105,10 +105,10 @@ index 529f54b59f..f0ecac5c0c 100644
 +  },
  ]
 diff --git a/src/maglev/maglev-ir.h b/src/maglev/maglev-ir.h
-index 68a751b775..75277e0f7e 100644
+index c6f7245d49..5f924ce243 100644
 --- a/src/maglev/maglev-ir.h
 +++ b/src/maglev/maglev-ir.h
-@@ -2335,8 +2335,8 @@ class NodeTMixin : public Base {
+@@ -2386,8 +2386,8 @@ class NodeTMixin : public Base {
    template <typename... Args>
    explicit NodeTMixin(uint64_t bitfield, Args&&... args)
        : Base(bitfield, std::forward<Args>(args)...) {
@@ -119,7 +119,7 @@ index 68a751b775..75277e0f7e 100644
    }
  };
  
-@@ -2403,7 +2403,7 @@ class FixedInputNodeTMixin : public NodeTMixin<Base, Derived> {
+@@ -2454,7 +2454,7 @@ class FixedInputNodeTMixin : public NodeTMixin<Base, Derived> {
    template <typename... Args>
    explicit FixedInputNodeTMixin(uint64_t bitfield, Args&&... args)
        : NodeTMixin<Base, Derived>(bitfield, std::forward<Args>(args)...) {

--- a/scripts/update_version.ps1
+++ b/scripts/update_version.ps1
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 param(
-    [System.IO.DirectoryInfo]$SourcesPath = $PSScriptRoot
+    [System.IO.DirectoryInfo]$SourcesPath = $PSScriptRoot,
+    [switch]$BetaBranch,
+    [switch]$GitPush
 )
 
 # Details about the V8 release process: https://v8.dev/docs/release-process
@@ -9,9 +11,15 @@ param(
 # TODO: a cron ADO task should trigger this script to update the version
 
 # https://omahaproxy.appspot.com is deprecated in favor of https://chromiumdash.appspot.com
-$latestVersion = (Invoke-WebRequest "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Windows&num=1" -UseBasicParsing | ConvertFrom-Json).milestone / 10
 
-Write-Host "Latest stable version is $latestVersion"
+$channel = "Stable"
+if ($BetaBranch.IsPresent) {
+  $channel = "Beta"
+}
+
+$latestVersion = (Invoke-WebRequest "https://chromiumdash.appspot.com/fetch_releases?channel=$channel&platform=Windows&num=1" -UseBasicParsing | ConvertFrom-Json).milestone / 10
+
+Write-Host "Latest $channel version is $latestVersion"
 
 $config = Get-Content (Join-Path $SourcesPath "config.json") | Out-String | ConvertFrom-Json
 $builtVersion = (($config.v8ref | Select-String -Pattern "refs/branch-heads/(\d+\.\d+)").Matches[0].Groups[1].Value).Trim()
@@ -19,9 +27,9 @@ $builtVersion = (($config.v8ref | Select-String -Pattern "refs/branch-heads/(\d+
 Write-Host "Version currently being built is $builtVersion"
 
 if ($builtVersion -eq $latestVersion) {
-  Write-Host "Latest stable version is already being built"
+  Write-Host "Latest $channel version is already being built"
 } else {
-  Write-Host "New stable version released, manual intervention required to bump the version!"
+  Write-Host "New $channel version released, manual intervention required to bump the version!"
   exit 1
 }
 
@@ -54,15 +62,19 @@ if ($buildNumber -eq $config.buildNumber) {
   exit 0
 }
 
-Write-Host "New stable build number released, attempting to bump it"
+Write-Host "New $channel build number released, attempting to bump it"
 
 $config.buildNumber = $buildNumber
 $config.version = BumpSemVer($config.version)
 
 ConvertTo-Json -InputObject $config | Set-Content (Join-Path $SourcesPath "config.json")
 
-git config user.name github-actions
-git config user.email github-actions@github.com
-git add config.json
-git commit -m "Updating version to $($config.version) (new upstream build number $buildNumber)"
-git push
+if (! $GitPush.IsPresent) {
+  Write-Host "Git push not requested, we would be updating the version to $($config.version) (new upstream build number $buildNumber)"
+} else {
+  git config user.name github-actions
+  git config user.email github-actions@github.com
+  git add config.json
+  git commit -m "Updating version to $($config.version) (new upstream build number $buildNumber)"
+  git push
+}

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -408,8 +408,6 @@ v8::Isolate *V8Runtime::CreateNewIsolate() {
   // TODO :: Toggle for ship builds.
   isolate_->SetAbortOnUncaughtExceptionCallback([](v8::Isolate *) { return true; });
 
-  isolate_->Enter();
-
   TRACEV8RUNTIME_VERBOSE("CreateNewIsolate", TraceLoggingString("end", "op"));
   DumpCounters("isolate_created");
 
@@ -495,8 +493,9 @@ V8Runtime::V8Runtime(V8RuntimeArgs &&args) : args_(std::move(args)) {
 #endif
 
   // Try to reuse the already existing isolate in this thread.
-  if (tls_isolate_usage_counter_++ > 0) {
+  if (v8::Isolate::TryGetCurrent()) {
     TRACEV8RUNTIME_WARNING("Reusing existing V8 isolate in the current thread !");
+    tls_isolate_usage_counter_++;
     isolate_ = v8::Isolate::GetCurrent();
   } else {
     platform_holder_.addUsage(args.flags.thread_pool_size);
@@ -580,7 +579,6 @@ V8Runtime::~V8Runtime() {
     isolate_->SetData(v8runtime::ISOLATE_DATA_SLOT, nullptr);
     isolate_->SetData(v8runtime::ISOLATE_INSPECTOR_SLOT, nullptr);
 
-    isolate_->Exit();
     isolate_->Dispose();
 
     delete create_params_.array_buffer_allocator;

--- a/src/node-api-jsi/NodeApiJsiRuntime.cpp
+++ b/src/node-api-jsi/NodeApiJsiRuntime.cpp
@@ -1528,7 +1528,6 @@ jsi::Value NodeApiJsiRuntime::callAsConstructor(const jsi::Function &func, const
 }
 
 jsi::Runtime::ScopeState *NodeApiJsiRuntime::pushScope() {
-  NodeApiEnvScope scope{getEnv()};
   napi_handle_scope result{};
   CHECK_NAPI(jsrApi_->napi_open_handle_scope(env_, &result));
   pushPointerValueScope();
@@ -1536,7 +1535,6 @@ jsi::Runtime::ScopeState *NodeApiJsiRuntime::pushScope() {
 }
 
 void NodeApiJsiRuntime::popScope(jsi::Runtime::ScopeState *state) {
-  NodeApiEnvScope scope{getEnv()};
   popPointerValueScope();
   CHECK_NAPI(jsrApi_->napi_close_handle_scope(env_, reinterpret_cast<napi_handle_scope>(state)));
 }


### PR DESCRIPTION
Populate the beta branch with the Beta version of V8 (12.2). This version included additional checks for isolate entrance/exit consistency which we were failing before, because apparently we kept the Isolated "entered" all the time on the thread.

This change implies that we may create more than one Isolate (even on the same thread) so that's something to look out for (potential perf impact).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/189)