### PR TITLE
Fix publishing to ms/react-native-public feed

### DIFF
--- a/.ado/templates/publish-nuget-to-ado-feed.yml
+++ b/.ado/templates/publish-nuget-to-ado-feed.yml
@@ -1,0 +1,123 @@
+#
+# Push NuGet packages to an Azure DevOps NuGet feed using a managed-identity
+# access token.
+#
+# Mirrors the pattern from microsoft/react-native-windows
+# (.ado/templates/publish-nuget-to-ado-feed.yml). The release agent runs on
+# Azure-Pipelines-1ESPT-ExDShared and is not allowed to enlist sources, so it
+# cannot rotate a stored PAT on the service connection. Instead, this template
+# acquires a fresh access token from the managed identity at job time and
+# overrides the apitoken on the existing service connection for the duration
+# of the job. After that, 1ES.PublishNuGet@1 picks up the new token via the
+# normal service-connection lookup.
+#
+
+parameters:
+- name: azureSubscription
+  type: string
+  default: 'Office-V8-Jsi-Bot'
+  # The GUID of the service connection whose apitoken is being overridden.
+  # Look it up in ADO Project Settings -> Service connections -> click the
+  # connection -> the URL ends with `?resourceId=<GUID>`.
+- name: endpointId
+  type: string
+- name: nugetFeedUrl
+  type: string
+- name: packageParentPath
+  type: string
+- name: packagesToPush
+  type: string
+- name: publishFeedCredentials
+  type: string
+- name: feedDisplayName
+  type: string
+
+steps:
+- script: dir /S "${{ parameters.packageParentPath }}"
+  displayName: Show NuGet packages before cleanup
+
+- task: AzureCLI@2
+  displayName: Override NuGet credentials with Managed Identity
+  inputs:
+    azureSubscription: ${{ parameters.azureSubscription }}
+    visibleAzLogin: false
+    scriptType: 'pscore'
+    scriptLocation: 'inlineScript'
+    inlineScript: |
+      $accessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+      # Set the access token as a secret, so it doesn't get leaked in the logs
+      Write-Host "##vso[task.setsecret]$accessToken"
+      # Override the apitoken of the nuget service connection, for the duration of this stage
+      Write-Host "##vso[task.setendpoint id=${{ parameters.endpointId }};field=authParameter;key=apitoken]$accessToken"
+      # Also expose the token for the pre-push duplicate check
+      Write-Host "##vso[task.setvariable variable=NuGetAccessToken;issecret=true]$accessToken"
+
+- pwsh: |
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $feedUrl = "${{ parameters.nugetFeedUrl }}"
+    $token = "$(NuGetAccessToken)"
+    $headers = @{ Authorization = "Bearer $token" }
+
+    # Discover the flat container (PackageBaseAddress) URL from the V3 index
+    $index = Invoke-RestMethod -Uri $feedUrl -Headers $headers
+    $baseAddress = ($index.resources |
+      Where-Object { $_.'@type' -like 'PackageBaseAddress*' } |
+      Select-Object -First 1).'@id'
+    if (-not $baseAddress) { throw "Could not find PackageBaseAddress in NuGet V3 index at $feedUrl" }
+    if (-not $baseAddress.EndsWith('/')) { $baseAddress += '/' }
+    Write-Host "PackageBaseAddress: $baseAddress"
+
+    $nupkgs = Get-ChildItem -Path "${{ parameters.packageParentPath }}" -Filter "*.nupkg" -Recurse
+    $removedCount = 0
+
+    foreach ($file in $nupkgs) {
+      # Read the .nuspec from inside the nupkg (zip) to get the exact id and version
+      $zip = [System.IO.Compression.ZipFile]::OpenRead($file.FullName)
+      try {
+        $nuspecEntry = $zip.Entries | Where-Object { $_.FullName -like "*.nuspec" } | Select-Object -First 1
+        $reader = New-Object System.IO.StreamReader($nuspecEntry.Open())
+        [xml]$nuspec = $reader.ReadToEnd()
+        $reader.Close()
+      } finally { $zip.Dispose() }
+
+      $id = $nuspec.package.metadata.id
+      $version = $nuspec.package.metadata.version
+
+      # Query the flat container for all published versions of this package
+      $versionsUrl = "${baseAddress}$($id.ToLower())/index.json"
+      try {
+        $result = Invoke-RestMethod -Uri $versionsUrl -Headers $headers -ErrorAction Stop
+        if ($version.ToLower() -in $result.versions) {
+          Write-Host "  SKIP $id $version — already on feed"
+          Remove-Item $file.FullName
+          $removedCount++
+          continue
+        }
+      } catch {
+        if ($_.Exception.Response.StatusCode -eq [System.Net.HttpStatusCode]::NotFound) {
+          # Package has never been published — keep it
+        } else { throw }
+      }
+      Write-Host "  PUSH $id $version — new"
+    }
+
+    $remaining = (Get-ChildItem -Path "${{ parameters.packageParentPath }}" -Filter "*.nupkg" -Recurse).Count
+    Write-Host "Removed $removedCount already-published package(s). $remaining package(s) to push."
+    Write-Host "##vso[task.setvariable variable=HasNewPackages]$($remaining -gt 0)"
+  displayName: Remove already-published packages
+
+- script: dir /S "${{ parameters.packageParentPath }}"
+  displayName: Show NuGet packages after cleanup
+
+- task: 1ES.PublishNuGet@1
+  displayName: 'NuGet push to ${{ parameters.feedDisplayName }}'
+  condition: and(succeeded(), eq(variables['HasNewPackages'], 'True'))
+  inputs:
+    useDotNetTask: true
+    packageParentPath: '${{ parameters.packageParentPath }}'
+    packagesToPush: '${{ parameters.packagesToPush }}'
+    nuGetFeedType: external
+    publishFeedCredentials: '${{ parameters.publishFeedCredentials }}'
+    externalEndpoint: '${{ parameters.publishFeedCredentials }}'
+    publishPackageMetadata: true

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -116,7 +116,7 @@ extends:
 
             # Sign binaries only for the non-fake CI builds.
           - ${{ if and(eq(parameters.isPublish, true), eq(parameters.fakeBuild, false)) }}:
