### PR TITLE
[0.71] Use CI image with VS 17.8 and JSI version 10

### DIFF
--- a/.ado/windows-ci.yml
+++ b/.ado/windows-ci.yml
@@ -31,9 +31,7 @@ extends:
   template: v1/Office.Official.PipelineTemplate.yml@OfficePipelineTemplates
   parameters:
     pool:
-      name: OE-OfficePublic
-      demands:
-        - ImageVersionOverride -equals 69.0.0
+      name: OEDevJeff-OfficePublic
 
     sdl:
       baseline:

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -34,7 +34,7 @@ jobs:
 
   - ${{ each matrix in parameters.BuildMatrix }}:
     - job: V8JsiBuild_${{ matrix.Name }}
-      timeoutInMinutes: 300
+      timeoutInMinutes: 1200
       variables:
         - name: Packaging.EnableSBOMSigning
           value: ${{ startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft') }}

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.75.2",
+    "version":  "0.71.15",
     "v8ref":  "refs/branch-heads/12.6",
     "buildNumber":  "1"
 }

--- a/src/jsi/jsi.h
+++ b/src/jsi/jsi.h
@@ -30,7 +30,7 @@
 // JSI version defines set of features available in the API.
 // Each significant API change must be under a new version.
 #ifndef JSI_VERSION
-#define JSI_VERSION 12
+#define JSI_VERSION 10
 #endif
 
 #if JSI_VERSION >= 3


### PR DESCRIPTION
This PR backports PR #198 that enables a temporary CI image with 17.8.
It also creates a new release branch 0.71 that is currently used in Office code.
Comparing with the previous release 0.71.14 the new version includes:
- JSI related changes added in PR #190
- Upgrade V8 to  version 12.6 from 12.1 implemented in PR #196 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/199)