### PR TITLE
Update build and release pipelines and fix tests

### DIFF
--- a/.ado/windows-build.yml
+++ b/.ado/windows-build.yml
@@ -3,16 +3,22 @@ parameters:
   type: string
 - name: outputPath
   type: string
+  # isPublish is `true` for CI builds and `false` for PR validation.
 - name: isPublish
   type: boolean
-  default : false
+  default: false
 - name: buildConfiguration
   type: string
 - name: buildPlatform
   type: string
+  # To fake building v8-jsi for faster debugging.
+- name: fakeBuild
+  type: boolean
+  default: false
 
 
 steps:
+- ${{ if eq(parameters.fakeBuild, false) }}:
   - task: PowerShell@2
     displayName: Download and extract depot_tools.zip
     inputs:
@@ -31,18 +37,20 @@ steps:
         -Configuration:${{parameters.buildConfiguration}}
         -AppPlatform:${{parameters.appPlatform}}
 
-  - task: PowerShell@2
-    displayName: Build code
-    inputs:
-      targetType: filePath
-      filePath: $(Build.SourcesDirectory)\scripts\build.ps1
-      arguments:
-        -OutputPath:${{parameters.outputPath}}
-        -SourcesPath:$(Build.SourcesDirectory)
-        -Platform:${{parameters.buildPlatform}}
-        -Configuration:${{parameters.buildConfiguration}}
-        -AppPlatform:${{parameters.appPlatform}}
+- task: PowerShell@2
+  displayName: Build code
+  inputs:
+    targetType: filePath
+    filePath: $(Build.SourcesDirectory)\scripts\build.ps1
+    arguments:
+      -OutputPath:${{parameters.outputPath}}
+      -SourcesPath:$(Build.SourcesDirectory)
+      -Platform:${{parameters.buildPlatform}}
+      -Configuration:${{parameters.buildConfiguration}}
+      -AppPlatform:${{parameters.appPlatform}}
+      -FakeBuild:$${{parameters.fakeBuild}}
 
+- ${{ if eq(parameters.fakeBuild, false) }}:
   - script: |
       dir build\v8\buildtools\reclient\scandeps_server.exe
       taskkill -f -im scandeps_server.exe
@@ -90,37 +98,3 @@ steps:
       collectDumpOn: onAbortOnly
       vsTestVersion: latest
     condition: and(succeeded(), not(startsWith('${{parameters.buildPlatform}}', 'arm')))
-
-  - ${{ if not(parameters.isPublish) }}:
-    - task: ComponentGovernanceComponentDetection@0
-      inputs:
-        ignoreDirectories: 'build\depot_tools'
-  
-    - script: mkdir ${{parameters.outputPath}}\_manifest\${{parameters.buildPlatform}}\${{parameters.buildConfiguration}}
-      displayName: 📒 Prep Manifest
-  
-    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: 📒 Generate Manifest
-      inputs:
-        BuildDropPath: ${{parameters.outputPath}}
-        ManifestDirPath: ${{parameters.outputPath}}\_manifest\${{parameters.buildPlatform}}\${{parameters.buildConfiguration}}
-  
-    # Guardian does not handle custom builds, so manually running Binskim
-    - task: BinSkim@3
-      displayName: Run Binskim Analysis
-      inputs:
-          InputType: 'Basic'
-          Function: 'analyze'
-          AnalyzeTarget: $(Build.ArtifactStagingDirectory)/**/*.dll
-          AnalyzeVerbose: true
-          toolVersion: 'LatestPreRelease'
-      continueOnError: true
-      condition: and(succeeded(), and(eq('${{parameters.buildConfiguration}}', 'Release'), not(eq('${{parameters.buildPlatform}}', 'arm64'))))
-  
-    - task: PublishBuildArtifacts@1
-      displayName: "Publish artifacts"
-      inputs:
-        artifactName: V8Jsi
-        pathtoPublish: ${{parameters.outputPath}}
-  
-    - task: ComponentGovernanceComponentDetection@0

--- a/.ado/windows-ci.yml
+++ b/.ado/windows-ci.yml
@@ -1,22 +1,8 @@
-name: v8jsi_win_ci_0.0.$(Date:yyMM.d)$(Rev:rrr)
+name: v8jsi_ci_0.0.$(Date:yyMM.d)$(Rev:rrr)
 
+# The triggers are overridden by the ADO pipeline definitions.
+trigger: none
 pr: none
