### PR TITLE
Fix thread-safety issues in process-wide statics

### DIFF
--- a/src/V8JsiRuntime.cpp
+++ b/src/V8JsiRuntime.cpp
@@ -154,115 +154,12 @@ void V8Runtime::GCPrologueCallback(v8::Isolate *isolate, v8::GCType type, v8::GC
   std::string prefix("GCPrologue");
   std::string gcTypeString = GCTypeToString(prefix, type, flags);
   TRACEV8RUNTIME_VERBOSE("V8::GCPrologueCallback", TraceLoggingString(gcTypeString.c_str(), "GCType"));
-  DumpCounters(gcTypeString.c_str());
 }
 
 void V8Runtime::GCEpilogueCallback(v8::Isolate *isolate, v8::GCType type, v8::GCCallbackFlags flags) {
   std::string prefix("GCEpilogue");
   std::string gcTypeString = GCTypeToString(prefix, type, flags);
   TRACEV8RUNTIME_VERBOSE("V8::GCEpilogueCallback", TraceLoggingString(gcTypeString.c_str(), "GCType"));
-
-  DumpCounters(gcTypeString.c_str());
-}
-
-CounterMap *V8Runtime::counter_map_;
-char V8Runtime::counters_file_[sizeof(CounterCollection)];
-CounterCollection V8Runtime::local_counters_;
-CounterCollection *V8Runtime::counters_ = &local_counters_;
-
-int32_t *Counter::Bind(const char *name, bool is_histogram) {
-  int i;
-  for (i = 0; i < kMaxNameSize - 1 && name[i]; i++)
-    name_[i] = static_cast<char>(name[i]);
-  name_[i] = '\0';
-  is_histogram_ = is_histogram;
-  return ptr();
-}
-
-void Counter::AddSample(int32_t sample) {
-  count_++;
-  sample_total_ += sample;
-}
-
-CounterCollection::CounterCollection() {
-  magic_number_ = 0xDEADFACE;
-  max_counters_ = kMaxCounters;
-  max_name_size_ = Counter::kMaxNameSize;
-  counters_in_use_ = 0;
-}
-
-Counter *CounterCollection::GetNextCounter() {
-  if (counters_in_use_ == kMaxCounters)
-    return nullptr;
-  return &counters_[counters_in_use_++];
-}
-
-void V8Runtime::DumpCounters(const char *when) {
-  static int cookie = 0;
-  cookie++;
-#ifdef _WIN32
-  for (std::pair<std::string, Counter *> element : *counter_map_) {
-    TRACEV8RUNTIME_VERBOSE(
-        "V8::PerfCounters",
-        TraceLoggingString(when, "when"),
-        TraceLoggingInt32(cookie, "cookie"),
-        TraceLoggingString(element.first.c_str(), "name"),
-        TraceLoggingInt32(element.second->count(), "count"),
-        TraceLoggingInt32(element.second->sample_total(), "sample_total"),
-        TraceLoggingBool(element.second->is_histogram(), "is_histogram"));
-  }
-#endif
-}
-
-void V8Runtime::MapCounters(v8::Isolate *isolate, const char *name) {
-  // counters_file_ = base::OS::MemoryMappedFile::create(
-  //	name, sizeof(CounterCollection), &local_counters_);
-  // void* memory =
-  //	(counters_file_ == nullptr) ? nullptr : counters_file_->memory();
-  // if (memory == nullptr) {
-  //	printf("Could not map counters file %s\n", name);
-  //	base::OS::ExitProcess(1);
-  //}
-  // counters_ = static_cast<CounterCollection*>(memory);
-  counters_ = reinterpret_cast<CounterCollection *>(&counters_file_);
-  isolate->SetCounterFunction(LookupCounter);
-  isolate->SetCreateHistogramFunction(CreateHistogram);
-  isolate->SetAddHistogramSampleFunction(AddHistogramSample);
-}
-
-Counter *V8Runtime::GetCounter(const char *name, bool is_histogram) {
-  auto map_entry = counter_map_->find(name);
-  Counter *counter = map_entry != counter_map_->end() ? map_entry->second : nullptr;
-
-  if (counter == nullptr) {
-    counter = counters_->GetNextCounter();
-    if (counter != nullptr) {
-      (*counter_map_)[name] = counter;
-      counter->Bind(name, is_histogram);
-    }
-  } else {
-    assert(counter->is_histogram() == is_histogram);
-  }
-  return counter;
-}
-
-int *V8Runtime::LookupCounter(const char *name) {
-  Counter *counter = GetCounter(name, false);
-
-  if (counter != nullptr) {
-    return counter->ptr();
-  } else {
-    return nullptr;
-  }
-}
-
-void *V8Runtime::CreateHistogram(const char *name, int min, int max, size_t buckets) {
-  return GetCounter(name, true);
-}
-
-void V8Runtime::AddHistogramSample(void *histogram, int sample) {
-  Counter *counter = reinterpret_cast<Counter *>(histogram);
-  counter->AddSample(sample);
 }
 
 // This class is used to record the JITed code position info for JIT
