### PR TITLE
Remove more unused code to avoid CG alerts.

### DIFF
--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -88,10 +88,13 @@ if ($AppPlatform -eq "linux") {
 }
 
 # Remove unused code
+Remove-Item -Recurse -Force (Join-Path $workpath "depot_tools\external_bin\gsutil")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8\test\test262\data\tools")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8\third_party\depot_tools\external_bin\gsutil")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8\third_party\perfetto")
+Remove-Item -Recurse -Force (Join-Path $workpath "v8\third_party\protobuf_chrome")
+Remove-Item -Recurse -Force (Join-Path $workpath "v8\bazel")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8\tools\clusterfuzz")
-Remove-Item -Recurse -Force (Join-Path $workpath "v8\tools\turbolizer")
-Remove-Item -Recurse -Force (Join-Path $workpath "v8\tools\package.json")
 Remove-Item -Recurse -Force (Join-Path $workpath "v8\tools\package-lock.json")
+Remove-Item -Recurse -Force (Join-Path $workpath "v8\tools\package.json")
+Remove-Item -Recurse -Force (Join-Path $workpath "v8\tools\turbolizer")


### PR DESCRIPTION
This PR removes several more unused folders prior to the build process to mitigate Component Governance alerts.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/213)