### PR TITLE
Remove PDB files from Nuget and restore ARM64 build

### DIFF
--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -13,6 +13,10 @@ parameters:
         BuildConfiguration: Debug
         BuildPlatform: x86
         AppPlatform: win32
+      - Name: Desktop_ARM64_Debug
+        BuildConfiguration: Debug
+        BuildPlatform: arm64
+        AppPlatform: win32
       - Name: Desktop_x64_Release
         BuildConfiguration: Release
         BuildPlatform: x64
@@ -20,6 +24,10 @@ parameters:
       - Name: Desktop_x86_Release
         BuildConfiguration: Release
         BuildPlatform: x86
+        AppPlatform: win32
+      - Name: Desktop_ARM64_Release
+        BuildConfiguration: Release
+        BuildPlatform: arm64
         AppPlatform: win32
 
 jobs:

--- a/ReactNative.V8Jsi.Windows.nuspec
+++ b/ReactNative.V8Jsi.Windows.nuspec
@@ -11,7 +11,7 @@
     <repository type="git" url="$RepoUri$" commit="$CommitId$" />
   </metadata>
   <files>
-    <file src="$nugetroot$\lib\win32\**\*.*" target="lib\win32" exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\lib\win32\**\*.*" target="lib\win32" exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk;**\*.pdb" />
     <file src="$nugetroot$\build\**\*.*" target="build" exclude="**\*.targets" />
     <file src="$nugetroot$\build\native\ReactNative.V8Jsi.Windows.targets" target="build\native\ReactNative.V8Jsi.Windows.targets" />
     <file src="$nugetroot$\license\*.*" target="license"/>

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.71.15",
+    "version":  "0.71.16",
     "v8ref":  "refs/branch-heads/12.6",
     "buildNumber":  "1"
 }


### PR DESCRIPTION
We still need ARM64 bit sin Office.
This PR removes PDB files to reduce the Nuget package size.