### PR TITLE
Use CI image with VS 17.8

### DIFF
--- a/.ado/windows-ci.yml
+++ b/.ado/windows-ci.yml
@@ -31,9 +31,7 @@ extends:
   template: v1/Office.Official.PipelineTemplate.yml@OfficePipelineTemplates
   parameters:
     pool:
-      name: OE-OfficePublic
-      demands:
-        - ImageVersionOverride -equals 69.0.0
+      name: OEDevJeff-OfficePublic
 
     sdl:
       baseline:

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -34,7 +34,7 @@ jobs:
 
   - ${{ each matrix in parameters.BuildMatrix }}:
     - job: V8JsiBuild_${{ matrix.Name }}
-      timeoutInMinutes: 300
+      timeoutInMinutes: 1200
       variables:
         - name: Packaging.EnableSBOMSigning
           value: ${{ startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft') }}

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.75.2",
+    "version":  "0.75.3",
     "v8ref":  "refs/branch-heads/12.6",
     "buildNumber":  "1"
 }


### PR DESCRIPTION
The latest VS 17.10 fails to compile V8 code.
While VS team works on the fix, we must switch to a temporary CI image that uses VS 17.8.
We had to increase the timeout to 20 hours since the new image is much slower and it may take 14-15 hours to build some configurations.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/198)