-            - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+            - task: EsrpCodeSigning@6
               displayName: CodeSign Binaries
               inputs:
                 connectedServiceName: 'ESRP-JSHost3'
@@ -172,7 +172,7 @@ extends:
         - checkout: none
 
           # The substitution tags in the nuspec require that we use at least NuGet 4.6.
-        - task: NuGetToolInstaller@0
+        - task: NuGetToolInstaller@1
           displayName: Install NuGet tools
           inputs:
             versionSpec: ">=4.6.0"
@@ -214,7 +214,7 @@ extends:
 
           # Sign the NuGet packages only for the CI builds.
         - ${{ if parameters.isPublish }}:
-          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+          - task: EsrpCodeSigning@6
             displayName: CodeSign NuGets
             inputs:
               connectedServiceName: 'ESRP-JSHost3'

--- a/.ado/windows-release.yml
+++ b/.ado/windows-release.yml
@@ -41,11 +41,13 @@ extends:
 
       jobs:
       - job: ms_react_native_nuget_job
-        displayName: Publish Nuget to ms/react-native
+        displayName: Publish Nuget to ms/react-native-public
         condition: succeeded()
-        timeoutInMinutes: 0
+        timeoutInMinutes: 30
 
         templateContext:
+          type: releaseJob
+          isProduction: true
           inputs:
           - input: pipelineArtifact
             pipeline: microsoft.v8-jsi.ci
@@ -53,30 +55,23 @@ extends:
             targetPath: $(Pipeline.Workspace)\published-packages
 
         steps:
-        - script: dir /S $(Pipeline.Workspace)\published-packages
-          displayName: Show directory contents
-
-        - script: dotnet nuget list source
-          displayName: Show Nuget sources
-
-          # TODO: Fix the NuGet name after the service connection approval
-        - task: 1ES.PublishNuGet@1
-          displayName: NuGet push
-          inputs:
-            useDotNetTask: true
+        - template: .ado/templates/publish-nuget-to-ado-feed.yml@self
+          parameters:
+            endpointId: '29e4c04c-ae69-4453-b9f3-bfef7a4c8d32'
+            nugetFeedUrl: 'https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json'
             packageParentPath: '$(Pipeline.Workspace)/published-packages'
             packagesToPush: '$(Pipeline.Workspace)/published-packages/ReactNative.V8Jsi.Windows.*.nupkg'
-            nuGetFeedType: external
             publishFeedCredentials: 'Nuget - ms/react-native-public'
-            externalEndpoint: 'Nuget - ms/react-native-public'
-            publishPackageMetadata: true
+            feedDisplayName: 'ms/react-native-public'
 
       - job: office_nuget_job
         displayName: Publish Nuget to office
         condition: succeeded()
-        timeoutInMinutes: 0
+        timeoutInMinutes: 30
 
         templateContext:
+          type: releaseJob
+          isProduction: true
           inputs:
           - input: pipelineArtifact
             pipeline: microsoft.v8-jsi.ci
@@ -85,14 +80,70 @@ extends:
 
         steps:
         - script: dir /S $(Pipeline.Workspace)\published-packages
-          displayName: Show directory contents
+          displayName: Show NuGet packages before cleanup
 
-        - script: dotnet nuget list source
-          displayName: Show Nuget sources
+        - pwsh: |
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
 
