### PR TITLE
Publish PDB files from the Release pipeline

### DIFF
--- a/.ado/windows-ci.yml
+++ b/.ado/windows-ci.yml
@@ -5,11 +5,6 @@ trigger: none
 pr: none
 
 variables:
-  - group: V8-Jsi Secrets
-  - name: ArtifactServices.Symbol.AccountName
-    value: microsoft
-  - name: ArtifactServices.Symbol.PAT
-    value: $(pat-symbols-publish-microsoft)
   - name: tags
     value: production,externalfacing
 

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -185,16 +185,6 @@ extends:
               artifact: ${{ matrix.Name }}
               path: $(Build.StagingDirectory)\out\pkg-staging
 
-          # Publish symbols only for the non-fake CI builds.
-        - ${{ if and(eq(parameters.isPublish, true), eq(parameters.fakeBuild, false)) }}:
-            # Make symbols available through http://symweb.
-          - task: PublishSymbols@2
-            displayName: Publish symbols
-            inputs:
-              UseNetCoreClientTool: true
-              SearchPattern: $(Build.StagingDirectory)\out\pkg-staging\**\*.pdb
-              SymbolServerType: TeamServices
-
         - task: PowerShell@2
           displayName: Set version variables
           inputs:

--- a/.ado/windows-release.yml
+++ b/.ado/windows-release.yml
@@ -101,3 +101,63 @@ extends:
             publishFeedCredentials: 'ES365-Office-Nuget-Package-Publisher'
             publishPackageMetadata: true
             publishVstsFeed: 'office'
+
+      - job: publish_symbols_job
+        displayName: Publish PDB Symbols to Symbol Server
+        condition: succeeded()
+        timeoutInMinutes: 30
+
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: microsoft.v8-jsi.ci
+            artifactName: published-packages
+            targetPath: $(Pipeline.Workspace)\published-packages
+
+        steps:
+        - pwsh: |
+            # NuGet packages are zip archives — extract them to harvest the PDBs.
+            $nugetDir   = "$(Pipeline.Workspace)/published-packages"
+            $symbolsDir = "$(Pipeline.Workspace)/symbols"
+            New-Item -ItemType Directory -Path $symbolsDir -Force | Out-Null
+
+            $nupkgs = Get-ChildItem "$nugetDir/*.nupkg"
+            Write-Host "Found $($nupkgs.Count) NuGet packages"
+
+            foreach ($nupkg in $nupkgs) {
+              Write-Host "Extracting PDBs from: $($nupkg.Name)"
+              $extractDir = "$symbolsDir/$($nupkg.BaseName)"
+              $zipPath = "$nugetDir/$($nupkg.BaseName).zip"
+              Copy-Item $nupkg.FullName $zipPath
+              Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+              Remove-Item $zipPath
+            }
+
+            $pdbs = Get-ChildItem "$symbolsDir" -Recurse -Filter "*.pdb"
+            Write-Host "`nFound $($pdbs.Count) PDB files:"
+            foreach ($pdb in $pdbs) {
+              Write-Host "  $($pdb.FullName) ($([math]::Round($pdb.Length / 1MB, 2)) MB)"
+            }
+
+            if ($pdbs.Count -eq 0) {
+              Write-Host "##vso[task.logissue type=warning]No PDB files found in NuGet packages"
+            }
+          displayName: Extract PDBs from NuGet packages
+
+        - task: PublishSymbols@2
+          displayName: Publish Symbols to Microsoft Symbol Server
+          continueOnError: true
+          inputs:
+            UseNetCoreClientTool: true
+            ConnectedServiceName: Office-V8-Jsi-Bot
+            SymbolsFolder: '$(Pipeline.Workspace)/symbols'
+            SearchPattern: '**/*.pdb'
+            SymbolServerType: TeamServices
+            IndexSources: false
+            SymbolsProduct: V8Jsi
+            SymbolsVersion: $(Build.BuildNumber)
+            SymbolsArtifactName: V8Jsi-Symbols-$(Build.BuildId)
+            DetailedLog: true
+            TreatNotIndexedAsWarning: false


### PR DESCRIPTION
## Summary

The CI pipeline currently fails on the **Publish symbols** step:

```
[Symbol App][VERBOSE] Authenticating with PAT
[Symbol App][VERBOSE] ArtifactHttpRetryMessageHandler.SendAsync:
    https://microsoft.artifacts.visualstudio.com/_apis/ attempt 1/6 failed with
    VssUnauthorizedException: 'VS30063: You are not authorized to access
    https://microsoft.artifacts.visualstudio.com.'
[Symbol App][ERROR]   Operation ended with exit code: 1244
##[error]C:\hostedtoolcache\windows\symbol\0.2.542\x64\symbol.exe exited with exit code 1244
```

