### PR TITLE
[0.74] Implement support for RN 0.74

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.75.1",
+    "version":  "0.74.1",
     "v8ref":  "refs/branch-heads/12.1",
     "buildNumber":  "285"
 }

--- a/src/jsi/jsi.h
+++ b/src/jsi/jsi.h
@@ -30,7 +30,7 @@
 // JSI version defines set of features available in the API.
 // Each significant API change must be under a new version.
 #ifndef JSI_VERSION
-#define JSI_VERSION 12
+#define JSI_VERSION 11
 #endif
 
 #if JSI_VERSION >= 3


### PR DESCRIPTION
In this change we default JSI version to 11 and change the release version to 0.74.1.
The PR goes to the new `0.74-stable` branch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/191)