### PR TITLE
[0.74] Trigger new build, and make publish build more robust to failures

### DIFF
--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -2,63 +2,67 @@ parameters:
   - name: isPublish
     type: boolean
     default : false
+  - name: BuildMatrix
+    type: object
+    default : 
+      - Name: Desktop|x64|Debug
+        BuildConfiguration: Debug
+        BuildPlatform: x64
+        AppPlatform: win32
+      - Name: Desktop|x86|Debug:
+        BuildConfiguration: Debug
+        BuildPlatform: x86
+        AppPlatform: win32
+      - Name: Desktop|ARM64|Debug:
+        BuildConfiguration: Debug
+        BuildPlatform: arm64
+        AppPlatform: win32
+      - Name: Desktop|x64|Release:
+        BuildConfiguration: Release
+        BuildPlatform: x64
+        AppPlatform: win32
+      - Name: Desktop|x86|Release:
+        BuildConfiguration: Release
+        BuildPlatform: x86
+        AppPlatform: win32
+      - Name: Desktop|ARM64|Release:
+        BuildConfiguration: Release
+        BuildPlatform: arm64
+        AppPlatform: win32
 
 jobs:
-  - job: V8JsiBuild
-    timeoutInMinutes: 300
-    variables:
-      - name: Packaging.EnableSBOMSigning
-        value: ${{ startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft') }}
-    displayName: Build v8jsi.dll
-    strategy:
-      matrix:
-        Desktop|x64|Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x64
-          AppPlatform: win32
-        Desktop|x86|Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x86
-          AppPlatform: win32
-        Desktop|ARM64|Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: arm64
-          AppPlatform: win32
-        Desktop|x64|Release:
-          BuildConfiguration: Release
-          BuildPlatform: x64
-          AppPlatform: win32
-        Desktop|x86|Release:
-          BuildConfiguration: Release
-          BuildPlatform: x86
-          AppPlatform: win32
-        Desktop|ARM64|Release:
-          BuildConfiguration: Release
-          BuildPlatform: arm64
-          AppPlatform: win32
-    ${{ if parameters.isPublish }}:
-      templateContext:
-        outputs:
-          - output: buildArtifacts
-            PathtoPublish: $(Build.ArtifactStagingDirectory)
-            ArtifactName: V8Jsi
-    steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.x'
-          addToPath: true
-          architecture: 'x64'
 
-      - template: windows-build.yml
-        parameters:
-          outputPath: $(Build.ArtifactStagingDirectory)
-          appPlatform: $(AppPlatform)
-          isPublish: ${{ parameters.isPublish }}
+  - ${{ each matrix in parameters.BuildMatrix }}:
+    - job: V8JsiBuild$ {{ matrix.Name }}
+      timeoutInMinutes: 300
+      variables:
+        - name: Packaging.EnableSBOMSigning
+          value: ${{ startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft') }}
+      displayName: Build v8jsi.dll
+      ${{ if parameters.isPublish }}:
+        templateContext:
+          outputs:
+            - output: buildArtifacts
+              PathtoPublish: $(Build.ArtifactStagingDirectory)
+              ArtifactName: V8Jsi
+      steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.x'
+            addToPath: true
+            architecture: 'x64'
+
+        - template: windows-build.yml
+          parameters:
+            outputPath: $(Build.ArtifactStagingDirectory)
+            appPlatform: $(AppPlatform)
+            isPublish: ${{ parameters.isPublish }}
 
   - job: V8JsiPublishNuget
     condition: not(eq(variables['Build.Reason'], 'PullRequest'))
     dependsOn:
-      - V8JsiBuild
+      - ${{ each matrix in parameters.BuildMatrix }}:
+        - V8JsiBuild$ {{ matrix.Name }}
     displayName: Publish Nuget
     ${{ if parameters.isPublish }}:
       templateContext:

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -9,23 +9,23 @@ parameters:
         BuildConfiguration: Debug
         BuildPlatform: x64
         AppPlatform: win32
-      - Name: Desktop|x86|Debug:
+      - Name: Desktop|x86|Debug
         BuildConfiguration: Debug
         BuildPlatform: x86
         AppPlatform: win32
-      - Name: Desktop|ARM64|Debug:
+      - Name: Desktop|ARM64|Debug
         BuildConfiguration: Debug
         BuildPlatform: arm64
         AppPlatform: win32
-      - Name: Desktop|x64|Release:
+      - Name: Desktop|x64|Release
         BuildConfiguration: Release
         BuildPlatform: x64
         AppPlatform: win32
-      - Name: Desktop|x86|Release:
+      - Name: Desktop|x86|Release
         BuildConfiguration: Release
         BuildPlatform: x86
         AppPlatform: win32
-      - Name: Desktop|ARM64|Release:
+      - Name: Desktop|ARM64|Release
         BuildConfiguration: Release
         BuildPlatform: arm64
         AppPlatform: win32

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.74.1",
+    "version":  "0.74.2",
     "v8ref":  "refs/branch-heads/12.1",
     "buildNumber":  "285"
 }


### PR DESCRIPTION
the last publish build had a failure on some of its slices.  But it wasn't setup to cancel the final nuget job if any of the slices failed.  So it attempted to publish a partial nuget.

Unfortunately, retriggers cannot be kicked off, as they would rewrite the build artifacts.

This change should prevent the nuget from attempting to publish unless all the slices complete successfully.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/192)