-          # TODO: Fix the NuGet name after the service connection approval
+            $feedUrl = 'https://pkgs.dev.azure.com/office/_packaging/office/nuget/v3/index.json'
+            $token = "$env:SYSTEM_ACCESSTOKEN"
+            $headers = @{ Authorization = "Bearer $token" }
+
+            # Discover the flat container (PackageBaseAddress) URL from the V3 index
+            $index = Invoke-RestMethod -Uri $feedUrl -Headers $headers
+            $baseAddress = ($index.resources |
+              Where-Object { $_.'@type' -like 'PackageBaseAddress*' } |
+              Select-Object -First 1).'@id'
+            if (-not $baseAddress) { throw "Could not find PackageBaseAddress in NuGet V3 index at $feedUrl" }
+            if (-not $baseAddress.EndsWith('/')) { $baseAddress += '/' }
+            Write-Host "PackageBaseAddress: $baseAddress"
+
+            $nupkgs = Get-ChildItem -Path '$(Pipeline.Workspace)/published-packages' -Filter '*.nupkg' -Recurse
+            $removedCount = 0
+
+            foreach ($file in $nupkgs) {
+              # Read the .nuspec from inside the nupkg (zip) to get the exact id and version
+              $zip = [System.IO.Compression.ZipFile]::OpenRead($file.FullName)
+              try {
+                $nuspecEntry = $zip.Entries | Where-Object { $_.FullName -like '*.nuspec' } | Select-Object -First 1
+                $reader = New-Object System.IO.StreamReader($nuspecEntry.Open())
+                [xml]$nuspec = $reader.ReadToEnd()
+                $reader.Close()
+              } finally { $zip.Dispose() }
+
+              $id = $nuspec.package.metadata.id
+              $version = $nuspec.package.metadata.version
+
+              $versionsUrl = "${baseAddress}$($id.ToLower())/index.json"
+              try {
+                $result = Invoke-RestMethod -Uri $versionsUrl -Headers $headers -ErrorAction Stop
+                if ($version.ToLower() -in $result.versions) {
+                  Write-Host "  SKIP $id $version — already on office feed"
+                  Remove-Item $file.FullName
+                  $removedCount++
+                  continue
+                }
+              } catch {
+                if ($_.Exception.Response.StatusCode -eq [System.Net.HttpStatusCode]::NotFound) {
+                  # Package has never been published — keep it
+                } else { throw }
+              }
+              Write-Host "  PUSH $id $version — new"
+            }
+
+            $remaining = (Get-ChildItem -Path '$(Pipeline.Workspace)/published-packages' -Filter '*.nupkg' -Recurse).Count
+            Write-Host "Removed $removedCount already-published package(s). $remaining package(s) to push."
+            Write-Host "##vso[task.setvariable variable=HasNewPackages]$($remaining -gt 0)"
+          displayName: Remove already-published packages
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+        - script: dir /S $(Pipeline.Workspace)\published-packages
+          displayName: Show NuGet packages after cleanup
+
         - task: 1ES.PublishNuGet@1
-          displayName: NuGet push
+          displayName: NuGet push to office
+          condition: and(succeeded(), eq(variables['HasNewPackages'], 'True'))
           inputs:
             useDotNetTask: true
             packageParentPath: '$(Pipeline.Workspace)/published-packages'


### PR DESCRIPTION
# Fix publishing to ms/react-native-public feed

Follow-up to the previous PR ("Publish PDB files from the Release pipeline").
After that one merged, the next release run surfaced a fresh problem in the
NuGet push job and a couple of stale task versions in the build template.
This PR fixes them in one batch.

## Summary

Three issues addressed:

1. **ms/react-native-public push fails with 401 Unauthorized.** The
   `1ES.PublishNuGet@1` task in `ms_react_native_nuget_job` was authenticating
   via the stored credential on the `Nuget - ms/react-native-public` service
   connection, which is no longer valid. The push log shows
   `dotnet nuget push … --api-key RequiredApiKey` followed by
   `Response status code does not indicate success: 401 (Unauthorized).`

2. **Office push has no skip-already-published logic.** Re-running a release
   for any reason (e.g. transient failure on a peer feed, or just the new
   PDB-publish job) re-runs the office push too. Without a skip step it
   tries to push a version that's already there and fails the entire job.
   The CI pipeline must remain re-runnable so a single feed failure does
   not block re-publishing the others.

3. **Outdated task versions in `windows-jobs.yml`.**
   `SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5` is the legacy
   fully-qualified name; it was promoted into the standard catalog as
   `EsrpCodeSigning@6` long ago. Hermes-windows already migrated;
   v8-jsi still on the old name. Same story for `NuGetToolInstaller@0` →
   `@1`.

