### PR TITLE
[0.71] Remove support for ARM64

### DIFF
--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -13,10 +13,6 @@ parameters:
         BuildConfiguration: Debug
         BuildPlatform: x86
         AppPlatform: win32
-      - Name: Desktop_ARM64_Debug
-        BuildConfiguration: Debug
-        BuildPlatform: arm64
-        AppPlatform: win32
       - Name: Desktop_x64_Release
         BuildConfiguration: Release
         BuildPlatform: x64
@@ -24,10 +20,6 @@ parameters:
       - Name: Desktop_x86_Release
         BuildConfiguration: Release
         BuildPlatform: x86
-        AppPlatform: win32
-      - Name: Desktop_ARM64_Release
-        BuildConfiguration: Release
-        BuildPlatform: arm64
         AppPlatform: win32
 
 jobs:


### PR DESCRIPTION
Our Nuget package currently exceeds 500Mb limit set for the ADO feeds.
In this PR we reduce its size by removing support for ARM64 binaries.

Office does not support ARM64 apps. It uses x64 emulation for ARM64.
The change must not affect consumption of V8 in Office.

For other scenarios, we target to restore ARM64 after we switch to the ABI-safe API and stop shipping Debug binaries.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/200)