### PR TITLE
Update JSI to version 19

### DIFF
--- a/.ado/windows-release.yml
+++ b/.ado/windows-release.yml
@@ -65,7 +65,7 @@ extends:
           inputs:
             useDotNetTask: true
             packageParentPath: '$(Pipeline.Workspace)/published-packages'
-            packagesToPush: '$(Pipeline.Workspace)/published-packages/ReactNative.V8Jsi.Windows_FIXME.*.nupkg'
+            packagesToPush: '$(Pipeline.Workspace)/published-packages/ReactNative.V8Jsi.Windows.*.nupkg'
             nuGetFeedType: external
             publishFeedCredentials: 'Nuget - ms/react-native-public'
             externalEndpoint: 'Nuget - ms/react-native-public'
@@ -96,7 +96,7 @@ extends:
           inputs:
             useDotNetTask: true
             packageParentPath: '$(Pipeline.Workspace)/published-packages'
-            packagesToPush: '$(Pipeline.Workspace)/published-packages/ReactNative.V8Jsi.Windows_FIXME.*.nupkg'
+            packagesToPush: '$(Pipeline.Workspace)/published-packages/ReactNative.V8Jsi.Windows.*.nupkg'
             nuGetFeedType: external
             publishFeedCredentials: 'ES365-Office-Nuget-Package-Publisher'
             externalEndpoint: 'ES365-Office-Nuget-Package-Publisher'

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.75.5",
+    "version":  "0.79.0",
     "v8ref":  "refs/branch-heads/12.1",
     "buildNumber":  "285"
 }

--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -46,6 +46,13 @@ std::string JSStringToSTLString(v8::Isolate *isolate, v8::Local<v8::String> stri
   return result;
 }
 
+std::u16string JSStringToStlU16String(v8::Isolate *isolate, v8::Local<v8::String> string) {
+  int utf16Len = string->Length();
+  std::u16string result(utf16Len, '\0');
+  string->Write(isolate, reinterpret_cast<uint16_t *>(&result[0]), 0, utf16Len, v8::String::NO_NULL_TERMINATION);
+  return result;
+}
+
 namespace {
 
 // Extracts a C string from a V8 Utf8Value.
@@ -1091,16 +1098,37 @@ jsi::PropNameID V8Runtime::createPropNameIDFromUtf8(const uint8_t *utf8, size_t 
   IsolateLocker isolate_locker(this);
   v8::Local<v8::String> v8String;
   if (!v8::String::NewFromUtf8(
-           GetIsolate(), reinterpret_cast<const char *>(utf8), v8::NewStringType::kNormal, static_cast<int>(length))
+           GetIsolate(),
+           reinterpret_cast<const char *>(utf8),
+           v8::NewStringType::kInternalized,
+           static_cast<int>(length))
            .ToLocal(&v8String)) {
     std::stringstream strstream;
     strstream << "Unable to create property id: " << utf8;
     throw jsi::JSError(*this, strstream.str());
   }
 
-  auto res = make<jsi::PropNameID>(V8StringValue::make(GetIsolate(), v8::Local<v8::String>::Cast(v8String)));
+  auto res = make<jsi::PropNameID>(V8StringValue::make(GetIsolate(), v8String));
   return res;
 }