-trigger:
-  branches:
-    include:
-      - master
-      - "*-stable"
-  paths:
-    exclude:
-      - README.md
-      - docs/*
-
-resources:
-  repositories:
-  - repository: OfficePipelineTemplates
-    type: git
-    name: 1ESPipelineTemplates/OfficePipelineTemplates
-    ref: refs/tags/release
 
 variables:
   - group: V8-Jsi Secrets
@@ -28,27 +14,9 @@ variables:
     value: production,externalfacing
 
 extends:
-  template: v1/Office.Official.PipelineTemplate.yml@OfficePipelineTemplates
+  template: windows-jobs.yml@self
   parameters:
-    pool:
-      name: OEDevJeff-OfficePublic
-
-    sdl:
-      baseline:
-        baselineFile: $(Build.SourcesDirectory)\.ado\guardian\SDL\.gdnbaselines
-      eslint:
-        enableExclusions: true
-        # This repo does not ship any javascript code. But has many test cases for the js engine that fail parsing, have code considered insecure and crash eslint.
-        exclusionPatterns: |
-          '**/*.[jt]s'
-      codeql:
-        compiled:
-          enabled: true
-        runSourceLanguagesInSourceAnalysis: true
-
-    stages:
-    - stage: main
-      jobs:
-      - template: .ado/windows-jobs.yml@self
-        parameters:
-          isPublish: true
+    # CI builds must pass true.
+    isPublish: true
+    # It must be false for real builds. Use true only for the build pipeline debugging.
+    fakeBuild: false

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -1,10 +1,16 @@
 parameters:
+    # isPublish is `true` for CI builds and `false` for PR validation.
   - name: isPublish
     type: boolean
-    default : false
+    default: false
+    # To fake building v8-jsi for faster debugging.
+  - name: fakeBuild
+    type: boolean
+    default: false
+    # Matrix with target platforms for v8-jsi binaries.
   - name: BuildMatrix
     type: object
-    default : 
+    default:
       - Name: Desktop_x64_Debug
         BuildConfiguration: Debug
         BuildPlatform: x64
@@ -30,106 +36,224 @@ parameters:
         BuildPlatform: arm64
         AppPlatform: win32
 
-jobs:
+resources:
+  repositories:
+    # The repo for the Office compliant build pipeline templates.
+  - repository: OfficePipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/OfficePipelineTemplates
+    ref: refs/tags/release
 