@@ -372,13 +269,6 @@ v8::Isolate *V8Runtime::CreateNewIsolate() {
     create_params_.constraints = constraints;
   }
 
-  counter_map_ = new CounterMap();
-  if (args_.flags.trackGCObjectStats) {
-    create_params_.counter_lookup_callback = LookupCounter;
-    create_params_.create_histogram_callback = CreateHistogram;
-    create_params_.add_histogram_sample_callback = AddHistogramSample;
-  }
-
   isolate_ = v8::Isolate::Allocate();
   if (isolate_ == nullptr)
     std::abort();
@@ -392,10 +282,6 @@ v8::Isolate *V8Runtime::CreateNewIsolate() {
 
   if (!args_.flags.ignoreUnhandledPromises) {
     isolate_->SetPromiseRejectCallback(PromiseRejectCallback);
-  }
-
-  if (args_.flags.trackGCObjectStats) {
-    MapCounters(isolate_, "v8jsi");
   }
 
   if (args_.flags.enableJitTracing) {
@@ -419,7 +305,6 @@ v8::Isolate *V8Runtime::CreateNewIsolate() {
   isolate_->Enter();
 
   TRACEV8RUNTIME_VERBOSE("CreateNewIsolate", TraceLoggingString("end", "op"));
-  DumpCounters("isolate_created");
 
   return isolate_;
 }
@@ -454,9 +339,6 @@ void V8Runtime::initializeV8() {
     // We are only allowed to set the flags the first time V8 is being initialized
     std::vector<const char *> argv;
     argv.push_back("v8jsi");
-
-    if (args_.flags.trackGCObjectStats)
-      argv.push_back("--track_gc_object_stats");
 
     if (args_.flags.enableGCApi)
       argv.push_back("--expose_gc");
@@ -630,7 +512,6 @@ jsi::Value V8Runtime::evaluateJavaScript(
   jsi::Value result = createValue(ExecuteString(sourceV8String, sourceURL, hash));
 
   TRACEV8RUNTIME_VERBOSE("evaluateJavaScript", TraceLoggingString("end", "op"));
-  DumpCounters("script evaluated");
 
   return result;
 }
@@ -665,7 +546,6 @@ v8::Local<v8::Context> V8Runtime::CreateContext(v8::Isolate *isolate) {
   context->SetAlignedPointerInEmbedderData(1, this);
 
   TRACEV8RUNTIME_VERBOSE("CreateContext", TraceLoggingString("end", "op"));
-  DumpCounters("context_created");
 
   return context;
 }
@@ -1455,7 +1335,7 @@ V8Runtime::call(const jsi::Function &jsiFunc, const jsi::Value &jsThis, const js
   // calls from native. Evaluate !
   std::string functionName = getFunctionName(GetIsolate(), func);
 
-  static uint8_t callCookie = 0;
+  thread_local static uint8_t callCookie = 0;
   if (callCookie > 0) {
     TRACEV8RUNTIME_WARNING(
         "CallFunctionNested",
@@ -1482,7 +1362,6 @@ V8Runtime::call(const jsi::Function &jsiFunc, const jsi::Value &jsThis, const js
 
   TRACEV8RUNTIME_VERBOSE(
       "CallFunction", TraceLoggingString(functionName.c_str(), "name"), TraceLoggingString("end", "op"));
-  DumpCounters("call_completed");
 
   callCookie--;
 
@@ -1521,7 +1400,6 @@ jsi::Value V8Runtime::callAsConstructor(const jsi::Function &jsiFunc, const jsi:
 
   TRACEV8RUNTIME_VERBOSE(
       "CallConstructor", TraceLoggingString(functionName.c_str(), "name"), TraceLoggingString("end", "op"));
-  DumpCounters("callAsConstructor_completed");
 
   return createValue(newObject);
 }

--- a/src/V8JsiRuntime_impl.h
+++ b/src/V8JsiRuntime_impl.h
@@ -34,52 +34,6 @@ namespace v8runtime {
 
 class NativeStateHolder;
 
-// Note : Counter implementation based on d8
-// A single counter in a counter collection.
-class Counter {
- public:
-  static const int kMaxNameSize = 64;
-  int32_t *Bind(const char *name, bool histogram);
-  int32_t *ptr() {
-    return &count_;
-  }
-  int32_t count() {
-    return count_;
-  }
-  int32_t sample_total() {
-    return sample_total_;
-  }
-  bool is_histogram() {
-    return is_histogram_;
-  }
-  void AddSample(int32_t sample);
-
- private:
-  int32_t count_;
-  int32_t sample_total_;
-  bool is_histogram_;
-  uint8_t name_[kMaxNameSize];
-};
-
-// A set of counters and associated information.  An instance of this
-// class is stored directly in the memory-mapped counters file if
-// the --map-counters options is used
-class CounterCollection {
- public:
-  CounterCollection();
-  Counter *GetNextCounter();
-
- private:
-  static const unsigned kMaxCounters = 512;
-  uint32_t magic_number_;
-  uint32_t max_counters_;
-  uint32_t max_name_size_;
-  uint32_t counters_in_use_;
-  Counter counters_[kMaxCounters];
-};
-
-using CounterMap = std::unordered_map<std::string, Counter *>;
-
 // This class is used to hold the V8 platform singleton.
 // It ensures that the platform is initialized and disposed only once.
 // It is thread-safe.
@@ -846,21 +800,6 @@ class V8Runtime : public facebook::jsi::Runtime {
 
   bool ignore_unhandled_promises_{false};
   std::unique_ptr<UnhandledPromiseRejection> last_unhandled_promise_;
-
-  static CounterMap *counter_map_;
-
-  // We statically allocate a set of local counters to be used if we
-  // don't want to store the stats in a memory-mapped file
-  static CounterCollection local_counters_;
-  static CounterCollection *counters_;
-  static char counters_file_[sizeof(CounterCollection)];
-
-  static void MapCounters(v8::Isolate *isolate, const char *name);
-  static Counter *GetCounter(const char *name, bool is_histogram);
-  static int *LookupCounter(const char *name);
-  static void *CreateHistogram(const char *name, int min, int max, size_t buckets);
-  static void AddHistogramSample(void *histogram, int sample);
-  static void DumpCounters(const char *when);
 
   static void JitCodeEventListener(const v8::JitCodeEvent *event);
 

--- a/src/inspector/inspector_agent.cpp
+++ b/src/inspector/inspector_agent.cpp
@@ -145,12 +145,6 @@ class AgentImpl : public std::enable_shared_from_this<AgentImpl> {
   // Tracks the number of contexts added to this Isolate/V8Inspector/Agent
   size_t inspected_contexts_count_{0};
 
-  // This map keeps weak references to Inspector Websocket servers running on a
-  // given port.
-  // This allows us to reuse Websocket servers across inspector agents.
-  static std::mutex g_mutex_server_init_;
-  static std::unordered_map<int, std::weak_ptr<inspector::InspectorSocketServer>> g_servers_;
-
   std::string title_;
   std::string loaded_urls_;
   std::string targetId_;
@@ -298,13 +292,17 @@ class V8NodeInspector : public v8_inspector::V8InspectorClient {
 
 namespace {
 std::string GenerateID() {
+  static std::mutex mte_mutex;
   static std::random_device rd;
   static std::mt19937 mte(rd());
 
   std::uniform_int_distribution<uint16_t> dist;
 
   std::array<uint16_t, 8> buffer;
-  std::generate(buffer.begin(), buffer.end(), [&]() { return dist(mte); });
+  {
+    std::lock_guard<std::mutex> lock(mte_mutex);
+    std::generate(buffer.begin(), buffer.end(), [&]() { return dist(mte); });
+  }
 
   char uuid[256];
   snprintf(uuid, sizeof(uuid), "%04x%04x-%04x-%04x-%04x-%04x%04x%04x",
@@ -421,6 +419,7 @@ class ServerCollection {
   }
 
   void removeServer(int port) {
+    const std::lock_guard<std::mutex> lock(mutex_server_init_);
     servers_.erase(port);
   }
 

--- a/src/public/V8JsiRuntime.h
+++ b/src/public/V8JsiRuntime.h
@@ -72,7 +72,7 @@ struct V8RuntimeArgs {
   // Padded to allow adding boolean flags without breaking the ABI
   union {
     struct {
-      bool trackGCObjectStats : 1;
+      bool trackGCObjectStats : 1; // deprecated, no-op; reserved for ABI stability
       bool enableJitTracing : 1;
       bool enableMessageTracing : 1;
       bool enableGCTracing : 1;


### PR DESCRIPTION
# PR notes — fix remaining thread-safety holes in process-wide statics

## Summary

Companion to the `agents_s_` fix in PR #229. v8jsi consumers may create
and destroy `V8Runtime` instances on multiple threads concurrently. A
few remaining process-wide statics in `src/` are not safe under that
usage — the same pattern as `agents_s_`: dormant in single-threaded
hosts, surfaces once runtime lifecycle moves across threads. The
individual fixes are small and closely related, so they are grouped
into a single PR.

## Changes

**1. `ServerCollection::removeServer` — add lock.** `getServer` already
takes `mutex_server_init_` around the `std::unordered_map` access;
`removeServer` did not. Concurrent reader/writer on `std::unordered_map`
is undefined behavior. Added the same `lock_guard` to `removeServer`.

**2. `inspector::GenerateID` — lock the PRNG.** `std::mt19937` is
stateful, and `GenerateID` runs from every `AgentImpl` constructor while
sharing a single engine instance. Added a `std::mutex` and held it
across the `std::generate` call. The `snprintf` formatting remains
outside the critical section.

**3. Counter machinery — delete.** Removed the d8-derived counter
classes (`Counter`, `CounterCollection`, `CounterMap`), their static
state (`counter_map_`, `counters_`, `local_counters_`,
`counters_file_[]`), the related static methods (`MapCounters`,
`GetCounter`, `LookupCounter`, `CreateHistogram`, `AddHistogramSample`,
`DumpCounters`), all `DumpCounters` call sites, the
`trackGCObjectStats` wiring inside `CreateNewIsolate`, and the
`--track_gc_object_stats` argv push. The machinery was a debug-only
ETW hook gated on a flag no caller sets; the JSI `Instrumentation` API
did not consume it; and the static design did not fit v8jsi's
multi-isolate model. The unconditional
`counter_map_ = new CounterMap();` on every constructor was also a
per-runtime leak and a race on the static pointer. The
`trackGCObjectStats : 1` bit is preserved in the public flags union as
a no-op for ABI stability, with an inline comment.

**4. Delete dead `AgentImpl::g_servers_` / `g_mutex_server_init_`.**
Two class-static declarations with no out-of-line definition and no
callers — leftovers from the refactor that moved this state into
`ServerCollection`.

**5. `callCookie` — `thread_local`.** `V8Runtime::call`'s nesting cookie
was a process-wide `static uint8_t` incremented around every JS call,
which produced spurious "nested call" warnings under multi-threaded
use. The variable name and warning text describe per-thread nesting, so
`thread_local` is the correct semantics.

## Public API

Unchanged. The `V8RuntimeArgs::flags` layout is preserved (the
`trackGCObjectStats` bit is retained as a no-op for ABI stability), and
no exports are added or removed.

## Files changed

- `src/V8JsiRuntime.cpp` — items 3, 5.
- `src/V8JsiRuntime_impl.h` — item 3. `tls_isolate_usage_counter_`,
  which is unrelated despite being declared next to the deleted
  members, is preserved.
- `src/inspector/inspector_agent.cpp` — items 1, 2, 4.
- `src/public/V8JsiRuntime.h` — item 3, inline comment only. No layout
  change.

Net: +8 / -192 lines.

## Validation

Local build succeeds. The race signature is not reproducible locally;
the binary will be validated by consumer integration after merge, as
with PR #229. The existing test suites under `src/jsi/test` and
`src/node-api/test` do not exercise the inspector or the counter
machinery and serve only as a regression check for the remaining
changes.