+
+#if JSI_VERSION >= 19
+jsi::PropNameID V8Runtime::createPropNameIDFromUtf16(const char16_t *utf16, size_t length) {
+  IsolateLocker isolate_locker(this);
+  v8::Local<v8::String> v8String;
+  if (!v8::String::NewFromTwoByte(
+           GetIsolate(),
+           reinterpret_cast<const uint16_t *>(utf16),
+           v8::NewStringType::kInternalized,
+           static_cast<int>(length))
+           .ToLocal(&v8String)) {
+    throw jsi::JSError(*this, "Unable to create UTF16 property id");
+  }
+
+  auto res = make<jsi::PropNameID>(V8StringValue::make(GetIsolate(), v8String));
+  return res;
+}
+#endif
 
 jsi::PropNameID V8Runtime::createPropNameIDFromString(const jsi::String &str) {
   IsolateLocker isolate_locker(this);
@@ -1140,6 +1168,24 @@ jsi::String V8Runtime::createStringFromUtf8(const uint8_t *str, size_t length) {
   jsi::String jsistr = make<jsi::String>(V8StringValue::make(GetIsolate(), v8string));
   return jsistr;
 }
+
+#if JSI_VERSION >= 19
+jsi::String V8Runtime::createStringFromUtf16(const char16_t *utf16, size_t length) {
+  IsolateLocker isolate_locker(this);
+  v8::Local<v8::String> v8string;
+  if (!v8::String::NewFromTwoByte(
+           GetIsolate(),
+           reinterpret_cast<const uint16_t *>(utf16),
+           v8::NewStringType::kNormal,
+           static_cast<int>(length))
+           .ToLocal(&v8string)) {
+    throw jsi::JSError(*this, "V8 UTF-16 string creation failed.");
+  }
+
+  jsi::String jsistr = make<jsi::String>(V8StringValue::make(GetIsolate(), v8string));
+  return jsistr;
+}
+#endif
 
 std::string V8Runtime::utf8(const jsi::String &str) {
   IsolateLocker isolate_locker(this);
@@ -1363,6 +1409,14 @@ jsi::HostFunctionType &V8Runtime::getHostFunction(const jsi::Function &obj) {
   std::abort();
 }
 
+#if JSI_VERSION >= 18
+jsi::Object V8Runtime::createObjectWithPrototype(const jsi::Value &prototype) {
+  IsolateLocker isolate_locker(this);
+  return make<jsi::Object>(
+      V8ObjectValue::make(GetIsolate(), v8::Object::New(GetIsolate(), valueReference(prototype), nullptr, nullptr, 0)));
+}
+#endif
+
 namespace {
 std::string getFunctionName(v8::Isolate *isolate, v8::Local<v8::Function> func) {
   std::string functionNameStr;
@@ -1497,9 +1551,49 @@ bool V8Runtime::instanceOf(const jsi::Object &o, const jsi::Function &f) {
   return objectRef(o)->InstanceOf(GetContextLocal(), objectRef(f)).ToChecked();
 }
 
+#if JSI_VERSION >= 17
+void V8Runtime::setPrototypeOf(const jsi::Object &object, const jsi::Value &prototype) {
+  IsolateLocker isolate_locker(this);
+  objectRef(object)->SetPrototype(GetContextLocal(), valueReference(prototype));
+}
+
+jsi::Value V8Runtime::getPrototypeOf(const jsi::Object &object) {
+  IsolateLocker isolate_locker(this);
+  return createValue(objectRef(object)->GetPrototype());
+}
+#endif
+
 #if JSI_VERSION >= 11
 void V8Runtime::setExternalMemoryPressure(const jsi::Object &obj, size_t amount) {
-  //    IsolateLocker isolate_locker(this);
+  // TODO: implement this
+}
+#endif
+
+#if JSI_VERSION >= 14
+std::u16string V8Runtime::utf16(const jsi::String &str) {
+  IsolateLocker isolate_locker(this);
+  return JSStringToStlU16String(GetIsolate(), stringRef(str));
+}
+
+std::u16string V8Runtime::utf16(const jsi::PropNameID &sym) {
+  IsolateLocker isolate_locker(this);
+  return JSStringToStlU16String(GetIsolate(), v8::Local<v8::String>::Cast(valueRef(sym)));
+}
+#endif
+
+#if JSI_VERSION >= 16
+void V8Runtime::getStringData(
+    const jsi::String &str,
+    void *ctx,
+    void (*cb)(void *ctx, bool ascii, const void *data, size_t num)) {
+  return Runtime::getStringData(str, ctx, cb);
+}
+
+void V8Runtime::getPropNameIdData(
+    const jsi::PropNameID &sym,
+    void *ctx,
+    void (*cb)(void *ctx, bool ascii, const void *data, size_t num)) {
+  return Runtime::getPropNameIdData(sym, ctx, cb);
 }
 #endif
 

--- a/src/jsi/CMakeLists.txt
+++ b/src/jsi/CMakeLists.txt
@@ -24,9 +24,6 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   list(APPEND jsi_compile_flags "/Qspectre")
   list(APPEND jsi_compile_flags "/sdl")
 endif()
-if (HERMES_ENABLE_BITCODE)
-  list(APPEND jsi_compile_flags "-fembed-bitcode")
-endif ()
 
 target_compile_options(jsi PRIVATE ${jsi_compile_flags})
 

--- a/src/jsi/JSIDynamic.cpp
+++ b/src/jsi/JSIDynamic.cpp
@@ -155,7 +155,7 @@ void dynamicFromValueShallow(
 folly::dynamic dynamicFromValue(
     Runtime& runtime,
     const Value& valueInput,
-    std::function<bool(const std::string&)> filterObjectKeys) {
+    const std::function<bool(const std::string&)>& filterObjectKeys) {
   std::vector<FromValue> stack;
   folly::dynamic ret;
 

--- a/src/jsi/JSIDynamic.h
+++ b/src/jsi/JSIDynamic.h
@@ -20,7 +20,7 @@ facebook::jsi::Value valueFromDynamic(
 folly::dynamic dynamicFromValue(
     facebook::jsi::Runtime& runtime,
     const facebook::jsi::Value& value,
-    std::function<bool(const std::string&)> filterObjectKeys = nullptr);
+    const std::function<bool(const std::string&)>& filterObjectKeys = nullptr);
 
 } // namespace jsi
 } // namespace facebook

--- a/src/jsi/README.md
+++ b/src/jsi/README.md
@@ -11,6 +11,15 @@ https://github.com/facebook/hermes repo.
 
 | Version | Commit Hash                                | Commit Description
 |--------:|:-------------------------------------------|------------------------------------------------------
+|      19 | `00a84e7bae9b8569e7b3f4118f4238544c67fe1b` | Add createFromUtf16 JSI method
+|      18 | `d0328097291aade7269b2879910e11c48c8fbeb1` | Add default implementation for Object.create(prototype)
+|      17 | `1012f891165e7dda3b51939b75bbc52e16e48a75` | Add default implementation for Object.getPrototypeOf and Object.setPrototypeOf
+|      16 | `215bbe6ddc75393332b74138205e7cf5ab874e4e` | Add default getStringData/getPropNameIdData implementation
+|      15 | `54e428c749358fb4aa25c6d7e2dcc3fc23b47124` | Let Pointer be nothrow-move-constructible
+|         | `c582a23d62505a00948f5aa49006f60f959f8df4` | Let PointerValue::invalidate() be noexcept
+|         | `b07ef4fc10dd53ad542f811040c820064c5ceb57` | Let Value be nothrow-move-constructible
+|      14 | `c98b00e88bb685e75b769be67919a23a7f03b2e0` | Add utf16 method to JSI
+|      13 | `077f2633dea36e1d0d18d6c4f114bf66e3ab74cf` | Add HeapSnapshotOptions for jsi::Instrumentation
 |      12 | `de9dfe408bc3f8715aef161c5fcec291fc6dacb2` | Add queueMicrotask method to JSI
 |         | `a699e87f995bc2f7193990ff36a57ec9cad940e5` | Make queueMicrotask pure virtual
 |      11 | `a1c168705f609c8f1ae800c60d88eb199154264b` | Add JSI method for setting external memory size

--- a/src/jsi/instrumentation.h
+++ b/src/jsi/instrumentation.h
@@ -25,6 +25,14 @@ namespace jsi {
 /// it modify the values of any jsi values in the heap (although GCs are fine).
 class JSI_EXPORT Instrumentation {
  public:
+#if JSI_VERSION >= 13
+  /// Additional options controlling what to include when capturing a heap
+  /// snapshot.
+  struct HeapSnapshotOptions {
+    bool captureNumericValue{false};
+  };
+#endif
+
   virtual ~Instrumentation() = default;
 
   /// Returns GC statistics as a JSON-encoded string, with an object containing
@@ -89,15 +97,35 @@ class JSI_EXPORT Instrumentation {
   /// \p os. The output is a JSON formatted string.
   virtual void stopHeapSampling(std::ostream& os) = 0;
 
+#if JSI_VERSION >= 13
+  /// Captures the heap to a file
+  ///
+  /// \param path to save the heap capture.
+  /// \param options additional options for what to capture.
+  virtual void createSnapshotToFile(
+      const std::string& path,
+      const HeapSnapshotOptions& options = {false}) = 0;
+#else
   /// Captures the heap to a file
   ///
   /// \param path to save the heap capture
   virtual void createSnapshotToFile(const std::string& path) = 0;
+#endif
 
+#if JSI_VERSION >= 13
+  /// Captures the heap to an output stream
+  ///
+  /// \param os output stream to write to.
+  /// \param options additional options for what to capture.
+  virtual void createSnapshotToStream(
+      std::ostream& os,
+      const HeapSnapshotOptions& options = {false}) = 0;
+#else
   /// Captures the heap to an output stream
   ///
   /// \param os output stream to write to.
   virtual void createSnapshotToStream(std::ostream& os) = 0;
+#endif
 
   /// If the runtime has been created to trace to a temp file, flush
   /// any unwritten parts of the trace of bridge traffic to the file,

--- a/src/jsi/jsi-inl.h
+++ b/src/jsi/jsi-inl.h
@@ -86,6 +86,12 @@ inline const Runtime::PointerValue* Runtime::getPointerValue(
   return value.data_.pointer.ptr_;
 }
 
+#if JSI_VERSION >= 17
+Value Object::getPrototype(Runtime& runtime) const {
+  return runtime.getPrototypeOf(*this);
+}
+#endif
+
 inline Value Object::getProperty(Runtime& runtime, const char* name) const {
   return getProperty(runtime, String::createFromAscii(runtime, name));
 }

--- a/src/jsi/jsi.cpp
+++ b/src/jsi/jsi.cpp
@@ -64,6 +64,150 @@ Value callGlobalFunction(Runtime& runtime, const char* name, const Value& arg) {
   return f.call(runtime, arg);
 }
 
+#if JSI_VERSION >= 14
+// Given a sequence of UTF8 encoded bytes, advance the input to past where a
+// 32-bit unicode codepoint as been decoded and return the codepoint. If the
+// UTF8 encoding is invalid, then return the value with the unicode replacement
+// character (U+FFFD). This decoder also relies on zero termination at end of
+// the input for bound checks.
+// \param input char pointer pointing to the current character
+// \return Unicode codepoint
+uint32_t decodeUTF8(const char*& input) {
+  uint32_t ch = (unsigned char)input[0];
+  if (ch <= 0x7f) {
+    input += 1;
+    return ch;
+  }
+  uint32_t ret;
+  constexpr uint32_t replacementCharacter = 0xFFFD;
+  if ((ch & 0xE0) == 0xC0) {
+    uint32_t ch1 = (unsigned char)input[1];
+    if ((ch1 & 0xC0) != 0x80) {
+      input += 1;
+      return replacementCharacter;
+    }
+    ret = ((ch & 0x1F) << 6) | (ch1 & 0x3F);
+    input += 2;
+    if (ret <= 0x7F) {
+      return replacementCharacter;
+    }
+  } else if ((ch & 0xF0) == 0xE0) {
+    uint32_t ch1 = (unsigned char)input[1];
+    if ((ch1 & 0x40) != 0 || (ch1 & 0x80) == 0) {
+      input += 1;
+      return replacementCharacter;
+    }
+    uint32_t ch2 = (unsigned char)input[2];
+    if ((ch2 & 0x40) != 0 || (ch2 & 0x80) == 0) {
+      input += 2;
+      return replacementCharacter;
+    }
+    ret = ((ch & 0x0F) << 12) | ((ch1 & 0x3F) << 6) | (ch2 & 0x3F);
+    input += 3;
+    if (ret <= 0x7FF) {
+      return replacementCharacter;
+    }
+  } else if ((ch & 0xF8) == 0xF0) {
+    uint32_t ch1 = (unsigned char)input[1];
+    if ((ch1 & 0x40) != 0 || (ch1 & 0x80) == 0) {
+      input += 1;
+      return replacementCharacter;
+    }
+    uint32_t ch2 = (unsigned char)input[2];
+    if ((ch2 & 0x40) != 0 || (ch2 & 0x80) == 0) {
+      input += 2;
+      return replacementCharacter;
+    }
+    uint32_t ch3 = (unsigned char)input[3];
+    if ((ch3 & 0x40) != 0 || (ch3 & 0x80) == 0) {
+      input += 3;
+      return replacementCharacter;
+    }
+    ret = ((ch & 0x07) << 18) | ((ch1 & 0x3F) << 12) | ((ch2 & 0x3F) << 6) |
+        (ch3 & 0x3F);
+    input += 4;
+    if (ret <= 0xFFFF) {
+      return replacementCharacter;
+    }
+    if (ret > 0x10FFFF) {
+      return replacementCharacter;
+    }
+  } else {
+    input += 1;
+    return replacementCharacter;
+  }
+  return ret;
+}
+
+// Given a valid 32-bit unicode codepoint, encode it as UTF-16 into the output.
+void encodeUTF16(std::u16string& out, uint32_t cp) {
+  if (cp < 0x10000) {
+    out.push_back((uint16_t)cp);
+    return;
+  }
+  cp -= 0x10000;
+  uint16_t highSurrogate = 0xD800 + ((cp >> 10) & 0x3FF);
+  out.push_back(highSurrogate);
+  uint16_t lowSurrogate = 0xDC00 + (cp & 0x3FF);
+  out.push_back(lowSurrogate);
+}
+
+// Convert the UTF8 encoded string into a UTF16 encoded string. If the
+// input is not valid UTF8, the replacement character (U+FFFD) is used to
+// represent the invalid sequence.
+std::u16string convertUTF8ToUTF16(const std::string& utf8) {
+  std::u16string ret;
+  const char* curr = utf8.data();
+  const char* end = curr + utf8.length();
+  while (curr < end) {
+    auto cp = decodeUTF8(curr);
+    encodeUTF16(ret, cp);
+  }
+  return ret;
+}
+#endif
+
+#if JSI_VERSION >= 19
+// Given a unsigned number, which is less than 16, return the hex character.
+inline char hexDigit(unsigned x) {
+  return x < 10 ? '0' + x : 'A' + (x - 10);
+}
+
+// Given a sequence of UTF 16 code units, return true if all code units are
+// ASCII characters
+bool isAllASCII(const char16_t* utf16, size_t length) {
+  for (const char16_t* e = utf16 + length; utf16 != e; ++utf16) {
+    if (*utf16 > 0x7F)
+      return false;
+  }
+  return true;
+}
+
+// Given a sequences of UTF 16 code units, return a string that explicitly
+// expresses the code units
+std::string getUtf16CodeUnitString(const char16_t* utf16, size_t length) {
+  // Every character will need 4 hex digits + the character escape "\u".
+  // Plus 2 character for the opening and closing single quote.
+  std::string s = std::string(6 * length + 2, 0);
+  s.front() = '\'';
+
+  for (size_t i = 0; i != length; ++i) {
+    char16_t ch = utf16[i];
+    size_t start = (6 * i) + 1;
+
+    s[start] = '\\';
+    s[start + 1] = 'u';
+
+    s[start + 2] = hexDigit((ch >> 12) & 0x000f);
+    s[start + 3] = hexDigit((ch >> 8) & 0x000f);
+    s[start + 4] = hexDigit((ch >> 4) & 0x000f);
+    s[start + 5] = hexDigit(ch & 0x000f);
+  }
+  s.back() = '\'';
+  return s;
+}
+#endif
+
 } // namespace
 
 Buffer::~Buffer() = default;
@@ -115,12 +259,26 @@ Instrumentation& Runtime::instrumentation() {
     void startHeapSampling(size_t) override {}
     void stopHeapSampling(std::ostream&) override {}
 
-    void createSnapshotToFile(const std::string&) override {
+#if JSI_VERSION >= 13
+    void createSnapshotToFile(
+        const std::string& /*path*/,
+        const HeapSnapshotOptions& /*options*/) override
+#else
+    void createSnapshotToFile(const std::string&) override
+#endif
+    {
       throw JSINativeException(
           "Default instrumentation cannot create a heap snapshot");
     }
 
-    void createSnapshotToStream(std::ostream&) override {
+#if JSI_VERSION >= 13
+    void createSnapshotToStream(
+        std::ostream& /*os*/,
+        const HeapSnapshotOptions& /*options*/) override
+#else
+    void createSnapshotToStream(std::ostream&) override
+#endif
+    {
       throw JSINativeException(
           "Default instrumentation cannot create a heap snapshot");
     }
@@ -161,7 +319,86 @@ Value Value::createFromJsonUtf8(
 }
 #endif
 
-Pointer& Pointer::operator=(Pointer&& other) {
+#if JSI_VERSION >= 19
+String Runtime::createStringFromUtf16(const char16_t* utf16, size_t length) {
+  if (isAllASCII(utf16, length)) {
+    std::string buffer(length, '\0');
+    for (size_t i = 0; i < length; ++i) {
+      buffer[i] = static_cast<char>(utf16[i]);
+    }
+    return createStringFromAscii(buffer.data(), length);
+  }
+  auto s = getUtf16CodeUnitString(utf16, length);
+  return global()
+      .getPropertyAsFunction(*this, "eval")
+      .call(*this, s)
+      .getString(*this);
+}
+
+PropNameID Runtime::createPropNameIDFromUtf16(
+    const char16_t* utf16,
+    size_t length) {
+  auto jsString = createStringFromUtf16(utf16, length);
+  return createPropNameIDFromString(jsString);
+}
+#endif
+
+#if JSI_VERSION >= 14
+std::u16string Runtime::utf16(const PropNameID& sym) {
+  auto utf8Str = utf8(sym);
+  return convertUTF8ToUTF16(utf8Str);
+}
+
+std::u16string Runtime::utf16(const String& str) {
+  auto utf8Str = utf8(str);
+  return convertUTF8ToUTF16(utf8Str);
+}
+#endif
+
+#if JSI_VERSION >= 16
+void Runtime::getStringData(
+    const jsi::String& str,
+    void* ctx,
+    void (*cb)(void* ctx, bool ascii, const void* data, size_t num)) {
+  auto utf16Str = utf16(str);
+  cb(ctx, false, utf16Str.data(), utf16Str.size());
+}
+
+void Runtime::getPropNameIdData(
+    const jsi::PropNameID& sym,
+    void* ctx,
+    void (*cb)(void* ctx, bool ascii, const void* data, size_t num)) {
+  auto utf16Str = utf16(sym);
+  cb(ctx, false, utf16Str.data(), utf16Str.size());
+}
+#endif
+
+#if JSI_VERSION >= 17
+void Runtime::setPrototypeOf(const Object& object, const Value& prototype) {
+  auto setPrototypeOfFn = global()
+                              .getPropertyAsObject(*this, "Object")
+                              .getPropertyAsFunction(*this, "setPrototypeOf");
+  setPrototypeOfFn.call(*this, object, prototype).asObject(*this);
+}
+
+Value Runtime::getPrototypeOf(const Object& object) {
+  auto setPrototypeOfFn = global()
+                              .getPropertyAsObject(*this, "Object")
+                              .getPropertyAsFunction(*this, "getPrototypeOf");
+  return setPrototypeOfFn.call(*this, object);
+}
+#endif
+
+#if JSI_VERSION >= 18
+Object Runtime::createObjectWithPrototype(const Value& prototype) {
+  auto createFn = global()
+                      .getPropertyAsObject(*this, "Object")
+                      .getPropertyAsFunction(*this, "create");
+  return createFn.call(*this, prototype).asObject(*this);
+}
+#endif
+
+Pointer& Pointer::operator=(Pointer&& other) JSI_NOEXCEPT_15 {
   if (ptr_) {
     ptr_->invalidate();
   }
@@ -236,7 +473,7 @@ Function Object::asFunction(Runtime& runtime) && {
   return std::move(*this).getFunction(runtime);
 }
 
-Value::Value(Value&& other) : Value(other.kind_) {
+Value::Value(Value&& other) JSI_NOEXCEPT_15 : Value(other.kind_) {
   if (kind_ == BooleanKind) {
     data_.boolean = other.data_.boolean;
   } else if (kind_ == NumberKind) {

--- a/src/jsi/test/testlib.cpp
+++ b/src/jsi/test/testlib.cpp
@@ -1584,6 +1584,213 @@ TEST_P(JSITest, UTF8ExceptionTest) {
   }
 }
 
+#if JSI_VERSION >= 14
+TEST_P(JSITest, UTF16ConversionTest) {
+  // This Runtime Decorator is used to test the conversion from UTF-8 to UTF-16
+  // in the default utf16 method for runtimes that do not provide their own
+  // utf16 implementation.
+  class UTF16RD : public RuntimeDecorator<Runtime, Runtime> {
+   public:
+    UTF16RD(Runtime& rt) : RuntimeDecorator(rt) {}
+
+    std::string utf8(const String&) override {
+      return utf8Str;
+    }
+
+    std::u16string utf16(const String& str) override {
+      return Runtime::utf16(str);
+    }
+
+    std::string utf8Str;
+  };
+
+  UTF16RD rd = UTF16RD(rt);
+  String str = String::createFromUtf8(rd, "placeholder");
+
+  rd.utf8Str = "foobar";
+  EXPECT_EQ(str.utf16(rd), u"foobar");
+
+  // 你 in UTF-8 encoding is 0xe4 0xbd 0xa0 and 好 is 0xe5 0xa5 0xbd
+  // 你 in UTF-16 encoding is 0x4f60 and 好 is 0x597d
+  rd.utf8Str = "\xe4\xbd\xa0\xe5\xa5\xbd";
+  EXPECT_EQ(str.utf16(rd), u"\x4f60\x597d");
+
+  // 👍 in UTF-8 encoding is 0xf0 0x9f 0x91 0x8d
+  // 👍 in UTF-16 encoding is 0xd83d 0xdc4d
+  rd.utf8Str = "\xf0\x9f\x91\x8d";
+  EXPECT_EQ(str.utf16(rd), u"\xd83d\xdc4d");
+
+  // String is foobar👍你好
+  rd.utf8Str = "foobar\xf0\x9f\x91\x8d\xe4\xbd\xa0\xe5\xa5\xbd";
+  EXPECT_EQ(str.utf16(rd), u"foobar\xd83d\xdc4d\x4f60\x597d");
+
+  // String ended before second byte of the encoding
+  rd.utf8Str = "\xcf";
+  EXPECT_EQ(str.utf16(rd), u"\uFFFD");
+
+  // Third byte should follow the pattern of 0b10xxxxxx
+  rd.utf8Str = "\xef\x8f\x29";
+  EXPECT_EQ(str.utf16(rd), u"\uFFFD\u0029");
+
+  // U+2200 should be encoded in 3 bytes as 0xE2 0x88 0x80, not 4 bytes
+  rd.utf8Str = "\xf0\x82\x88\x80";
+  EXPECT_EQ(str.utf16(rd), u"\uFFFD");
+
+  // Unicode Max Value is U+10FFFF, U+11FFFF is invalid
+  rd.utf8Str = "\xf4\x9f\xbf\xbf";
+  EXPECT_EQ(str.utf16(rd), u"\uFFFD");
+
+  // Missing the third byte of the 3-byte encoding, followed by 'z'
+  rd.utf8Str = "\xe1\xa0\x7a";
+  EXPECT_EQ(str.utf16(rd), u"\uFFFD\u007A");
+
+  // First byte is neither ASCII nor a valid continuation byte
+  rd.utf8Str = "\xea\x7a";
+  EXPECT_EQ(str.utf16(rd), u"\uFFFD\u007A");
+}
+#endif
+
+#if JSI_VERSION >= 19
+TEST_P(JSITest, CreateFromUtf16Test) {
+  // This Runtime Decorator is used to test the default createStringFromUtf16
+  // and createPropNameIDFromUtf16 implementation for VMs that do not provide
+  // their own implementation
+  class RD : public RuntimeDecorator<Runtime, Runtime> {
+   public:
+    RD(Runtime& rt) : RuntimeDecorator(rt) {}
+
+    String createStringFromUtf16(const char16_t* utf16, size_t length)
+        override {
+      return Runtime::createStringFromUtf16(utf16, length);
+    }
+
+    PropNameID createPropNameIDFromUtf16(const char16_t* utf16, size_t length)
+        override {
+      return Runtime::createPropNameIDFromUtf16(utf16, length);
+    }
+  };
+
+  RD rd = RD(rt);
+  std::u16string utf16 = u"foobar";
+
+  auto jsString = String::createFromUtf16(rd, utf16);
+  EXPECT_EQ(jsString.utf16(rd), utf16);
+  auto prop = PropNameID::forUtf16(rd, utf16);
+  EXPECT_EQ(prop.utf16(rd), utf16);
+
+  // 👋 in UTF-16 encoding is 0xd83d 0xdc4b
+  utf16 = u"hello!\xd83d\xdc4b";
+  jsString = String::createFromUtf16(rd, utf16.data(), utf16.length());
+  EXPECT_EQ(jsString.utf16(rd), utf16);
+  prop = PropNameID::forUtf16(rd, utf16);
+  EXPECT_EQ(prop.utf16(rd), utf16);
+
+  utf16 = u"\xd83d";
+  jsString = String::createFromUtf16(rd, utf16.data(), utf16.length());
+  /// We need to use charCodeAt instead of UTF16 because the default
+  /// implementation of UTF16 converts to UTF8, then to UTF16, so we will lose
+  /// the lone surrogate value.
+  rd.global().setProperty(rd, "loneSurrogate", jsString);
+  auto cp = eval("loneSurrogate.charCodeAt(0)").getNumber();
+  EXPECT_EQ(cp, 55357); // 0xD83D in decimal
+}
+#endif
+
+#if JSI_VERSION >= 16
+TEST_P(JSITest, GetStringDataTest) {
+  // This Runtime Decorator is used to test the default getStringData
+  // implementation for VMs that do not provide their own implementation
+  class RD : public RuntimeDecorator<Runtime, Runtime> {
+   public:
+    RD(Runtime& rt) : RuntimeDecorator(rt) {}
+
+    void getStringData(
+        const String& str,
+        void* ctx,
+        void (*cb)(void* ctx, bool ascii, const void* data, size_t num))
+        override {
+      Runtime::getStringData(str, ctx, cb);
+    }
+  };
+
+  RD rd = RD(rt);
+  // 👋 in UTF8 encoding is 0xf0 0x9f 0x91 0x8b
+  String str = String::createFromUtf8(rd, "hello\xf0\x9f\x91\x8b");
+
+  std::u16string buf;
+  auto cb = [&buf](bool ascii, const void* data, size_t num) {
+    assert(!ascii && "Default implementation is always utf16");
+    buf.append((const char16_t*)data, num);
+  };
+
+  str.getStringData(rd, cb);
+  EXPECT_EQ(buf, str.utf16(rd));
+}
+#endif
+
+#if JSI_VERSION >= 17
+TEST_P(JSITest, ObjectSetPrototype) {
+  // This Runtime Decorator is used to test the default implementation of
+  // Object.setPrototypeOf
+  class RD : public RuntimeDecorator<Runtime, Runtime> {
+   public:
+    explicit RD(Runtime& rt) : RuntimeDecorator(rt) {}
+
+    void setPrototypeOf(const Object& object, const Value& prototype) override {
+      return Runtime::setPrototypeOf(object, prototype);
+    }
+
+    Value getPrototypeOf(const Object& object) override {
+      return Runtime::getPrototypeOf(object);
+    }
+  };
+
+  RD rd = RD(rt);
+  Object child(rd);
+
+  // Tests null value as prototype
+  child.setPrototype(rd, Value::null());
+  EXPECT_TRUE(child.getPrototype(rd).isNull());
+
+  Object prototypeObj(rd);
+  prototypeObj.setProperty(rd, "someProperty", 123);
+  Value prototype(rd, prototypeObj);
+
+  child.setPrototype(rd, prototype);
+  EXPECT_EQ(child.getProperty(rd, "someProperty").getNumber(), 123);
+
+  auto getPrototypeRes = child.getPrototype(rd).asObject(rd);
+  EXPECT_EQ(getPrototypeRes.getProperty(rd, "someProperty").getNumber(), 123);
+}
+#endif
+
+#if JSI_VERSION >= 18
+TEST_P(JSITest, ObjectCreateWithPrototype) {
+  // This Runtime Decorator is used to test the default implementation of
+  // Object.create(prototype)
+  class RD : public RuntimeDecorator<Runtime, Runtime> {
+   public:
+    RD(Runtime& rt) : RuntimeDecorator(rt) {}
+
+    Object createObjectWithPrototype(const Value& prototype) override {
+      return Runtime::createObjectWithPrototype(prototype);
+    }
+  };
+
+  RD rd = RD(rt);
+  Object prototypeObj(rd);
+  prototypeObj.setProperty(rd, "someProperty", 123);
+  Value prototype(rd, prototypeObj);
+
+  Object child = Object::create(rd, prototype);
+  EXPECT_EQ(child.getProperty(rd, "someProperty").getNumber(), 123);
+
+  // Tests null value as prototype
+  child = Object::create(rd, Value::null());
+  EXPECT_TRUE(child.getPrototype(rd).isNull());
+}
+#endif
+
 INSTANTIATE_TEST_CASE_P(
     Runtimes,
     JSITest,


### PR DESCRIPTION
In the last few months JSI had a number of changes in the Hermes repo.
We assigned a new version to each JSI change commit.
This PR merges changes up to the JSI version 19 and implements new methods in the V8 JSI API and the JSI for Node-API.
The v8-jsi version is changed to 0.79.0 that corresponds to the RN version 0.79 that was still in main when the JSI updates were captured.

Also, this PR fixes the Release pipeline script.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/215)