### PR TITLE
[0.74] Fix Node-API based API shutdown sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ powershell ./localbuild.ps1 -NoSetup -Platform x86 -Configuration Release
 * Install minimal dependencies on the Debian VM: `sudo apt install lsb-release`
 * Make sure you have at least 15Gb of disk space on the drive where the WSL image lives (usually C:)
 * Build with `pwsh ./localbuild.ps1 -AppPlatform android`
-* If setup is completed succesfully, build incrementally with `pwsh ./localbuild.ps1 -AppPlatform android -NoSetup`
+* If setup is completed successfully, build incrementally with `pwsh ./localbuild.ps1 -AppPlatform android -NoSetup`
 
 ##### [EXPERIMENTAL!] Building on macOS
 * [Install PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.3) by running `brew install --cask powershell`
 * Build with `pwsh ./localbuild.ps1 -AppPlatform mac`
-* If setup is completed succesfully, build incrementally with `pwsh ./localbuild.ps1 -AppPlatform mac -NoSetup`
+* If setup is completed successfully, build incrementally with `pwsh ./localbuild.ps1 -AppPlatform mac -NoSetup`
 * **Note**: there are several test failures on macOS currently
 
 ### Out-of-sync issues

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.74.3",
+    "version":  "0.74.4",
     "v8ref":  "refs/branch-heads/12.1",
-    "buildNumber":  "1"
+    "buildNumber":  "285"
 }


### PR DESCRIPTION
Cherry pick PR #208 for the 0.71-stable branch. The original description:

Fixed the shutdown sequence for the Node-API based API.
- Rollback all 12.6 related changes in the V8Runtime.
- Delete V8RuntimeEnv instance only after all its Node-API environments are destroyed.

Related changes:
- Some typo fixes in the README.md

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/212)