### PR TITLE
Export JSI RTTI from shared library builds

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -124,9 +124,13 @@ target("shared_library", "v8jsi") {
     "//:toolchain",
     "//:internal_config_base",
     "//build/config/compiler:exceptions",
+    "//build/config/compiler:rtti",
     ":hybrid_crt_swap",
   ]
-  configs -= [ "//build/config/compiler:no_exceptions" ]
+  configs -= [
+    "//build/config/compiler:no_exceptions",
+    "//build/config/compiler:no_rtti",
+  ]
 
   if (is_win) {
     configs -= [ "//build/config/compiler:cet_shadow_stack" ]

--- a/src/jsi/jsi.h
+++ b/src/jsi/jsi.h
@@ -57,7 +57,7 @@
 #define JSI_EXPORT
 #endif // CREATE_SHARED_LIBRARY
 #else // _MSC_VER
-#define JSI_EXPORT __attribute__((visibility("default")))
+#define JSI_EXPORT __attribute__((visibility("default"), type_visibility("default")))
 #endif // _MSC_VER
 #endif // !defined(JSI_EXPORT)
 


### PR DESCRIPTION
## Summary

This makes shared-library `v8jsi` builds export JSI RTTI/vtable metadata on Clang/GCC by adding `type_visibility("default")` to `JSI_EXPORT` and explicitly enabling RTTI for the `v8jsi` shared library target.

## Why

Consumers that link against `libv8jsi.dylib` without compiling their own copy of `jsi.cpp` need the canonical JSI exception/base-class symbols, vtables, and typeinfo to come from `libv8jsi`. Without exported RTTI/type metadata, cross-dylib exception handling and polymorphic JSI base classes can fail at runtime.

This showed up while integrating v8-jsi as a drop-in JSI backend for a Godot GDExtension that already links against a JSI implementation dynamically.

## Testing

Validated locally on macOS arm64 by rebuilding `libv8jsi.dylib` and checking the dynamic symbol table exports JSI destructors plus `typeinfo`/`vtable` symbols for `facebook::jsi::JSError`, `JSIException`, `Runtime`, `HostObject`, `NativeState`, `Buffer`, `MutableBuffer`, and `PreparedJavaScript`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/238)