### PR TITLE
[0.71] Revert code to use V8 12.1

### DIFF
--- a/.ado/windows-build.yml
+++ b/.ado/windows-build.yml
@@ -10,9 +10,7 @@ parameters:
   type: string
 - name: buildPlatform
   type: string
-- name: noSetup
-  type: boolean
-  default : false
+
 
 steps:
   - task: PowerShell@2
@@ -20,13 +18,8 @@ steps:
     inputs:
       targetType: filePath
       filePath: $(Build.SourcesDirectory)\scripts\download_depottools.ps1
-      ${{ if eq(parameters.noSetup, true) }}:
-        arguments:
-          -SourcesPath:$(Build.SourcesDirectory)
-          -NoSetup
-      ${{ else }}:
-        arguments:
-          -SourcesPath:$(Build.SourcesDirectory)
+      arguments:
+        -SourcesPath:$(Build.SourcesDirectory)
 
   - task: PowerShell@2
     displayName: Fetch the V8 source code and extra build tools
@@ -37,7 +30,6 @@ steps:
         -SourcesPath:$(Build.SourcesDirectory)
         -Configuration:${{parameters.buildConfiguration}}
         -AppPlatform:${{parameters.appPlatform}}
-    condition: not(${{parameters.noSetup}})
 
   - task: PowerShell@2
     displayName: Build code

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -4,11 +4,14 @@ parameters:
     default : false
   - name: BuildMatrix
     type: object
-    default :
-      # We build x86 along with x64
+    default : 
       - Name: Desktop_x64_Debug
         BuildConfiguration: Debug
         BuildPlatform: x64
+        AppPlatform: win32
+      - Name: Desktop_x86_Debug
+        BuildConfiguration: Debug
+        BuildPlatform: x86
         AppPlatform: win32
       - Name: Desktop_ARM64_Debug
         BuildConfiguration: Debug
@@ -18,12 +21,17 @@ parameters:
         BuildConfiguration: Release
         BuildPlatform: x64
         AppPlatform: win32
+      - Name: Desktop_x86_Release
+        BuildConfiguration: Release
+        BuildPlatform: x86
+        AppPlatform: win32
       - Name: Desktop_ARM64_Release
         BuildConfiguration: Release
         BuildPlatform: arm64
         AppPlatform: win32
 
 jobs:
+
   - ${{ each matrix in parameters.BuildMatrix }}:
     - job: V8JsiBuild_${{ matrix.Name }}
       timeoutInMinutes: 1200
@@ -51,17 +59,6 @@ jobs:
             buildConfiguration: ${{ matrix.BuildConfiguration }}
             buildPlatform: ${{ matrix.BuildPlatform }}
             isPublish: ${{ parameters.isPublish }}
-
-        # Build x86 in the same machine as x64 to save build time
-        - ${{ if eq(matrix.BuildPlatform, 'x64') }}:
-          - template: windows-build.yml
-            parameters:
-              outputPath: $(Build.ArtifactStagingDirectory)
-              appPlatform: ${{ matrix.AppPlatform }}
-              buildConfiguration: ${{ matrix.BuildConfiguration }}
-              buildPlatform: x86
-              isPublish: ${{ parameters.isPublish }}
-              noSetup: true
 
   - job: V8JsiPublishNuget
     condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))

--- a/ReactNative.V8Jsi.Windows.nuspec
+++ b/ReactNative.V8Jsi.Windows.nuspec
@@ -11,7 +11,7 @@
     <repository type="git" url="$RepoUri$" commit="$CommitId$" />
   </metadata>
   <files>
-    <file src="$nugetroot$\lib\win32\**\*.*" target="lib\win32" exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk;**\*.pdb" />
+    <file src="$nugetroot$\lib\win32\**\*.*" target="lib\win32" exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
     <file src="$nugetroot$\build\**\*.*" target="build" exclude="**\*.targets" />
     <file src="$nugetroot$\build\native\ReactNative.V8Jsi.Windows.targets" target="build\native\ReactNative.V8Jsi.Windows.targets" />
     <file src="$nugetroot$\license\*.*" target="license"/>

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.71.17",
-    "v8ref":  "refs/branch-heads/12.6",
+    "version":  "0.71.18",
+    "v8ref":  "refs/branch-heads/12.1",
     "buildNumber":  "1"
 }

--- a/scripts/patch/build.diff
+++ b/scripts/patch/build.diff
@@ -1,8 +1,8 @@
 diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
-index 89b4755ac..f358bd78b 100644
+index de1cd6efc..ed87ccb75 100644
 --- a/config/compiler/BUILD.gn
 +++ b/config/compiler/BUILD.gn