Root cause: the CI declared `ArtifactServices.Symbol.PAT =
$(pat-symbols-publish-microsoft)`, which forced `PublishSymbols@2` into PAT
auth. The PAT no longer has access to the symbol service, so every CI run
goes red on this step even though the build, tests, signing, and NuGet pack
all succeed.

This PR moves symbol publishing out of the CI pipeline and into the Release
pipeline, mirroring the pattern that already runs in
[react-native-windows](https://github.com/microsoft/react-native-windows/blob/main/.ado/release.yml).
The Release pipeline authenticates via the `Office-V8-Jsi-Bot` managed
identity service connection — no PAT.

## What changes

### CI (`.ado/windows-ci.yml`, `.ado/windows-jobs.yml`)

* Drop the `V8-Jsi Secrets` variable group reference and the two
  `ArtifactServices.Symbol.AccountName` / `ArtifactServices.Symbol.PAT`
  variables from `windows-ci.yml`. They were only ever used by the failing
  symbol step.
* Delete the `PublishSymbols@2` block from the `V8JsiCreateNuget` job.

PDBs continue to ride inside the `ReactNative.V8Jsi.Windows.*.nupkg`
packages — the nuspec does not exclude `*.pdb` and `scripts/build.ps1` copies
each platform's PDB into the staging tree, so the existing `published-packages`
pipeline artifact already contains everything the Release pipeline needs.
No nuspec or build-script changes.

### Release (`.ado/windows-release.yml`)

Add a new `publish_symbols_job` to the `publish_nugets` stage, peer to the
two existing NuGet-push jobs:

* Pulls the `published-packages` artifact from `microsoft.v8-jsi.ci` via the
  1ES `releaseJob` `pipelineArtifact` input.
* Treats every `.nupkg` as a zip and extracts it into
  `$(Pipeline.Workspace)/symbols`, then logs every harvested PDB.
* Runs `PublishSymbols@2` against `$(Pipeline.Workspace)/symbols` with:
  * `UseNetCoreClientTool: true`
  * `ConnectedServiceName: Office-V8-Jsi-Bot` (managed identity, no PAT)
  * `SymbolServerType: TeamServices`
  * `IndexSources: false` — SourceLink is already embedded in the PDBs at
    compile time, and the Release agent doesn't enlist sources, so re-indexing
    would only re-trigger the previous *"Unsupported source provider 'GitHub'
    for source indexing"* warning.
  * `continueOnError: true` — a symbol-server hiccup must not fail a release
    that has already pushed NuGets.
  * `SymbolsProduct: V8Jsi`, `SymbolsVersion: $(Build.BuildNumber)`,
    `SymbolsArtifactName: V8Jsi-Symbols-$(Build.BuildId)` for traceability.

## Why this pattern

* The Release pipeline runs on `Azure-Pipelines-1ESPT-ExDShared`, which is
  not allowed to enlist the v8-jsi sources. Anything it needs has to come
  from a CI artifact — the `published-packages` artifact already does.
* Authentication via `ConnectedServiceName` uses the same managed-identity
  story we already use for NuGet feed pushes (`1ES.PublishNuGet@1` with
  `publishFeedCredentials`). No long-lived PAT to rotate.
* Mirrors react-native-windows
  [.ado/release.yml `PublishSymbols` job](https://github.com/microsoft/react-native-windows/blob/main/.ado/release.yml),
  which has been running this way successfully.

## Test plan

* [ ] CI run on this PR no longer hits VS30063; the `V8JsiCreateNuget` job
      goes green end-to-end.
* [ ] Manually queue the v8-jsi Release pipeline against a CI run from this
      branch. Confirm the new `Publish PDB Symbols to Symbol Server` job
      appears in the `publish_nugets` stage and finishes successfully.
* [ ] Inside that job, the *"Extract PDBs from NuGet packages"* step logs the
      expected PDBs (one `v8jsi.dll.pdb` per platform/configuration; the
      ARM64 PDB is the stripped variant copied as `v8jsi.dll.pdb`).
* [ ] The *"Publish Symbols to Microsoft Symbol Server"* step authenticates
      via `Office-V8-Jsi-Bot` and reports a successful upload. If it logs a
      warning instead of an error, that's by design (`continueOnError: true`)
      — investigate the warning before the next release.
* [ ] After publish, query the symbol service for `v8jsi.pdb` at the
      published `SymbolsArtifactName` and confirm symbols are resolvable
      from a local debugger configured against the Microsoft symbol server.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/231)