-  - ${{ each matrix in parameters.BuildMatrix }}:
-    - job: V8JsiBuild_${{ matrix.Name }}
-      timeoutInMinutes: 1200
-      variables:
-        - name: Packaging.EnableSBOMSigning
-          value: ${{ startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft') }}
-      displayName: 'Build v8jsi.dll ${{ matrix.BuildPlatform }} ${{ matrix.BuildConfiguration }}'
-      ${{ if parameters.isPublish }}:
+extends:
+  # Extend the Office compliant build pipeline template.
+  ${{ if eq(parameters.isPublish, true) }}:
+    template: v1/Office.Official.PipelineTemplate.yml@OfficePipelineTemplates
+  ${{ else }}:
+    template: v1/Office.Unofficial.PipelineTemplate.yml@OfficePipelineTemplates
+
+  parameters:
+    settings:
+      ${{ if eq(parameters.isPublish, false) }}:
+        skipBuildTagsForGitHubPullRequests: true
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-latest
+      os: windows
+    sdl:
+      binskim:
+        analyzeTarget: |
+          $(Build.StagingDirectory)\out\pkg-staging\**\*.dll
+          $(Build.StagingDirectory)\out\pkg-staging\**\*.exe
+      componentgovernance:
+        ignoreDirectories: $(Build.SourcesDirectory)\website
+      eslint:
+        enableExclusions: true
+        # This repo does not ship any JavaScript code. But it has many test cases for
+        # the Hermes JS engine that fail parsing, have code considered insecure and crash eslint.
+        exclusionPatterns: |
+          '**/*.*'
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\.ado\guardian\SDL\.gdnsuppress
+      codeql:
+        compiled:
+          enabled: true
+        runSourceLanguagesInSourceAnalysis: true
+
+    stages:
+    - stage: main
+      jobs:
+      - ${{ each matrix in parameters.BuildMatrix }}:
+        - job: V8JsiBuild_${{ matrix.Name }}
+          displayName: Build V8-JSI ${{ matrix.Name }}
+
+          timeoutInMinutes: 1200
+
+          variables:
+          - name: Packaging.EnableSBOMSigning
+            value: ${{ startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft') }}
+
+          templateContext:
+            outputs:
+              # The base template takes care of publishing the artifacts.
+            - output: pipelineArtifact
+              artifactName: ${{ matrix.Name }}
+              targetPath: $(Build.StagingDirectory)\out\pkg-staging
+
+          steps:
+          - task: UsePythonVersion@0
+            displayName: Use Python 3.x
+            inputs:
+              versionSpec: '3.x'
+              addToPath: true
+              architecture: 'x64'
+
+          - template: /.ado/windows-build.yml@self
+            parameters:
+              outputPath: $(Build.StagingDirectory)\out\pkg-staging
+              appPlatform: ${{ matrix.AppPlatform }}
+              buildConfiguration: ${{ matrix.BuildConfiguration }}
+              buildPlatform: ${{ matrix.BuildPlatform }}
+              isPublish: ${{ parameters.isPublish }}
+              fakeBuild: ${{ parameters.fakeBuild }}
+
+            # Sign binaries only for the non-fake CI builds.
+          - ${{ if and(eq(parameters.isPublish, true), eq(parameters.fakeBuild, false)) }}:
+            - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+              displayName: CodeSign Binaries
+              inputs:
+                connectedServiceName: 'ESRP-JSHost3'
+                appRegistrationClientId: '0a35e01f-eadf-420a-a2bf-def002ba898d'
+                appRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
+                authAKVName: 'OGX-JSHost-KV'
+                authCertName: 'OGX-JSHost-Auth4'
+                authSignCertName: 'OGX-JSHost-Sign3'
+                folderPath: $(Build.StagingDirectory)\out\pkg-staging
+                # Recursively finds files matching these patterns:
+                pattern: |
+                  **\v8jsi.dll
+                useMinimatch: true
+                signConfigType: inlineSignParams
+                inlineOperation: |
+                  [
+                    {
+                      "KeyCode" : "CP-230012",
+                      "OperationCode" : "SigntoolSign",
+                      "Parameters" : {
+                        "OpusName" : "Microsoft",
+                        "OpusInfo" : "http://www.microsoft.com",
+                        "FileDigest" : "/fd \"SHA256\"",
+                        "PageHash" : "/NPH",
+                        "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                      },
+                      "ToolName" : "sign",
+                      "ToolVersion" : "1.0"
+                    },
+                    {
+                      "KeyCode" : "CP-230012",
+                      "OperationCode" : "SigntoolVerify",
+                      "Parameters" : {},
+                      "ToolName" : "sign",
+                      "ToolVersion" : "1.0"
+                    }
+                  ]
+
+      - job: V8JsiCreateNuget
+        dependsOn:
+        - ${{ each matrix in parameters.BuildMatrix }}:
+          - V8JsiBuild_${{ matrix.Name }}
+        displayName: Create Nuget
+
         templateContext:
           outputs:
-            - output: buildArtifacts
-              PathtoPublish: $(Build.ArtifactStagingDirectory)
-              ArtifactName: V8Jsi
-      steps:
-        - task: UsePythonVersion@0
-          inputs:
-            versionSpec: '3.x'
-            addToPath: true
-            architecture: 'x64'
-
-        - template: windows-build.yml
-          parameters:
-            outputPath: $(Build.ArtifactStagingDirectory)
-            appPlatform: ${{ matrix.AppPlatform }}
-            buildConfiguration: ${{ matrix.BuildConfiguration }}
-            buildPlatform: ${{ matrix.BuildPlatform }}
-            isPublish: ${{ parameters.isPublish }}
-
-  - job: V8JsiPublishNuget
-    condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
-    dependsOn:
-      - ${{ each matrix in parameters.BuildMatrix }}:
-        - V8JsiBuild_${{ matrix.Name }}
-    displayName: Publish Nuget
-    ${{ if parameters.isPublish }}:
-      templateContext:
-        outputs:
+            # The base template takes care of publishing the artifacts.
           - output: pipelineArtifact
-            targetPath: $(System.DefaultWorkingDirectory)\NugetRootFinal
-            artifactName: "V8Jsi-final-nuget"
+            targetPath: $(Build.StagingDirectory)\out\pkg
+            artifactName: published-packages
 
-    steps:
-      - checkout: none
+        steps:
+        - checkout: none
 
-      - task: NuGetToolInstaller@0
-        inputs:
-          versionSpec: ">=4.6.0"
-
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Build outputs
-        inputs:
-          artifactName: V8Jsi
-          downloadPath: $(System.DefaultWorkingDirectory)
-
-      # Make symbols available through http://symweb.
-      - task: PublishSymbols@2
-        displayName: Publish symbols
-        inputs:
-          UseNetCoreClientTool: true
-          SearchPattern: $(System.DefaultWorkingDirectory)/**/*.pdb
-          SymbolServerType: TeamServices
-
-      - task: PowerShell@2
-        displayName: Set version variables
-        inputs:
-          targetType: 'inline'
-          script: |
-            $config = Get-Content (Join-Path $(System.DefaultWorkingDirectory) "V8Jsi\config.json") | ConvertFrom-Json
-            $Version = $config.version
-            Write-Host "##vso[task.setvariable variable=Version]$Version"
-            Write-Host "##vso[task.setvariable variable=VersionDetails]V8 version: $Version; Git revision: $(Build.SourceVersion)"
-
-      - task: NuGetCommand@2
-        displayName: 'NuGet Pack'
-        inputs:
-          command: pack
-          packagesToPack: $(System.DefaultWorkingDirectory)\V8Jsi\ReactNative.V8Jsi.Windows.nuspec
-          packDestination: $(System.DefaultWorkingDirectory)\NugetRootFinal
-          buildProperties: CommitId=$(Build.SourceVersion);nugetroot=$(System.DefaultWorkingDirectory)\V8Jsi;RepoUri=$(Build.Repository.Uri);VersionDetails=$(VersionDetails)
-          versioningScheme: byEnvVar
-          versionEnvVar: Version
-          includeSymbols: false
-
-      - pwsh: |
-          if ((Get-ChildItem $(System.DefaultWorkingDirectory)\NugetRootFinal\*nupkg).Count -lt 1) {
-            Write-Error 'No NUPKG generated'
-          }
-        displayName: Verify NuGet packages creation
-
-      - ${{ if not(parameters.isPublish) }}:
-        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-          displayName: 📒 Generate Manifest NuGet
-          condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
+          # The substitution tags in the nuspec require that we use at least NuGet 4.6.
+        - task: NuGetToolInstaller@0
+          displayName: Install NuGet tools
           inputs:
-            BuildDropPath: $(System.DefaultWorkingDirectory)\NugetRootFinal
+            versionSpec: ">=4.6.0"
 
-        - task: PublishBuildArtifacts@1
-          displayName: "Publish final nuget artifacts"
+          # Download v8-jsi binaries built in previous jobs.
+        - ${{ each matrix in parameters.BuildMatrix }}:
+          - task: DownloadPipelineArtifact@2
+            displayName: Download ${{ matrix.Name }} v8-jsi artifacts
+            inputs:
+              artifact: ${{ matrix.Name }}
+              path: $(Build.StagingDirectory)\out\pkg-staging
+
+          # Publish symbols only for the non-fake CI builds.
+        - ${{ if and(eq(parameters.isPublish, true), eq(parameters.fakeBuild, false)) }}:
+            # Make symbols available through http://symweb.
+          - task: PublishSymbols@2
+            displayName: Publish symbols
+            inputs:
+              UseNetCoreClientTool: true
+              SearchPattern: $(Build.StagingDirectory)\out\pkg-staging\**\*.pdb
+              SymbolServerType: TeamServices
+
+        - task: PowerShell@2
+          displayName: Set version variables
           inputs:
-            PathtoPublish: $(System.DefaultWorkingDirectory)\NugetRootFinal
-            ArtifactName: "V8Jsi-final-nuget"
+            targetType: 'inline'
+            script: |
+              $config = Get-Content $(Build.StagingDirectory)\out\pkg-staging\config.json | ConvertFrom-Json
+              $Version = $config.version
+              Write-Host "##vso[task.setvariable variable=Version]$Version"
+              Write-Host "##vso[task.setvariable variable=VersionDetails]V8 version: $Version; Git revision: $(Build.SourceVersion)"
+
+        - task: NuGetCommand@2
+          displayName: 'NuGet Pack'
+          inputs:
+            command: pack
+            packagesToPack: $(Build.StagingDirectory)\out\pkg-staging\ReactNative.V8Jsi.Windows.nuspec
+            packDestination: $(Build.StagingDirectory)\out\pkg
+            buildProperties: CommitId=$(Build.SourceVersion);nugetroot=$(Build.StagingDirectory)\out\pkg-staging;RepoUri=$(Build.Repository.Uri);VersionDetails=$(VersionDetails)
+            versioningScheme: byEnvVar
+            versionEnvVar: Version
+            includeSymbols: false
+
+        - pwsh: |
+            if ((Get-ChildItem $(Build.StagingDirectory)\out\pkg\*nupkg).Count -lt 1) {
+              Write-Error 'No NUPKG generated'
+            }
+          displayName: Verify NuGet packages creation
+
+          # Sign the NuGet packages only for the CI builds.
+        - ${{ if parameters.isPublish }}:
+          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+            displayName: CodeSign NuGets
+            inputs:
+              connectedServiceName: 'ESRP-JSHost3'
+              appRegistrationClientId: '0a35e01f-eadf-420a-a2bf-def002ba898d'
+              appRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
+              authAKVName: 'OGX-JSHost-KV'
+              authCertName: 'OGX-JSHost-Auth4'
+              authSignCertName: 'OGX-JSHost-Sign3'
+              folderPath: $(Build.StagingDirectory)\out\pkg
+              pattern: |
+                ReactNative.V8Jsi.Windows.*.nupkg
+              useMinimatch: true
+              signConfigType: inlineSignParams
+              inlineOperation: |
+                [
+                  {
+                    "KeyCode" : "CP-401405",
+                    "OperationCode" : "NuGetSign",
+                    "Parameters" : {},
+                    "ToolName" : "sign",
+                    "ToolVersion" : "1.0"
+                  },
+                  {
+                    "KeyCode" : "CP-401405",
+                    "OperationCode" : "NuGetVerify",
+                    "Parameters" : {},
+                    "ToolName" : "sign",
+                    "ToolVersion" : "1.0"
+                  }
+                ]

--- a/.ado/windows-pr.yml
+++ b/.ado/windows-pr.yml
@@ -1,8 +1,9 @@
 name: v8jsi_pr_0.0.$(Date:yyMM.d)$(Rev:rrr)
 
-# The triggers are overridden by the ADO pipeline definitions.
 trigger: none
-pr: none
+pr:
+  - master
+  - "*-stable"
 
 extends:
   template: windows-jobs.yml@self

--- a/.ado/windows-pr.yml
+++ b/.ado/windows-pr.yml
@@ -1,13 +1,13 @@
-name: v8jsi_win_pr_0.0.$(Date:yyMM.d)$(Rev:rrr)
+name: v8jsi_pr_0.0.$(Date:yyMM.d)$(Rev:rrr)
 
+# The triggers are overridden by the ADO pipeline definitions.
 trigger: none
-pr:
-  - beta
-  - master
-  - "*-stable"
+pr: none
 
-pool:
-  name: OEDevJeff-OfficePublic
-
-jobs:
-  - template: windows-jobs.yml
+extends:
+  template: windows-jobs.yml@self
+  parameters:
+    # PR builds must pass false.
+    isPublish: false
+    # It must be false for real builds. Use true only for the build pipeline debugging.
+    fakeBuild: false

--- a/.ado/windows-release.yml
+++ b/.ado/windows-release.yml
@@ -1,0 +1,103 @@
+#
+# The v8-jsi Release pipeline entry point.
+# It releases NuGet packages to the public ms/react-native ADO feed and to the Office feed.
+#
+
+name: v8jsi_release_0.0.$(Date:yyMM.d)$(Rev:rrr)
+
+# The triggers are overridden by the ADO pipeline definitions.
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+  - pipeline: microsoft.v8-jsi.ci
+    project: ISS
+    source: microsoft.v8-jsi.ci
+    trigger:
+      branches:
+        include:
+        - master
+        - main
+        - '*-stable'
+
+  repositories:
+  - repository: CustomPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/OfficePipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/Office.Official.PipelineTemplate.yml@CustomPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      vmImage: windows-latest
+      os: windows
+
+    stages:
+    - stage: publish_nugets
+      displayName: Publish V8Jsi NuGets
+
+      jobs:
+      - job: ms_react_native_nuget_job
+        displayName: Publish Nuget to ms/react-native
+        condition: succeeded()
+        timeoutInMinutes: 0
+
+        templateContext:
+          inputs:
+          - input: pipelineArtifact
+            pipeline: microsoft.v8-jsi.ci
+            artifactName: published-packages
+            targetPath: $(Pipeline.Workspace)\published-packages
+
+        steps:
+        - script: dir /S $(Pipeline.Workspace)\published-packages
+          displayName: Show directory contents
+
+        - script: dotnet nuget list source
+          displayName: Show Nuget sources
+
+          # TODO: Fix the NuGet name after the service connection approval
+        - task: 1ES.PublishNuGet@1
+          displayName: NuGet push
+          inputs:
+            useDotNetTask: true
+            packageParentPath: '$(Pipeline.Workspace)/published-packages'
+            packagesToPush: '$(Pipeline.Workspace)/published-packages/ReactNative.V8Jsi.Windows_FIXME.*.nupkg'
+            nuGetFeedType: external
+            publishFeedCredentials: 'Nuget - ms/react-native-public'
+            externalEndpoint: 'Nuget - ms/react-native-public'
+            publishPackageMetadata: true
+
+      - job: office_nuget_job
+        displayName: Publish Nuget to office
+        condition: succeeded()
+        timeoutInMinutes: 0
+
+        templateContext:
+          inputs:
+          - input: pipelineArtifact
+            pipeline: microsoft.v8-jsi.ci
+            artifactName: published-packages
+            targetPath: $(Pipeline.Workspace)\published-packages
+
+        steps:
+        - script: dir /S $(Pipeline.Workspace)\published-packages
+          displayName: Show directory contents
+
+        - script: dotnet nuget list source
+          displayName: Show Nuget sources
+
+          # TODO: Fix the NuGet name after the service connection approval
+        - task: 1ES.PublishNuGet@1
+          displayName: NuGet push
+          inputs:
+            useDotNetTask: true
+            packageParentPath: '$(Pipeline.Workspace)/published-packages'
+            packagesToPush: '$(Pipeline.Workspace)/published-packages/ReactNative.V8Jsi.Windows_FIXME.*.nupkg'
+            nuGetFeedType: external
+            publishFeedCredentials: 'ES365-Office-Nuget-Package-Publisher'
+            externalEndpoint: 'ES365-Office-Nuget-Package-Publisher'
+            publishPackageMetadata: true

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.75.4",
+    "version":  "0.75.5",
     "v8ref":  "refs/branch-heads/12.1",
     "buildNumber":  "285"
 }

--- a/localbuild.ps1
+++ b/localbuild.ps1
@@ -14,10 +14,12 @@ param(
     [ValidateSet('win32', 'android', 'linux', 'mac')]
     [String[]]$AppPlatform = @('win32'),
 
-    [switch]$NoSetup
+    [switch]$NoSetup,
+
+    [switch]$FakeBuild
 )
 
-if (! $NoSetup.IsPresent) {
+if (!$NoSetup -and !$FakeBuild) {
     Write-Host "Downloading environment..."
     & ".\scripts\download_depottools.ps1" -SourcesPath $SourcesPath -NoADO
 
@@ -41,7 +43,8 @@ foreach ($Plat in $Platform) {
     foreach ($Config in $Configuration) {
         foreach ($AppPlat in $AppPlatform) {
             Write-Host "Building $AppPlat $Plat $Config..."
-            & ".\scripts\build.ps1" -SourcesPath $SourcesPath -OutputPath $OutputPath -Platform $Plat -Configuration $Config -AppPlatform $AppPlat
+            & ".\scripts\build.ps1" -SourcesPath $SourcesPath -OutputPath $OutputPath `
+              -Platform $Plat -Configuration $Config -AppPlatform $AppPlat -FakeBuild:$FakeBuild
         }
     }
 }

--- a/scripts/download_depottools.ps1
+++ b/scripts/download_depottools.ps1
@@ -14,7 +14,7 @@ if (!(Test-Path -Path $workpath)) {
     New-Item -ItemType "directory" -Path $workpath | Out-Null
 }
 
-if (! $NoSetup.IsPresent) {
+if (! $NoSetup) {
     Write-Host "Downloading depot-tools.zip..."
 
     # This is the recommended way to get depot-tools on Windows, but the git checkout is much faster (shaves off about 5 minutes from CI loop runtime)
@@ -59,7 +59,7 @@ $env:DEPOT_TOOLS_WIN_TOOLCHAIN = 0
 $env:GCLIENT_PY3 = 1
 $env:ASIO_ROOT = Join-Path $workpath "asio-asio-$ASIO_VERSION\asio\include"
 
-if (! $NoADO.IsPresent) {
+if (! $NoADO) {
     Write-Host "##vso[task.setvariable variable=PATH;]$path"
     Write-Host "##vso[task.setvariable variable=DEPOT_TOOLS_WIN_TOOLCHAIN;]0"
     Write-Host "##vso[task.setvariable variable=GCLIENT_PY3;]1"

--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -74,6 +74,15 @@ Write-Host "##vso[task.setvariable variable=V8JSI_VERSION;]$verString"
     -replace ('V8JSIVER_V8REF', $v8Version) |`
     Set-Content "$SourcesPath\src\source_link_gen.json"
 
+# Update ADO build version string when run from ADO pipeline
+if ($env:BUILD_BUILDNUMBER) {
+    $buildVersion = $env:BUILD_BUILDNUMBER
+    if (!$buildVersion.EndsWith($v8Version.Replace('.', '_'))) {
+        $buildVersion = $buildVersion + " - " + $version.Major + "." + $version.Minor + "." + $version.Build + "." + $v8Version.Replace('.', '_')
+        Write-Host "##vso[build.updateBuildNumber]$buildVersion"
+    }
+}
+
 # Install build dependencies for Android
 if ($AppPlatform -eq "android") {
     $install_script_path = Join-Path $workpath "v8/build/install-build-deps-android.sh"

--- a/scripts/patch/build.diff
+++ b/scripts/patch/build.diff
@@ -51,7 +51,7 @@ index 6e1417aa4..4079a06c8 100644
 +
 +# Control Flow Guard (CFG)
 +config("win_msvc_cfg") {
-+  if (!is_clang && !is_debug) {
++  if (!is_clang) {
 +    cflags = [ "/guard:cf", "/Qspectre", "/W3" ]
 +    ldflags = [ "/guard:cf" ]
 +  }

--- a/scripts/tracing/trace.ps1
+++ b/scripts/tracing/trace.ps1
@@ -109,7 +109,7 @@ process {
     $traceLogStopCmd = "tracelog -stop $SessionName"
     
     $traceLogCmd = $traceLogStartCmd
-    if ($IncludeInspectorTraces.IsPresent)
+    if ($IncludeInspectorTraces)
     {
         $traceLogCmd = $traceLogCmd + " & $traceLogEnableInspectorCmd"
     }

--- a/scripts/update_version.ps1
+++ b/scripts/update_version.ps1
@@ -13,7 +13,7 @@ param(
 # https://omahaproxy.appspot.com is deprecated in favor of https://chromiumdash.appspot.com
 
 $channel = "Stable"
-if ($BetaBranch.IsPresent) {
+if ($BetaBranch) {
   $channel = "Beta"
 }
 
@@ -69,7 +69,7 @@ $config.version = BumpSemVer($config.version)
 
 ConvertTo-Json -InputObject $config | Set-Content (Join-Path $SourcesPath "config.json")
 
-if (! $GitPush.IsPresent) {
+if (! $GitPush) {
   Write-Host "Git push not requested, we would be updating the version to $($config.version) (new upstream build number $buildNumber)"
 } else {
   git config user.name github-actions

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -103,7 +103,7 @@ class V8PlatformHolder {
 
   static void disposePlatform() {
     std::lock_guard<std::mutex> guard(mutex_s_);
-    if (is_disposed_s_) {
+    if (!is_initialized_s_ || is_disposed_s_) {
       return;
     }
     is_disposed_s_ = true;

--- a/src/jsi/test/testlib_ext.cpp
+++ b/src/jsi/test/testlib_ext.cpp
@@ -69,6 +69,7 @@ TEST_P(JSITestExt, ArrayBufferTest) {
 }
 
 #if JSI_VERSION >= 9
+#ifndef JSI_V8_IMPL
 TEST_P(JSITestExt, ExternalArrayBufferTest) {
   struct FixedBuffer : MutableBuffer {
     size_t size() const override {
@@ -98,7 +99,7 @@ TEST_P(JSITestExt, ExternalArrayBufferTest) {
       EXPECT_EQ(buf->arr[i], i * i);
   }
 }
-
+#endif
 // This test fails in CI for V8 (x86 Release Win32), so disabling it for now.
 // TEST_P(JSITestExt, NoCorruptionOnJSError) {
 //   // If the test crashes or infinite loops, the likely cause is that

--- a/src/node-api-jsi/ApiLoaders/V8Api.inc
+++ b/src/node-api-jsi/ApiLoaders/V8Api.inc
@@ -7,5 +7,6 @@
 
 // The V8 runtime functions sorted alphabetically.
 V8_FUNC(v8_config_enable_multithreading)
+V8_FUNC(v8_platform_dispose)
 
 #undef V8_FUNC

--- a/src/node-api-jsi/NodeApiJsiRuntime.cpp
+++ b/src/node-api-jsi/NodeApiJsiRuntime.cpp
@@ -2078,7 +2078,7 @@ jsi::JSError NodeApiJsiRuntime::makeJSError(Args &&...args) {
 
   if (!hasPendingJSError_ && (status == napi_pending_exception || jsErrorType != napi_undefined)) {
     AutoRestore<bool> setValue(const_cast<NodeApiJsiRuntime *>(this)->hasPendingJSError_, true);
-    if (jsErrorType == napi_object && instanceOf(jsError, getNodeApiValue(cachedValue_.Error))) {
+    if (jsErrorType == napi_object) {
       rewriteErrorMessage(jsError);
     }
     throw jsi::JSError(*const_cast<NodeApiJsiRuntime *>(this), toJsiValue(jsError));

--- a/src/node-api/js_native_api_v8.h
+++ b/src/node-api/js_native_api_v8.h
@@ -290,9 +290,6 @@ inline napi_status napi_set_last_error(node_api_nogc_env nogc_env,
     }                                                                          \
   } while (0)
 
-#define CHECK_MAYBE_EMPTY_WITH_PREAMBLE(env, maybe, status)                    \
-  RETURN_STATUS_IF_FALSE_WITH_PREAMBLE((env), !((maybe).IsEmpty()), (status))
-
 #define STATUS_CALL(call)                                                      \
   do {                                                                         \
     napi_status status = (call);                                               \

--- a/src/node-api/test/node_api_test.cpp
+++ b/src/node-api/test/node_api_test.cpp
@@ -3,6 +3,7 @@
 
 #include "node_api_test.h"
 #include <js_runtime_api.h>
+#include <v8_api.h>
 #include <windows.h>
 #include <algorithm>
 #include <cstdarg>
@@ -989,6 +990,16 @@ std::string NodeApiTestErrorHandler::GetSourceCodeSliceForError(
 
 }  // namespace node_api_tests
 
+class DeferPlatformDispose {
+ public:
+  DeferPlatformDispose() = default;
+  DeferPlatformDispose(const DeferPlatformDispose&) = delete;
+  DeferPlatformDispose& operator=(const DeferPlatformDispose&) = delete;
+
+  ~DeferPlatformDispose() { v8_platform_dispose(); }
+};
+
 int main(int argc, char** argv) {
+  DeferPlatformDispose deferPlatformDispose;
   return node_api_tests::EvaluateJSFile(argc, argv);
 }

--- a/src/node-api/v8_api.cpp
+++ b/src/node-api/v8_api.cpp
@@ -772,6 +772,11 @@ JSR_API jsr_delete_runtime(jsr_runtime runtime) {
   return napi_ok;
 }
 
+JSR_API v8_platform_dispose() {
+  v8runtime::V8PlatformHolder::disposePlatform();
+  return napi_ok;
+}
+
 JSR_API jsr_runtime_get_node_api_env(jsr_runtime runtime, napi_env* env) {
   return CHECKED_RUNTIME(runtime)->getNodeApi(env);
 }

--- a/src/public/v8_api.h
+++ b/src/public/v8_api.h
@@ -8,11 +8,9 @@
 
 EXTERN_C_START
 
-//=============================================================================
-// jsr_config
-//=============================================================================
-
 JSR_API v8_config_enable_multithreading(jsr_config config, bool value);
+
+JSR_API v8_platform_dispose();
 
 EXTERN_C_END
 


### PR DESCRIPTION
We have a new build requirements that all releases must use an YAML-based pipeline.
In this PR we:
- Update version to 0.75.5
- Add new `release.yml` pipeline script.
- Make the `windows-pr.yml` script for PR to follow the recommended settings.
- Convert `windows-jobs.yml` to the base template which is used as a base for `windows-pr.yml` and `windows-ci.yml`.
- Added code sign for DLLs and NuGet packages.
- Added new "FakeBuild" parameter to speed up the pipeline development.
- Report current build info as the build number while running CI and PR pipelines in ADO (`fetch_code.ps1`).
- Add settings recured for secure builds for Debug builds. (`build.diff`)
- Added new `v8_platform_dispose` function to dispose V8 platform. Otherwise, there are random test crashes in Debug caused by GC pending work when the platform is disposed as a part of static variable destruction. The `V8JsiRuntime` is changed to implement the new API. Currently we only fixed the Node-API tests. We need to see how to use the new API in JSI tests and in client code.
- Minor fixed in the Node-API implementation.- 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/216)