-@@ -1757,7 +1757,7 @@ config("default_warnings") {
+@@ -1758,7 +1758,7 @@ config("default_warnings") {
        # TODO(thakis): Remove this once
        # https://swiftshader-review.googlesource.com/c/SwiftShader/+/57968 has
        # rolled into angle.
@@ -10,8 +10,8 @@ index 89b4755ac..f358bd78b 100644
 +      # cflags += [ "/wd4244" ]
      }
    } else {
-     if ((is_apple || is_android) && !is_nacl) {
-@@ -2047,7 +2047,7 @@ config("no_chromium_code") {
+     if (is_apple && !is_nacl) {
+@@ -2045,7 +2045,7 @@ config("no_chromium_code") {
      }
      cflags += [
        "/wd4800",  # Disable warning when forcing value to bool.

--- a/scripts/patch/src.diff
+++ b/scripts/patch/src.diff
@@ -1,8 +1,8 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index c2c11c24ac..389b26a557 100644
+index f0976f97e5..c4f6a026cf 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -1530,7 +1530,7 @@ config("toolchain") {
+@@ -1511,7 +1511,7 @@ config("toolchain") {
    if (is_win) {
      cflags += [
        "/wd4245",  # Conversion with signed/unsigned mismatch.
@@ -11,7 +11,7 @@ index c2c11c24ac..389b26a557 100644
        "/wd4324",  # Padding structure due to alignment.
        "/wd4701",  # Potentially uninitialized local variable.
        "/wd4702",  # Unreachable code.
-@@ -1634,14 +1634,14 @@ config("toolchain") {
+@@ -1615,14 +1615,14 @@ config("toolchain") {
  
        "/wd4100",  # Unreferenced formal function parameter.
        "/wd4121",  # Alignment of a member was sensitive to packing.
@@ -29,7 +29,7 @@ index c2c11c24ac..389b26a557 100644
  
        # These are variable shadowing warnings that are new in VS2015. We
        # should work through these at some point -- they may be removed from
-@@ -1665,7 +1665,7 @@ config("toolchain") {
+@@ -1646,7 +1646,7 @@ config("toolchain") {
        "/wd4245",  # 'conversion' : conversion from 'type1' to 'type2',
                    # signed/unsigned mismatch
  
@@ -38,7 +38,7 @@ index c2c11c24ac..389b26a557 100644
                    # data
  
        "/wd4305",  # 'identifier' : truncation from 'type1' to 'type2'
-@@ -7337,26 +7337,6 @@ group("v8_python_base") {
+@@ -7147,26 +7147,6 @@ group("v8_python_base") {
    data = [ ".vpython3" ]
  }
  
@@ -65,7 +65,7 @@ index c2c11c24ac..389b26a557 100644
  # Targets we ensure work with gcc. The aim is to keep this list small to have
  # a fast overall compile time.
  group("v8_gcc_light") {
-@@ -7588,7 +7568,7 @@ v8_executable("d8") {
+@@ -7401,7 +7381,7 @@ v8_executable("d8") {
    }
  
    if (v8_correctness_fuzzer) {
@@ -74,7 +74,7 @@ index c2c11c24ac..389b26a557 100644
    }
  
    defines = []
-@@ -7891,3 +7871,9 @@ if (!build_with_chromium && v8_use_perfetto) {
+@@ -8096,3 +8076,9 @@ if (!build_with_chromium && v8_use_perfetto) {
      ]
    }
  }  # if (!build_with_chromium && v8_use_perfetto)
@@ -84,13 +84,12 @@ index c2c11c24ac..389b26a557 100644
 +    "jsi:v8jsi",
 +  ]
 +}
-\ No newline at end of file
 diff --git a/DEPS b/DEPS
-index 35a9c38e12..32aafe447c 100644
+index 529f54b59f..f0ecac5c0c 100644
 --- a/DEPS
 +++ b/DEPS
-@@ -751,6 +751,17 @@ hooks = [
-                Var('rbe_instance'),
+@@ -708,4 +708,15 @@ hooks = [
+                '--quiet',
                 ],
    },
 +  {
@@ -105,13 +104,11 @@ index 35a9c38e12..32aafe447c 100644
 +    ],
 +  },
  ]
- 
- recursedeps = [
 diff --git a/src/maglev/maglev-ir.h b/src/maglev/maglev-ir.h
-index 83c2eb3957..3101ad9d35 100644
+index 68a751b775..75277e0f7e 100644
 --- a/src/maglev/maglev-ir.h
 +++ b/src/maglev/maglev-ir.h
-@@ -2660,8 +2660,8 @@ class NodeTMixin : public Base {
+@@ -2335,8 +2335,8 @@ class NodeTMixin : public Base {
    template <typename... Args>
    explicit NodeTMixin(uint64_t bitfield, Args&&... args)
        : Base(bitfield, std::forward<Args>(args)...) {
@@ -122,7 +119,7 @@ index 83c2eb3957..3101ad9d35 100644
    }
  };
  
-@@ -2728,7 +2728,7 @@ class FixedInputNodeTMixin : public NodeTMixin<Base, Derived> {
+@@ -2403,7 +2403,7 @@ class FixedInputNodeTMixin : public NodeTMixin<Base, Derived> {
    template <typename... Args>
    explicit FixedInputNodeTMixin(uint64_t bitfield, Args&&... args)
        : NodeTMixin<Base, Derived>(bitfield, std::forward<Args>(args)...) {
@@ -132,15 +129,18 @@ index 83c2eb3957..3101ad9d35 100644
  };
  
 diff --git a/src/utils/allocation.cc b/src/utils/allocation.cc
-index b886de7ee8..9d449e4104 100644
+index dc8a3696fa..50bcba0a3b 100644
 --- a/src/utils/allocation.cc
 +++ b/src/utils/allocation.cc
-@@ -64,8 +64,7 @@ const int kAllocationTries = 2;
+@@ -64,8 +64,10 @@ const int kAllocationTries = 2;
  }  // namespace
  
  v8::PageAllocator* GetPlatformPageAllocator() {
 -  DCHECK_NOT_NULL(GetPageAllocatorInitializer()->page_allocator());
 -  return GetPageAllocatorInitializer()->page_allocator();
++  //DCHECK_NOT_NULL(GetPageAllocatorInitializer()->page_allocator());
++  //return GetPageAllocatorInitializer()->page_allocator();
++
 +  return V8::GetCurrentPlatform()->GetPageAllocator();
  }
  


### PR DESCRIPTION
We are experiencing issues with the v8jsi code after moving to V8 version 12.6.
The V8 compiler crashes in debug mode.

In this PR we:
- Rollback to V8 version 12.1.
- Add back PDB files to the Nuget package since it has smaller size again.
- Change back the build script to use one VM per platform/configuration. It improves the build speed.
- The new v8-jsi package version is set to 0.71.18
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/204)