### PR TITLE
[0.74] Use large pool to improve CI build speed

### DIFF
--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -56,9 +56,7 @@ extends:
       ${{ if eq(parameters.isPublish, false) }}:
         skipBuildTagsForGitHubPullRequests: true
     pool:
-      name: Azure-Pipelines-1ESPT-ExDShared
-      image: windows-latest
-      os: windows
+      name: fabric-internal-pool-large
     sdl:
       binskim:
         analyzeTarget: |
@@ -86,7 +84,7 @@ extends:
         - job: V8JsiBuild_${{ matrix.Name }}
           displayName: Build V8-JSI ${{ matrix.Name }}
 
-          timeoutInMinutes: 1800
+          timeoutInMinutes: 1200
 
           variables:
           - name: Packaging.EnableSBOMSigning


### PR DESCRIPTION
Currently the build in CI pipeline for 0.74-stable branch takes more than 24 hours.
This issue already fixed in `master` branch by using bigger machines provided by the `fabric-internal-pool-large` machine pool.
This PR backports the changes from the `master` branch to `0.74-stable` branch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/235)