## What changes

### New file: `.ado/templates/publish-nuget-to-ado-feed.yml`

A v8-jsi-local copy of the
[react-native-windows template of the same name](https://github.com/microsoft/react-native-windows/blob/main/.ado/templates/publish-nuget-to-ado-feed.yml).
The default `azureSubscription` is set to `Office-V8-Jsi-Bot` (the v8-jsi
managed-identity service connection added in the previous PR for symbol
publishing).

What the template does:

1. `AzureCLI@2` against `Office-V8-Jsi-Bot` runs `az account get-access-token`
   to mint a fresh ADO access token for resource
   `499b84ac-1321-427f-aa17-267ca6975798` (Azure DevOps).
2. The token is set as a build secret and is also written into the existing
   service connection's `apitoken` auth field via
   `##vso[task.setendpoint id=…;field=authParameter;key=apitoken]`. This
   replaces the stale stored credential for the duration of the job.
3. A pwsh step queries the feed's V3 PackageBaseAddress index for each
   `*.nupkg` and removes any whose version is already on the feed. Sets a
   `HasNewPackages` variable so the push step can skip when there is
   nothing left to send.
4. `1ES.PublishNuGet@1` runs only when `HasNewPackages == True`, using the
   service connection (now with the freshly minted token).

### `.ado/windows-release.yml`

* **`ms_react_native_nuget_job`** is rewritten to call the new template:

  ```yaml
  - template: .ado/templates/publish-nuget-to-ado-feed.yml@self
    parameters:
      endpointId: '29e4c04c-ae69-4453-b9f3-bfef7a4c8d32'   # Nuget - ms/react-native-public service connection
      nugetFeedUrl: 'https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json'
      packageParentPath: '$(Pipeline.Workspace)/published-packages'
      packagesToPush: '$(Pipeline.Workspace)/published-packages/ReactNative.V8Jsi.Windows.*.nupkg'
      publishFeedCredentials: 'Nuget - ms/react-native-public'
      feedDisplayName: 'ms/react-native-public'
  ```

  Display name corrected from "Publish Nuget to ms/react-native" to
  "Publish Nuget to ms/react-native-public" (the actual feed). Job timeout
  changed from `0` (unlimited) to `30` minutes; `templateContext.type:
  releaseJob` + `isProduction: true` added for parity with the other
  release-stage jobs and 1ES policy.

* **`office_nuget_job`** keeps using `1ES.PublishNuGet@1` with the existing
  `ES365-Office-Nuget-Package-Publisher` service connection (which works —
  no token override needed) but gets an inline skip-already-published step
  in front of it. The skip step authenticates against the office feed at
  `https://pkgs.dev.azure.com/office/_packaging/office/nuget/v3/index.json`
  using `$(System.AccessToken)` — the build agent's OAuth token, already
  authorized to read ADO feeds in the same org. Same `HasNewPackages` /
  `condition:` pattern as the template. Inlined rather than templatized
  per project preference. Also gains `templateContext.type: releaseJob` +
  `isProduction: true` and a 30-minute timeout for consistency.

* The previous "TODO: Fix the NuGet name after the service connection
  approval" comments are removed (resolved by this PR).

### `.ado/windows-jobs.yml`

Pure task-version bumps, no behavior change:

* `task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5` →
  `task: EsrpCodeSigning@6` for binary signing in `V8JsiBuild_*` jobs.
* `task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5` →
  `task: EsrpCodeSigning@6` for NuGet signing in `V8JsiCreateNuget`.
* `task: NuGetToolInstaller@0` → `task: NuGetToolInstaller@1`.

Input keys are left in camelCase; `EsrpCodeSigning@6` accepts both casings,
and not touching the input keys keeps this strictly mechanical. Matches
the migration pattern hermes-windows used last quarter.

## Why this shape

* **MI for ms/react-native-public, but not for office.** The two feeds need
  different fixes because they have different working pieces. The public
  feed needs a fresh token because the service connection's stored credential
  is dead; the office feed already pushes successfully via its existing
  service connection — the only thing it was missing was the skip-duplicate
  logic. Using `Office-V8-Jsi-Bot` for the public feed and
  `$(System.AccessToken)` for the office feed's read-only check keeps each
  side using the simplest auth that works.
* **Skip-already-published, not a top-level "version already released" gate.**
  The skip is per-feed by design: when one feed publish fails for a transient
  reason, the release can be re-queued and the already-succeeded feeds
  silently no-op. A top-level gate would defeat that re-runnability.
* **PDBs are not re-skipped.** Symbol-server uploads are content-addressed
  by the PDB's GUID+age, so re-uploading the same PDB is server-side
  idempotent (storage dedup by SHA-256). No client-side skip needed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/232)