### PR TITLE
Adopt Hybrid CRT for `v8jsi.dll` on Win32

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.79.4",
+    "version":  "0.79.5",
     "v8ref":  "refs/branch-heads/12.1",
     "buildNumber":  "285"
 }

--- a/scripts/patch/build.diff
+++ b/scripts/patch/build.diff
@@ -40,7 +40,7 @@ index 6e1417aa4..4079a06c8 100644
      } else {
        # Desktop Windows: static CRT.
 -      configs = [ ":static_crt" ]
-+      configs = [ ":dynamic_crt", ":win_msvc_cfg" ]
++      configs = [ ":static_crt", ":win_msvc_cfg" ]
      }
    }
  }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -6,6 +6,28 @@ declare_args() {
   v8jsi_enable_node_api = true
 }
 
+# Hybrid CRT: drop the static UCRT pulled in by /MT(d) and use the dynamic
+# system UCRT instead. Result: no MSVCP140.dll / VCRUNTIME140.dll dependency,
+# and no Visual C++ Redistributable required on end-user machines.
+# Skipped on UWP (Store policy forbids static MSVC) and component builds
+# (those keep /MD(d) via :default_crt). See
+# https://github.com/microsoft/WindowsAppSDK/blob/main/docs/Coding-Guidelines/HybridCRT.md
+config("hybrid_crt_swap") {
+  if (is_win && current_os != "winuwp" && !is_component_build) {
+    if (is_debug) {
+      ldflags = [
+        "/NODEFAULTLIB:libucrtd.lib",
+        "/DEFAULTLIB:ucrtd.lib",
+      ]
+    } else {
+      ldflags = [
+        "/NODEFAULTLIB:libucrt.lib",
+        "/DEFAULTLIB:ucrt.lib",
+      ]
+    }
+  }
+}
+
 target("shared_library", "v8jsi") {
   sources = [
     "IsolateData.h",
@@ -102,6 +124,7 @@ target("shared_library", "v8jsi") {
     "//:toolchain",
     "//:internal_config_base",
     "//build/config/compiler:exceptions",
+    ":hybrid_crt_swap",
   ]
   configs -= [ "//build/config/compiler:no_exceptions" ]
 
@@ -147,6 +170,7 @@ target("executable", "jsitests") {
     "//:internal_config_base",
     "//build/config/compiler:exceptions",
     "//build/config/compiler:rtti",
+    ":hybrid_crt_swap",
   ]
   configs -= [
     "//build/config/compiler:no_exceptions",

--- a/src/node-api/test/BUILD.gn
+++ b/src/node-api/test/BUILD.gn
@@ -62,6 +62,22 @@ config("test_module") {
     "..",
     "js-native-api",
   ]
+
+  # Hybrid CRT: keep the test-module DLLs in lockstep with v8jsi.dll —
+  # static C++ runtime + dynamic UCRT. See //jsi:hybrid_crt_swap.
+  if (is_win && current_os != "winuwp" && !is_component_build) {
+    if (is_debug) {
+      ldflags = [
+        "/NODEFAULTLIB:libucrtd.lib",
+        "/DEFAULTLIB:ucrtd.lib",
+      ]
+    } else {
+      ldflags = [
+        "/NODEFAULTLIB:libucrt.lib",
+        "/DEFAULTLIB:ucrt.lib",
+      ]
+    }
+  }
 }
 
 # Test modules
@@ -310,6 +326,7 @@ executable("node_lite") {
     "//:internal_config_base",
     "//build/config/compiler:exceptions",
     "//build/config/compiler:rtti",
+    "//jsi:hybrid_crt_swap",
   ]
   configs -= [
     "//build/config/compiler:no_exceptions",
@@ -390,6 +407,7 @@ executable("node_api_tests") {
     "//:internal_config_base",
     "//build/config/compiler:exceptions",
     "//build/config/compiler:rtti",
+    "//jsi:hybrid_crt_swap",
   ]
   configs -= [
     "//build/config/compiler:no_exceptions",


### PR DESCRIPTION
## Summary

`v8jsi.dll` today links the C/C++ runtime dynamically (`/MD` /
`/MDd`), so it carries a hard load-time dependency on
`MSVCP140.dll`, `VCRUNTIME140.dll`, and `VCRUNTIME140_1.dll`. Those
DLLs ship via the Visual C++ Redistributable, are not inbox on
Windows, and pin a specific MSVC toolset. On older / clean Windows
images without `vc_redist` installed, `v8jsi.dll` fails to load and
the host process crashes.

Switch the Win32 build to the **Hybrid CRT** model documented for
the Windows App SDK: **statically link the C++ runtime, keep the
Universal CRT (UCRT) dynamic.** UCRT is inbox on every supported
Windows 10+ machine, so `v8jsi.dll` becomes redistributable-free
while avoiding the size cost of a fully static build.

UWP (`winuwp` / `WindowsStore`) targets continue to use the default
dynamic CRT — Microsoft Store policy forbids statically linking the
MSVC runtime in app-container binaries. Component builds also keep
the dynamic CRT.

Reference: [Windows App SDK — Hybrid CRT
guidance][hybridcrt-guidance]. Reference implementation in our
family of forks: [hermes-windows PR #256][hermes-pr].

[hybridcrt-guidance]: https://github.com/microsoft/WindowsAppSDK/blob/main/docs/Coding-Guidelines/HybridCRT.md
[hermes-pr]: https://github.com/microsoft/hermes-windows/pull/256

## Changes

**1. `scripts/patch/build.diff` — flip `default_crt` desktop branch
to `:static_crt`.** Our existing patch on
`build/config/win/BUILD.gn` previously forced `:dynamic_crt` on
every branch (component, UWP, desktop). Restore upstream's
`:static_crt` selection on the desktop-Windows branch, while keeping
our `:win_msvc_cfg` addition. UWP and component builds are
unchanged. With this single line, every target the V8 toolchain
applies `default_crt` to — `v8_monolith`, `v8jsi`, the test
binaries — switches from `/MD(d)` to `/MT(d)` for desktop Win32.

**2. `src/BUILD.gn` — new `:hybrid_crt_swap` GN config.** `/MT(d)`
also pulls in the *static* UCRT (`libucrt(d).lib`), which we don't
want — it would defeat the point of keeping UCRT dynamic. The new
config emits the standard MSVC linker swap:

```
/NODEFAULTLIB:libucrt[d].lib
/DEFAULTLIB:ucrt[d].lib
```

so the static UCRT is dropped from the link and the dynamic UCRT
import library takes its place. Gated on
`is_win && current_os != "winuwp" && !is_component_build` so UWP
and component builds remain untouched. Branched on `is_debug` to
pick the correct `[d]` variant. Applied to the `v8jsi` and
`jsitests` targets.

**3. `src/node-api/test/BUILD.gn` — extend the swap to test
binaries.** `node_lite` and `node_api_tests` reference the new
`//jsi:hybrid_crt_swap` directly. The 33 `loadable_module` test
DLLs all pull in the existing `:test_module` config, so the swap
ldflags are inlined there in one place rather than added to each
loadable_module separately. Same gating, same `is_debug`
branching. Keeps every test binary's CRT in lockstep with
`v8jsi.dll`.

## Public API

Unchanged. No exports added or removed. No header changes. The
only observable effect is the import table of the produced PE
binaries.

## Build / linkage matrix after this change

| Target               | Compile     | UCRT                            | VCRUNTIME / MSVCP             |
| -------------------- | ----------- | ------------------------------- | ----------------------------- |
| Win32 desktop x64/x86/arm64 (Release/Debug) | `/MT(d)`    | dynamic (`ucrtbase[d].dll`)     | statically linked, no DLL dep |
| `winuwp` (any arch)  | `/MD(d)`    | dynamic                         | dynamic — VCLibs framework    |
| `is_component_build` | `/MD(d)`    | dynamic                         | dynamic                       |

## Files changed

- `scripts/patch/build.diff` — one line: desktop branch's `+`
  side now selects `:static_crt` instead of `:dynamic_crt`.
- `src/BUILD.gn` — new `config("hybrid_crt_swap")`; referenced
  from the `v8jsi` and `jsitests` targets' `configs` list.
- `src/node-api/test/BUILD.gn` — UCRT swap inlined in the
  `:test_module` config so all 33 `loadable_module` test DLLs
  inherit it; `//jsi:hybrid_crt_swap` added to the `node_lite`
  and `node_api_tests` executables.

Net: +43 / -1 lines.

## Validation

**x64 Debug confirmed locally.** `dumpbin /imports v8jsi.dll`
after the change:

- `ucrtbased.dll` present (dynamic UCRT, debug variant).
- `MSVCP140d.dll`, `VCRUNTIME140d.dll`, `VCRUNTIME140_1d.dll` —
  all gone.
- Non-CRT imports (`ADVAPI32`, `WS2_32`, `KERNEL32`, `MSWSOCK`,
  `dbghelp`, `WINMM`) are unchanged.

The remaining slices (x64 Release, x86 Release/Debug, arm64
Release/Debug) and a clean-VM smoke test (Windows image without
`vc_redist` installed) will be verified before merge. The Release
import table will show `api-ms-win-crt-*-l1-1-0.dll` forwarders
instead of a direct `ucrtbase.dll` row — both shapes are correct
Hybrid CRT, the difference is the Debug UCRT skipping the
api-set redirection.

The existing JSI and Node-API test suites under `src/jsi/test`
and `src/node-api/test` are run for regressions.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/233)