### PR TITLE
[0.74] Set JSI version to 11

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version":  "0.74.7",
+    "version":  "0.74.8",
     "v8ref":  "refs/branch-heads/12.1",
     "buildNumber":  "285"
 }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -139,7 +139,16 @@ target("shared_library", "v8jsi") {
     "//:v8_monolith",
   ]
 
-  defines = [ "BUILDING_V8JSI_SHARED" ]
+  defines = [
+    "BUILDING_V8JSI_SHARED",
+
+    # Pin JSI_VERSION explicitly so v8jsi.dll's jsi::Runtime vtable layout is
+    # deterministic and matches consumers that build against the same version.
+    # Without this, jsi.h falls through to its default and a mismatch with the
+    # consumer's JSI_VERSION causes virtual dispatch into the DLL to land on
+    # the wrong method (e.g. createPropNameIDFromAscii hitting cloneSymbol).
+    "JSI_VERSION=11",
+  ]
 
   if (is_win) {
     libs = [

--- a/src/jsi/jsi.h
+++ b/src/jsi/jsi.h
@@ -27,8 +27,11 @@
 #endif
 
 #ifndef JSI_VERSION
-// Use the latest version by default
-#define JSI_VERSION 12
+// Default JSI_VERSION. Consumers may override via <jsi/jsi-version.h> or by
+// defining JSI_VERSION on the compiler command line. Keep this in sync with
+// what v8jsi.dll itself is compiled against to avoid jsi::Runtime vtable
+// layout mismatches across module boundaries.
+#define JSI_VERSION 11
 #endif
 
 #if JSI_VERSION >= 3


### PR DESCRIPTION
The RNW version 0.74 uses the JSI version 11.
Changing the JSI for v8jsi.dll version to 11 to match the RNW version.
Otherwise we see runtime crashes caused by v-table layout mismatch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/237)