### PR TITLE
Fix unsafe access to static `agents_s_` variable

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.79.3",
+    "version":  "0.79.4",
     "v8ref":  "refs/branch-heads/12.1",
     "buildNumber":  "285"
 }

--- a/src/inspector/inspector_agent.cpp
+++ b/src/inspector/inspector_agent.cpp
@@ -740,6 +740,7 @@ void Agent::addContext(v8::Local<v8::Context> context,
   impl->addContext(context, context_name);
 
   if (impl->getInspectedContextsCount() == 1) {
+    std::lock_guard<std::mutex> lock(agents_s_mutex_);
     agents_s_.insert(impl);
   }
 }
@@ -748,6 +749,7 @@ void Agent::removeContext(v8::Local<v8::Context> context) {
   impl->removeContext(context);
 
   if (impl->getInspectedContextsCount() == 0) {
+    std::lock_guard<std::mutex> lock(agents_s_mutex_);
     agents_s_.erase(impl);
   }
 }
@@ -764,11 +766,24 @@ void Agent::notifyLoadedUrl(const std::string& url) { impl->notifyLoadedUrl(url)
 
 std::shared_ptr<Agent> Agent::getShared() { return shared_from_this(); }
 
-/*static*/ std::unordered_set<std::shared_ptr<inspector::AgentImpl>>
-        Agent::agents_s_;
+/*static*/ std::mutex Agent::agents_s_mutex_;
+/*static*/ std::set<
+    std::weak_ptr<inspector::AgentImpl>,
+    std::owner_less<std::weak_ptr<inspector::AgentImpl>>>
+    Agent::agents_s_;
 
 /*static */void Agent::startAll() {
-  for (auto agent : agents_s_) {
+  std::vector<std::shared_ptr<AgentImpl>> snapshot;
+  {
+    std::lock_guard<std::mutex> lock(agents_s_mutex_);
+    snapshot.reserve(agents_s_.size());
+    for (auto& weak_agent : agents_s_) {
+      if (auto agent = weak_agent.lock()) {
+        snapshot.push_back(std::move(agent));
+      }
+    }
+  }
+  for (auto& agent : snapshot) {
     agent->Start();
   }
 }

--- a/src/inspector/inspector_agent.h
+++ b/src/inspector/inspector_agent.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <stddef.h>
-#include <unordered_set>
+#include <memory>
+#include <mutex>
+#include <set>
 
 #include <public/V8JsiRuntime.h>
 
@@ -18,7 +20,7 @@ class Agent : public std::enable_shared_from_this<Agent> {
       v8::Isolate *isolate,
       int port);
   ~Agent();
-  
+
   void waitForDebugger();
 
   void addContext(v8::Local<v8::Context> context, const char* context_name);
@@ -38,10 +40,20 @@ class Agent : public std::enable_shared_from_this<Agent> {
   std::shared_ptr<Agent> getShared();
 
   static void startAll();
-    
+
  private:
   std::shared_ptr<AgentImpl> impl;
-  static std::unordered_set<std::shared_ptr<inspector::AgentImpl>> agents_s_;
+
+  // Tracks every AgentImpl that currently has at least one inspected context,
+  // so the debugger-invoked startAll() can iterate live agents process-wide.
+  // Held as weak_ptr so the set never extends AgentImpl lifetime past natural
+  // V8Runtime teardown. Mutated/read concurrently by V8Runtime ctor/dtor on
+  // arbitrary threads, so all access is serialized by agents_s_mutex_.
+  static std::mutex agents_s_mutex_;
+  static std::set<
+      std::weak_ptr<inspector::AgentImpl>,
+      std::owner_less<std::weak_ptr<inspector::AgentImpl>>>
+      agents_s_;
 };
 
 } // namespace inspector


### PR DESCRIPTION
## Summary

Make the static `inspector::Agent::agents_s_` thread-safe and stop it from
extending `AgentImpl` lifetime past natural `V8Runtime` teardown. Fixes a
shutdown crash that manifests as an AV during DLL detach inside the static
set's destructor when the host creates and destroys `V8Runtime` instances
on multiple threads concurrently.

## Background

`inspector::Agent::agents_s_` is a process-wide static
`std::unordered_set<std::shared_ptr<AgentImpl>>` mutated by every
`V8Runtime` ctor/dtor through `Agent::addContext` / `Agent::removeContext`.
It is consumed by `Agent::startAll()` — the implementation behind the
DLL export `v8runtime::openInspectors_toberemoved` — which iterates every
live `AgentImpl` and opens its CDP inspector socket so a DevTools client
(Chrome / Edge / VS Code JS debugger) can attach. This gives the host a
way to enable the V8 inspector on already-constructed runtimes after the
fact, rather than only at `V8Runtime` construction time via
`V8RuntimeArgs::flags::enableInspector`.

Both mutating call sites accessed the set without synchronization. As long
as the host called `makeV8Runtime` / `~V8Runtime` from a single thread the
race was latent; once the host began creating and destroying runtimes from
multiple threads, `unordered_set::insert` / `erase` raced and produced
torn writes in the underlying `_List` head sentinel.

Crash signature: `_Mysize` reaches 0 while `_Myhead._Next` / `_Prev`
point at recycled LFH blocks, and the static destructor at DLL detach
walks those freed nodes and AVs in a `shared_ptr` decref.

## Root cause

Unsynchronized concurrent mutation of `std::unordered_set` is undefined
behavior. The race is latent if the host serializes runtime lifecycle to
a single thread, and only manifests when the host creates / destroys
`V8Runtime` instances on multiple threads concurrently.

## Fix

Two orthogonal changes, both in the inspector files:

1. **Serialize access.** Add `static std::mutex Agent::agents_s_mutex_` and
   take it inside `addContext`, `removeContext`, and `startAll` around the
   set operations only. The `impl->addContext` / `impl->removeContext`
   calls remain outside the lock to avoid serializing unrelated work.

2. **Convert to `weak_ptr`.** Change the element type from
   `shared_ptr<AgentImpl>` to `weak_ptr<AgentImpl>` and key the set with
   `std::owner_less` so insert/erase still take a `shared_ptr` argument
   transparently. This removes the lifetime extension that previously kept
   `AgentImpl` alive in the static after every `V8Runtime` had torn down.

`Agent::startAll` snapshots live agents under the lock into a local
`vector<shared_ptr<AgentImpl>>` (locking each `weak_ptr` and dropping
expired entries) and then drops the mutex before calling `Start()`. This
avoids running `AgentImpl::Start` under the static lock and prevents any
re-entrant `addContext` / `removeContext` from deadlocking against it.

### Why `weak_ptr` is safe here

Strong owners of `AgentImpl` outside `agents_s_`:

- `Agent::impl` — the natural 1:1 owner. Lives as long as the `Agent`,
  which is held by `V8Runtime::inspector_agent_`.
- `InspectorSocketServer::targets_map_` / `session_targets_map_` — hold a
  strong ref while the agent is registered as an inspector target.

`Agent::impl` already governs `AgentImpl` lifetime end-to-end. The static
set was redundant for ownership and only ever needed for enumeration. In
the observed crash, the `AgentImpl` control blocks had `_Uses == 0` and
`_Weaks == 0` at exit — proving `Agent::impl` had already released and
the static was carrying dangling list nodes, not live owners.

Behavior comparison with `weak_ptr`:

- Happy path: `removeContext` erases the entry, `~Agent` destroys
  `AgentImpl`. Identical to before.
- If `removeContext` is somehow skipped: `AgentImpl` still dies with
  `Agent`; a stale expired `weak_ptr` lingers in the set. Filtered by
  `lock()` in `startAll`. Previously this same path leaked `AgentImpl`
  into the static set indefinitely.

`weak_ptr` is strictly equal-or-better than `shared_ptr` here.

## Public API

Unchanged. `Agent::startAll` and the DLL export
`v8runtime::openInspectors_toberemoved` are preserved.

## Files changed

- `src/inspector/inspector_agent.h`
  - Replaced `<unordered_set>` with `<memory>`, `<mutex>`, `<set>`.
  - Added `static std::mutex agents_s_mutex_`.
  - Changed `agents_s_` to
    `std::set<weak_ptr<AgentImpl>, std::owner_less<weak_ptr<AgentImpl>>>`.
  - Comment block describing the invariant and the synchronization rule.
- `src/inspector/inspector_agent.cpp`
  - `addContext` / `removeContext`: take the mutex around the set
    operation only.
  - `startAll`: snapshot under lock, call `Start()` outside the lock.
  - Defined the static mutex and set.

No other files need changes. The inspector code is gated by
`_WIN32 && V8JSI_ENABLE_INSPECTOR`, which matches the default build
configuration where the bug surfaces.

## Validation

Local build succeeds. The crash cannot be reproduced locally; downstream
consumers will validate when they pick up the new binary.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/229)