### PR TITLE
Build v8jsi from Node.js 24.x source code

### DIFF
--- a/.ado/windows-build-new.yml
+++ b/.ado/windows-build-new.yml
@@ -19,6 +19,20 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.fakeBuild, false) }}:
+  # OpenSSL (built from the Node.js tree) assembles its crypto with NASM on
+  # x86/x64. Provision NASM and prepend it to PATH for the build step. Not needed
+  # on arm64, where the OpenSSL asm path is skipped.
+  - task: PowerShell@2
+    displayName: Download NASM 2.16.03
+    condition: and(succeeded(), not(startsWith('${{parameters.buildPlatform}}', 'arm')))
+    inputs:
+      targetType: inline
+      workingDirectory: $(Build.SourcesDirectory)
+      script: |
+        $ErrorActionPreference = 'Stop'
+        Invoke-WebRequest -Uri https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/win64/nasm-2.16.03-win64.zip -OutFile nasm-2.16.03-win64.zip
+        Expand-Archive nasm-2.16.03-win64.zip -DestinationPath nasm -Force
+
   - task: PowerShell@2
     displayName: Build v8jsi.dll via scripts/build.ts
     inputs:
@@ -30,6 +44,8 @@ steps:
             --platform ${{parameters.buildPlatform}} `
             --configuration ${{parameters.buildConfiguration}}
         if ($LASTEXITCODE -ne 0) { throw "scripts/build.ts failed (exit $LASTEXITCODE)" }
+    env:
+      path: $(Build.SourcesDirectory)\nasm\nasm-2.16.03;$(path)
 
   - task: PowerShell@2
     displayName: Run v8jsi_test.exe

--- a/.ado/windows-build-new.yml
+++ b/.ado/windows-build-new.yml
@@ -1,0 +1,73 @@
+parameters:
+- name: appPlatform
+  type: string
+- name: outputPath
+  type: string
+  # isPublish is `true` for CI builds and `false` for PR validation.
+- name: isPublish
+  type: boolean
+  default: false
+- name: buildConfiguration
+  type: string
+- name: buildPlatform
+  type: string
+  # To fake building v8-jsi for faster debugging.
+- name: fakeBuild
+  type: boolean
+  default: false
+
+
+steps:
+- ${{ if eq(parameters.fakeBuild, false) }}:
+  - task: PowerShell@2
+    displayName: Build v8jsi.dll via scripts/build.ts
+    inputs:
+      targetType: inline
+      workingDirectory: $(Build.SourcesDirectory)
+      script: |
+        $ErrorActionPreference = 'Stop'
+        node scripts/build.ts `
+            --platform ${{parameters.buildPlatform}} `
+            --configuration ${{parameters.buildConfiguration}}
+        if ($LASTEXITCODE -ne 0) { throw "scripts/build.ts failed (exit $LASTEXITCODE)" }
+
+  - task: PowerShell@2
+    displayName: Run v8jsi_test.exe
+    inputs:
+      targetType: inline
+      workingDirectory: $(Build.SourcesDirectory)
+      script: |
+        $ErrorActionPreference = 'Stop'
+        $exe = "deps/nodejs/out/${{parameters.buildConfiguration}}/v8jsi_test.exe"
+        if (-not (Test-Path $exe)) { throw "Test executable not found: $exe" }
+        & $exe --gtest_brief=1
+        if ($LASTEXITCODE -ne 0) { throw "v8jsi_test.exe failed (exit $LASTEXITCODE)" }
+    condition: and(succeeded(), not(startsWith('${{parameters.buildPlatform}}', 'arm')))
+
+  - task: PowerShell@2
+    displayName: Run node_api_tests.exe
+    inputs:
+      targetType: inline
+      workingDirectory: $(Build.SourcesDirectory)
+      script: |
+        $ErrorActionPreference = 'Stop'
+        $exe = "deps/nodejs/out/${{parameters.buildConfiguration}}/node_api_tests.exe"
+        if (-not (Test-Path $exe)) { throw "Test executable not found: $exe" }
+        & $exe --gtest_brief=1
+        if ($LASTEXITCODE -ne 0) { throw "node_api_tests.exe failed (exit $LASTEXITCODE)" }
+    condition: and(succeeded(), not(startsWith('${{parameters.buildPlatform}}', 'arm')))
+
+  - task: PowerShell@2
+    displayName: Stage v8jsi.dll artifact
+    inputs:
+      targetType: inline
+      workingDirectory: $(Build.SourcesDirectory)
+      script: |
+        $ErrorActionPreference = 'Stop'
+        $src = "deps/nodejs/out/${{parameters.buildConfiguration}}"
+        $dest = '${{parameters.outputPath}}'
+        New-Item -ItemType Directory -Force -Path $dest | Out-Null
+        Copy-Item -Path (Join-Path $src 'v8jsi.dll') -Destination $dest
+        if (Test-Path (Join-Path $src 'v8jsi.dll.pdb')) {
+          Copy-Item -Path (Join-Path $src 'v8jsi.dll.pdb') -Destination $dest
+        }

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -155,6 +155,44 @@ extends:
                     }
                   ]
 
+      - ${{ each matrix in parameters.BuildMatrix }}:
+        - job: V8JsiBuildNew_${{ matrix.Name }}
+          displayName: Build V8-JSI (Node.js source) ${{ matrix.Name }}
+
+          timeoutInMinutes: 1200
+
+          variables:
+          - name: Packaging.EnableSBOMSigning
+            value: ${{ startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft') }}
+
+          templateContext:
+            outputs:
+            - output: pipelineArtifact
+              artifactName: ${{ matrix.Name }}-new
+              targetPath: $(Build.StagingDirectory)\out-new
+
+          steps:
+          - task: UsePythonVersion@0
+            displayName: Use Python 3.x
+            inputs:
+              versionSpec: '3.x'
+              addToPath: true
+              architecture: 'x64'
+
+          - task: NodeTool@0
+            displayName: Use Node.js 24.x
+            inputs:
+              versionSpec: '24.x'
+
+          - template: /.ado/windows-build-new.yml@self
+            parameters:
+              outputPath: $(Build.StagingDirectory)\out-new
+              appPlatform: ${{ matrix.AppPlatform }}
+              buildConfiguration: ${{ matrix.BuildConfiguration }}
+              buildPlatform: ${{ matrix.BuildPlatform }}
+              isPublish: ${{ parameters.isPublish }}
+              fakeBuild: ${{ parameters.fakeBuild }}
+
       - job: V8JsiCreateNuget
         dependsOn:
         - ${{ each matrix in parameters.BuildMatrix }}:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,16 @@ out
 .sync/
 .logs/
 node_modules/
+
+# test-harness (real-consumer smoke build) — build outputs + NuGet restore.
+# Source files (main.cpp, consumer.vcxproj, run-smoke.ps1, packages.config,
+# *.ps1 helpers) stay tracked.
+test-harness/bin/
+test-harness/obj/
+test-harness/packages/
+
+# gyp-generated stub .sln files under src/ — gyp emits a per-gyp-file .sln
+# alongside the .vcxproj files, but the only solution we actually build
+# against is deps/nodejs/node.sln (which aggregates everything). These
+# stubs have no Project() entries and aren't referenced by anything.
+src/**/*.sln

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,197 @@
+# V8-JSI — Project Guide
+
+V8-JSI implements the JavaScript Interface (JSI) on top of the **V8** JavaScript
+engine, bridging native code and JavaScript. It ships as `v8jsi.dll` and is
+consumed mainly by React Native for Windows and related Microsoft projects.
+
+The project is transitioning from a standalone Google V8 build to building V8
+from the **vendored Node.js sources** under `deps/nodejs/`. New development
+targets the Node.js-based build.
+
+## Environment
+
+This is a Windows project. Builds and tooling run on Windows with **PowerShell**;
+paths use backslashes and `$null`/`$env:` rather than POSIX equivalents. The
+TypeScript tooling under `scripts/` runs on Node.js v24 directly (it uses
+`--strip-types`, so there is no separate transpile step — run `node script.ts`).
+
+## Build
+
+`v8jsi.dll` is built from the vendored Node.js v24.x tree via `scripts/build.ts`
+(which wraps `deps/nodejs/vcbuild.bat` with the right narrow-build flags).
+
+Canonical entry point:
+```powershell
+Set-Location 'e:\GitHub\microsoft\v8-jsi\scripts'
+node build.ts --platform x64 --configuration release   # or: debug
+```
+
+Raw `vcbuild.bat` (narrow-build flags spelled out):
+```powershell
+Set-Location 'e:\GitHub\microsoft\v8-jsi\deps\nodejs'
+.\vcbuild.bat release v8jsi without-intl no-node no-cctest no-embedtest no-openssl-cli no-fuzzers no-nop no-overlapped-checker
+```
+
+The `no-*` flags switch MSBuild from the solution-level `Build` meta-target to an
+explicit target list, skipping every Node.js binary v8-jsi does not ship
+(node.exe, cctest, embedtest, openssl-cli, fuzzers, nop, overlapped-checker).
+Running `vcbuild.bat release v8jsi without-intl` with no `no-*` flags falls
+through to the legacy whole-solution build. See
+[design-part-a.md](e:/GitHub/vmoroz/kb/v8-jsi/new-v8jsi-dll-phase1-cleanup/design-part-a.md)
+for the full mechanism.
+
+Clean build (for stale-artifact issues):
+```powershell
+Set-Location 'e:\GitHub\microsoft\v8-jsi\deps\nodejs'; .\vcbuild.bat clean
+```
+
+**Outputs** (`Release` or `Debug` per configuration):
+- `deps/nodejs/out/<config>/v8jsi.dll` — the shared library
+- `deps/nodejs/out/<config>/v8jsi_test.exe` — JSI test runner
+- `deps/nodejs/out/<config>/node_api_tests.exe` — Node-API test runner
+
+**Verifying a build succeeded:** `vcbuild.bat` prints a `Build took N m N s` line
+on success and the output binaries get fresh timestamps. These are more reliable
+signals than a shell pipeline's exit code, which can be misleading.
+
+**Key build files:**
+- `src/v8jsi.gyp` — main GYP target for v8jsi
+- `deps/nodejs/node.gyp` — includes `v8jsi.gyp` when `build_v8jsi=1`
+- `deps/nodejs/vcbuild.bat`, `deps/nodejs/configure.py` (`--build-v8jsi`)
+
+**Build variables:**
+- `v8jsi_root` = `../..` (from `deps/nodejs` to the repo root)
+- `v8jsi_enable_inspector` = 1 — the inspector is **always enabled**; v8-jsi must
+  ship with it on
+- `v8jsi_enable_node_api` — always-on in `v8jsi.gyp` (defines `V8JSI_ENABLE_NODE_API`)
+- `v8jsi_test_hooks` = 1 (default) — when 1, `v8jsi.dll` exports test-only hooks
+  guarded by `#ifdef JSI_TESTING_ONLY` (e.g. `v8_jsi_test_post_foreground_task`).
+  CI/release builds may set 0; test targets that reference a gated symbol then
+  fail to link.
+
+## Testing
+
+```powershell
+& 'e:\GitHub\microsoft\v8-jsi\deps\nodejs\out\Release\v8jsi_test.exe' --gtest_brief=1
+& 'e:\GitHub\microsoft\v8-jsi\deps\nodejs\out\Release\node_api_tests.exe' --gtest_brief=1
+```
+
+`v8jsi_test.exe` runs each JSI test against two runtime parameterizations,
+`.../0` and `.../1` (filter with `--gtest_filter=*0` / `*1`). Both are
+ABI-backed; `/0` goes through the public `makeV8Runtime`, `/1` through
+`makeJsiAbiRuntime` directly. Test sources: `src/jsitests_main.cpp`,
+`src/jsi/test/testlib.cpp` (from Meta), `src/jsi/test/testlib_ext.cpp`
+(V8-specific). Swap `Release`→`Debug` to exercise the Debug build (which compiles
+in V8's DCHECKs).
+
+Recent baseline: 116 JSI tests + 52 Node-API tests, x64 Release and Debug
+(the exact counts shift as tests are added or removed).
+
+## Source layout
+
+### Core (`src/`)
+- `V8JsiRuntime.cpp` / `V8JsiRuntime_impl.h` — legacy JSI runtime (uses C++
+  exceptions)
+- `v8_core.{h,cpp}` — shared V8 infrastructure (platform, isolate data, `TryCatch`
+  wrapper) used by both the ABI and the Node-API surfaces
+- `IsolateData.h` — V8 isolate data management
+- `V8Instrumentation.{cpp,h}` — performance/heap instrumentation (backs the
+  Node-API `jsr_instrumentation_*` surface)
+- `MurmurHash.{cpp,h}` — hashing
+- `v8jsi.cpp` — DLL exports / test entry points
+- `jsitests_main.cpp` — JSI test main + runtime factories
+
+### JSI interface (`src/jsi/`)
+`jsi.h` / `jsi.cpp` / `jsi-inl.h` / `decorator.h` / `instrumentation.h` — the core
+JSI interface (synced from `facebook/hermes`). `src/jsi/test/` holds the shared
+test library.
+
+### ABI layer (`src/jsi_abi/`)
+The binary-stable C ABI for JSI (see "ABI architecture" below).
+- `jsi_abi.h` — engine-agnostic C ABI header (shared with hermes-windows)
+- `jsi_abi_helpers.h` — C++ helpers for the OrError encodings (shared)
+- `jsi_abi_v8.cpp` — V8 implementation of the ABI (exception-free)
+- `v8_jsi_config.h` — V8-specific config + `v8_create_runtime` / `v8_jsi_set_v8_flags`
+- `JsiAbiRuntime.{h,cpp}` — C++ wrapper implementing `jsi::Runtime` over the ABI
+  (shared with hermes-windows; uses exceptions for JSI compatibility)
+- `v8_node_api_attach.h` — seam that attaches a Node-API surface to a `jsi_runtime`
+- `jsi_abi_v8_internal.h` — in-DLL-only accessors (not a public/consumer header)
+
+### Public headers (`src/public/`)
+- `V8JsiRuntime.h` + `V8JsiRuntime.cpp` — the legacy public `makeV8Runtime` API
+  (the `.cpp` is consumer-compiled source)
+- `ScriptStore.h` — prepared-script storage interface
+- `v8_api.h` — V8-specific Node-API config extensions
+
+### Node-API (`src/node-api/`)
+- `js_runtime_api.h` — the `jsr_*` JSI runtime API
+- `v8_api_abi.cpp` — Node-API → JSI-ABI bridge
+- standard Node-API headers (`js_native_api*.h`, `util-inl.h`, `env-inl.h`) are
+  vendored from Node.js
+
+### Platform / inspector
+- `src/jsi/jsilib-windows.cpp`, `src/etw/` — Windows + ETW
+- `src/inspector/` — V8 inspector integration (enabled)
+
+## ABI architecture
+
+> The JSI ABI surface (`src/jsi_abi/*.h`, `src/node-api/js_runtime_api.h`,
+> `src/public/v8_api.h`) is **experimental and not yet ABI-stable** — each header
+> carries a banner saying so. Nothing depends on it as a stable contract yet,
+> which is why it can still be reshaped freely.
+
+The ABI gives JSI a stable C interface so a single `v8jsi.dll` can serve
+consumers compiled with different toolchains.
+
+- **Creation is a flat function.** `v8_create_runtime(uint32_t
+  requested_abi_version, jsi_configure_runtime_cb configure, void *configure_data)`
+  — there is no factory vtable. It returns a `jsi_runtime*` (refcount 1) or NULL.
+- **Versioning is out of band (Model B).** `JSI_ABI_VERSION` is a single
+  monotonic integer; the consumer passes the version it compiled against and the
+  implementation pins to it or fails if it exceeds the implementation's max. The
+  C++ wrapper `makeJsiAbiRuntime` injects this for free. Vtables hold only
+  function pointers (no version/reserved fields); an optional `get_abi_version()`
+  reports the implementation's max.
+- **Configuration uses a factory-owned pull-callback.** The factory allocates the
+  opaque `jsi_config`, hands it to the consumer's `configure` callback to populate
+  via the typed `v8_jsi_config_*` setters, then frees it — the handle never
+  escapes the callback. Consumers do not allocate or free the config.
+- **Optional capabilities go through `query_interface`** (COM-style, two outputs:
+  vtable + instance) with immutable interface IDs. No optional interfaces are
+  registered yet; it is the extension seam.
+- **Process-global V8 engine flags** (`sparkplug`, `jitless`, …) are set via the
+  process-level `v8_jsi_set_v8_flags` (forwarded to `V8::SetFlagsFromCommandLine`),
+  not per-runtime config, because V8 reads them only at first process init.
+
+The V8 implementation (`jsi_abi_v8.cpp`) is **exception-free** to match
+V8/Node.js style: it uses a `TryCatch` wrapper and V8's `Maybe`/`MaybeLocal`
+patterns, returns `jsi_error_*` codes, and can compile with exceptions disabled.
+
+`makeV8Runtime` (the public JSI entry point) is itself ABI-backed — it builds a
+runtime through the same ABI path as the Node-API surface.
+
+## V8 API compatibility notes
+
+When updating to newer V8 versions, watch for these renames/changes:
+- `Utf8Length()` → `Utf8LengthV2()`; `WriteUtf8()` → `WriteUtf8V2()`; `Write()` → `WriteV2()`
+- `GetPrototype()` → `GetPrototypeV2()`; `SetPrototype()` → `SetPrototypeV2()`
+- `ScriptOrigin` no longer takes `Isolate*` as its first parameter
+- `promise->GetIsolate()` removed — use `v8::Isolate::GetCurrent()`
+- Property interceptor handlers now return the `v8::Intercepted` enum
+
+## Preprocessor defines
+- `V8JSI_EXPORT` / `V8JSI_IMPORT` — DLL export/import
+- `V8JSI_ENABLE_INSPECTOR` — inspector support (enabled)
+- `V8JSI_ENABLE_NODE_API` — Node-API integration
+- `JSI_TESTING_ONLY` — gates test-only DLL exports (see `v8jsi_test_hooks`)
+
+## Dependencies & binary size
+V8 + `v8_libplatform`, ICU, OpenSSL, libuv, etc. — all from the vendored Node.js
+tree. ICU adds ~30 MB; a full build is ~67 MB, and `--without-intl` (the default
+narrow build) is ~33 MB.
+
+## Scripts and tooling
+The `scripts/` folder holds the TypeScript build/sync tooling (`build.ts`,
+`sync.ts`, AI-merge, plus tests via `npm test`, type-checking via
+`npm run typecheck`, and lint/format via `npm run fix`). Run TypeScript with
+`node <script>.ts` directly.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,67 @@ To build the specific platform and flavor, use appropriate build flags:
 powershell ./localbuild.ps1 -NoSetup -Platform x86 -Configuration Release 
 ```
 
+##### Building v8jsi.dll from Node.js sources (new build, in development)
+
+A second build path is being developed that compiles v8jsi.dll from a
+vendored copy of Node.js (under [`deps/nodejs/`](deps/nodejs/)) without
+`depot_tools` / `gclient`. It produces its own `v8jsi.dll`,
+`v8jsi_test.exe`, and `node_api_tests.exe` into
+`deps/nodejs/out/{Release,Debug}/` — the legacy build's outputs in
+`out/{Release,Debug}/` are unaffected and continue to be the canonical
+artifacts shipped in the `ReactNative.V8Jsi.Windows` NuGet today.
+
+The two builds will coexist until downstream consumers migrate to the
+new `Microsoft.JavaScript.V8` NuGet, at which point the legacy build
+above is removed.
+
+###### Additional prerequisites
+
+In addition to the prerequisites listed under *Initial Windows Build
+Setup*, the new build also needs:
+
+1. **Python 3.x** on PATH (required by the Node.js `configure` step).
+1. **Node.js v24+** on PATH (required by [`scripts/build.ts`](scripts/build.ts)).
+
+###### Developer task runner: `dev.ps1`
+
+[`dev.ps1`](dev.ps1) at the repo root is the canonical entry point for
+the new build. Run `.\dev` with no arguments to see available commands.
+
+**Build** (Release x64 by default):
+```PowerShell
+.\dev build
+```
+
+**Other configurations**:
+```PowerShell
+.\dev build --configuration debug
+.\dev build --platform x86
+.\dev build --platform arm64
+```
+
+**Build + run tests**:
+```PowerShell
+.\dev build --test
+```
+
+**Run the fork-sync tool** (sync vendored Node.js / asio from upstream):
+```PowerShell
+.\dev fork-sync --dep nodejs --status
+```
+
+See `.\dev build --help` and `.\dev fork-sync --help` for the full
+option set. The `build` command forwards to
+[`scripts/build.ts`](scripts/build.ts), which drives
+[`deps/nodejs/vcbuild.bat`](deps/nodejs/vcbuild.bat) with narrow-build
+flags (skips `node.exe`, `cctest`, `embedtest`, etc.). See
+[`CLAUDE.md`](CLAUDE.md) for the underlying details.
+
+`.\dev build` also runs a version-sync check that compares
+`config.json.nodejs_version` against the vendored Node.js version in
+`deps/nodejs/src/node_version.h`, and fails fast on mismatch. See
+[`docs/versioning.md`](docs/versioning.md) for the `24.x.y` policy.
+
 ##### [EXPERIMENTAL!] Building with WSL2 on Windows 10/11
 * [Enable](https://docs.microsoft.com/en-us/windows/wsl/install) Windows Subsystem for Linux
 * Install debian: `wsl --install -d Debian`

--- a/config.json
+++ b/config.json
@@ -1,5 +1,7 @@
 {
-    "version":  "0.79.5",
+    "version":  "0.79.6",
     "v8ref":  "refs/branch-heads/12.1",
-    "buildNumber":  "285"
+    "buildNumber":  "285",
+    "v8jsi_version":  "24.0.0",
+    "nodejs_version":  "24.15.1"
 }

--- a/deps/nodejs/configure.py
+++ b/deps/nodejs/configure.py
@@ -1018,6 +1018,12 @@ parser.add_argument('--shared',
     help='compile shared library for embedding node in another project. ' +
          '(This mode is not officially supported for regular applications)')
 
+parser.add_argument('--build-v8jsi',
+    action='store_true',
+    dest='build_v8jsi',
+    default=None,
+    help='build v8jsi shared library (v8jsi.dll) using V8 from Node.js')
+
 parser.add_argument('--libdir',
     action='store',
     dest='libdir',
@@ -1465,6 +1471,7 @@ def host_arch_win():
 
   matchup = {
     'AMD64'  : 'x64',
+    'x86'    : 'ia32',
     'arm'    : 'arm',
     'mips'   : 'mips',
     'ARM64'  : 'arm64'
@@ -2432,6 +2439,9 @@ for builtin, value in shareable_builtins.items():
 
 # Forward OSS-Fuzz settings
 output['variables']['ossfuzz'] = b(options.ossfuzz)
+
+# Forward v8jsi build settings
+output['variables']['build_v8jsi'] = 1 if options.build_v8jsi else 0
 
 # variables should be a root level element,
 # move everything else to target_defaults

--- a/deps/nodejs/node.gyp
+++ b/deps/nodejs/node.gyp
@@ -37,6 +37,7 @@
     'node_v8_options%': '',
     'node_write_snapshot_as_string_literals': 'true',
     'ossfuzz' : 'false',
+    'build_v8jsi%': 0,
     'linked_module_files': [
     ],
     # We list the deps/ files out instead of globbing them in js2c.cc since we
@@ -525,6 +526,13 @@
                   'cflags': ['-mbranch-protection=standard'],
               }],
           ],
+      }],
+      ['target_arch=="ia32"', {
+        'msvs_settings': {
+          'VCLinkerTool': {
+            'ImageHasSafeExceptionHandlers': 'false',
+          },
+        },
       }],
       ['OS in "aix os400"', {
         'ldflags': [
@@ -1631,5 +1639,15 @@
        },
      ],
    }], # end win section
+    # v8jsi shared library target
+    # The v8jsi.gyp file is in the v8-jsi repo src folder (../../src from here)
+    ['build_v8jsi==1', {
+      'includes': [
+        '../../src/v8jsi.gyp',
+        # Node-API conformance test rig (W7) -> 34 addon DLLs + node_lite.exe
+        # + node_api_tests.exe + JS-file copy. Built alongside v8jsi.dll.
+        '../../src/node-api/test/node_api_tests.gyp',
+      ],
+    }],
   ], # end conditions block
 }

--- a/deps/nodejs/sync-instructions.md
+++ b/deps/nodejs/sync-instructions.md
@@ -1,0 +1,44 @@
+# V8-JSI Fork Patches on Node.js
+
+This Node.js tree is vendored. The hunks below are v8-jsi-side additions
+that the fork-sync must keep when upstream Node.js diverges around them.
+Defaults are unchanged: every patch is gated on opt-in (`--build-v8jsi`,
+`v8jsi` / `no-*` keywords, `target_arch=="ia32"`, etc.), so upstream
+behavior is preserved when the new options aren't requested.
+
+## Rule of thumb
+
+If a conflict hunk contains any of the markers below, KEEP OURS for that
+hunk and merge upstream's surrounding edits around it. Our hunks are
+additive — there is no "either/or" with upstream.
+
+## Markers to preserve (keep ours)
+
+- **`v8jsi`** (vcbuild.bat keyword) and **`--build-v8jsi`** / **`build_v8jsi`**
+  (configure.py flag/var, node.gyp variable + `build_v8jsi==1` conditional
+  `includes:` of `../../src/v8jsi.gyp` and `../../src/node-api/test/node_api_tests.gyp`).
+- **`no-node` / `no-cctest` / `no-embedtest` / `no-openssl-cli` / `no-fuzzers` /
+  `no-nop` / `no-overlapped-checker`** in vcbuild.bat and the **"Additive
+  target-list mode"** block that consumes them (`target_list`,
+  `use_target_list`, the strip-leading-`;` line).
+- **x86 re-enablement** in vcbuild.bat (removal of *"32-bit Windows builds
+  are not supported anymore"*, `msvs_host_arch` detection, `msbplatform=Win32`
+  default, `--no-cross-compiling` for AMD64→x86), in configure.py
+  (`'x86' : 'ia32'` mapping in `host_arch_win`), in node.gyp
+  (`target_arch=="ia32"` block with `ImageHasSafeExceptionHandlers=false`),
+  and in tools/v8_gypfiles/{toolchain.gypi, v8.gyp}
+  (`OS=="win" and v8_target_arch=="ia32"` block, ia32
+  `push_registers_asm.cc` source).
+- **`where /R ..\..\src /T *.gyp*`** line in vcbuild.bat (reconfigure
+  stamp watches v8-jsi-side gyp files).
+
+## When to call human
+
+- Upstream removed something we patched against (e.g. the `cctest` keyword
+  goes away). Our `no-cctest` / additive-list logic depends on the symbol
+  existing. Mark unresolved.
+- Upstream re-enables x86 itself (then our re-enablement hunks are
+  duplicates — drop ours, keep upstream).
+- Upstream changes the `configure_flags` assembly inside the `if defined …`
+  chain in a way that breaks ordering relative to our
+  `if defined build_v8jsi` line.

--- a/deps/nodejs/tools/v8_gypfiles/toolchain.gypi
+++ b/deps/nodejs/tools/v8_gypfiles/toolchain.gypi
@@ -564,6 +564,16 @@
           'V8_TARGET_OS_WIN',
         ]
       }],
+      ['OS=="win" and v8_target_arch=="ia32"', {
+        'msvs_settings': {
+          'VCCLCompilerTool': {
+            'AdditionalOptions': ['/arch:SSE2'],
+          },
+          'VCLinkerTool': {
+            'ImageHasSafeExceptionHandlers': 'false',
+          },
+        },
+      }],
       ['OS in "linux freebsd openbsd solaris netbsd mac android qnx openharmony" and v8_target_arch=="ia32"', {
         'cflags': [
           '-msse2',

--- a/deps/nodejs/tools/v8_gypfiles/v8.gyp
+++ b/deps/nodejs/tools/v8_gypfiles/v8.gyp
@@ -1999,6 +1999,11 @@
                   }],
                 ],
               }],
+              ['_toolset == "host" and host_arch == "ia32" or _toolset == "target" and target_arch=="ia32"', {
+                'sources': [
+                  '<(V8_ROOT)/src/heap/base/asm/ia32/push_registers_asm.cc',
+                ],
+              }],
             ],
           }, { # 'OS!="win"'
             'conditions': [

--- a/deps/nodejs/vcbuild.bat
+++ b/deps/nodejs/vcbuild.bat
@@ -67,6 +67,12 @@ set nghttp2_debug=
 set link_module=
 set no_cctest=
 set cctest=
+set no_node=
+set no_embedtest=
+set no_openssl_cli=
+set no_fuzzers=
+set no_nop=
+set no_overlapped_checker=
 set openssl_no_asm=
 set no_shared_roheap=
 set doc=
@@ -155,6 +161,13 @@ if /i "%1"=="doc"           set doc=1&goto arg-ok
 if /i "%1"=="binlog"        set extra_msbuild_args=/binaryLogger:out\%config%\node.binlog&goto arg-ok
 if /i "%1"=="compile-commands" set compile_commands=1&goto arg-ok
 if /i "%1"=="cfg"           set cfg=1&goto arg-ok
+if /i "%1"=="v8jsi"         set build_v8jsi=1&goto arg-ok
+if /i "%1"=="no-node"             set no_node=1&goto arg-ok
+if /i "%1"=="no-embedtest"        set no_embedtest=1&goto arg-ok
+if /i "%1"=="no-openssl-cli"      set no_openssl_cli=1&goto arg-ok
+if /i "%1"=="no-fuzzers"          set no_fuzzers=1&goto arg-ok
+if /i "%1"=="no-nop"              set no_nop=1&goto arg-ok
+if /i "%1"=="no-overlapped-checker" set no_overlapped_checker=1&goto arg-ok
 
 echo Error: invalid command line option `%1`.
 exit /b 1
@@ -218,11 +231,9 @@ if defined ccache_path      set configure_flags=%configure_flags% --use-ccache-w
 if defined compile_commands set configure_flags=%configure_flags% -C
 if defined cfg              set configure_flags=%configure_flags% --control-flow-guard
 if defined v8windbg         set configure_flags=%configure_flags% --enable-v8windbg
+if defined build_v8jsi      set configure_flags=%configure_flags% --build-v8jsi
 
-if "%target_arch%"=="x86" (
-  echo "32-bit Windows builds are not supported anymore."
-  exit /b 1
-)
+if "%target_arch%"=="x86" if "%PROCESSOR_ARCHITECTURE%"=="AMD64" set configure_flags=%configure_flags% --no-cross-compiling
 
 if not exist "%~dp0deps\icu" goto no-depsicu
 if "%target%"=="Clean" echo deleting %~dp0deps\icu
@@ -239,7 +250,7 @@ if "%target%"=="TestClean" (
 call tools\msvs\find_python.cmd
 if errorlevel 1 goto :exit
 
-REM NASM is only needed on x86_64.
+REM NASM is only needed on IA32 and x86_64.
 if not defined openssl_no_asm if "%target_arch%" NEQ "arm64" call tools\msvs\find_nasm.cmd
 if errorlevel 1 echo Could not find NASM, install it or build with openssl-no-asm. See BUILDING.md.
 
@@ -263,7 +274,9 @@ if defined noprojgen if defined nobuild goto :after-build
 
 @rem Set environment for msbuild
 
-set msvs_host_arch=amd64
+set msvs_host_arch=x86
+if _%PROCESSOR_ARCHITECTURE%_==_AMD64_ set msvs_host_arch=amd64
+if _%PROCESSOR_ARCHITEW6432%_==_AMD64_ set msvs_host_arch=amd64
 if _%PROCESSOR_ARCHITECTURE%_==_ARM64_ set msvs_host_arch=arm64
 @rem usually vcvarsall takes an argument: host + '_' + target
 set vcvarsall_arg=%msvs_host_arch%_%target_arch%
@@ -371,6 +384,9 @@ if not exist node.sln goto run-configure
 if not exist .gyp_configure_stamp goto run-configure
 echo %configure_flags% > .tmp_gyp_configure_stamp
 where /R . /T *.gyp* >> .tmp_gyp_configure_stamp
+@rem v8-jsi: also watch gyp files in <repo>/src so that edits to
+@rem src/v8jsi.gyp and src/node-api/test/node_api_tests.gyp trigger reconfigure.
+where /R ..\..\src /T *.gyp* >> .tmp_gyp_configure_stamp 2>NUL
 fc .gyp_configure_stamp .tmp_gyp_configure_stamp >NUL 2>&1
 if errorlevel 1 goto run-configure
 
@@ -400,8 +416,41 @@ if defined nobuild goto :after-build
 @rem Build the sln with msbuild.
 set "msbcpu=/m:2"
 if "%NUMBER_OF_PROCESSORS%"=="1" set "msbcpu=/m:1"
-set "msbplatform=x64"
+set "msbplatform=Win32"
+if "%target_arch%"=="x64" set "msbplatform=x64"
 if "%target_arch%"=="arm64" set "msbplatform=ARM64"
+@rem --- Additive target-list mode ----------------------------------
+@rem
+@rem When any `no-X` flag is set, switch from MSBuild's solution-level
+@rem "Build" meta-target to an explicit list of user-facing targets,
+@rem and skip whichever ones the caller opted out of. Transitive
+@rem dependencies (libnode, V8 intermediates, addon DLLs, etc.) are
+@rem pulled in automatically by MSBuild's dep walk.
+@rem
+@rem No `no-X` flags -> use_target_list stays unset -> fall through to
+@rem the legacy block below, byte-for-byte unchanged.
+@rem
+set target_list=
+set use_target_list=
+
+if defined no_node               (set use_target_list=1) else (set "target_list=%target_list%;node")
+if defined no_cctest             (set use_target_list=1) else (set "target_list=%target_list%;cctest")
+if defined no_embedtest          (set use_target_list=1) else (set "target_list=%target_list%;embedtest")
+if defined no_openssl_cli        (set use_target_list=1) else (set "target_list=%target_list%;openssl-cli")
+if defined no_fuzzers            (set use_target_list=1) else (set "target_list=%target_list%;fuzz_env;fuzz_ClientHelloParser;fuzz_strings")
+if defined no_nop                (set use_target_list=1) else (set "target_list=%target_list%;nop")
+if defined no_overlapped_checker (set use_target_list=1) else (set "target_list=%target_list%;overlapped-checker")
+
+@rem v8jsi-side targets only exist in the .sln when gyp pulled them in.
+@rem build_v8jsi adds v8jsi_test + node_api_tests as a unit (v8jsi.dll is
+@rem a transitive dep of v8jsi_test).
+if defined build_v8jsi set "target_list=%target_list%;v8jsi_test;node_api_tests"
+
+@rem strip leading ';' (flattened to top-level so each %target_list% re-expands fresh)
+if defined use_target_list if "%target_list:~0,1%"==";" set "target_list=%target_list:~1%"
+if defined use_target_list if "%target_list%"=="" echo Error: every target filtered out by 'no-*' flags -- nothing to build.&exit /b 1
+if defined use_target_list set "target=%target_list%"
+
 if "%target%"=="Build" (
   if defined no_cctest set target=node
   if "%test_args%"=="" set target=node

--- a/dev.ps1
+++ b/dev.ps1
@@ -10,6 +10,8 @@
   Run without arguments or with -? to see available commands.
 
 .EXAMPLE
+  .\dev build --help
+  .\dev build --configuration debug
   .\dev fork-sync --dep nodejs --status
 #>
 
@@ -45,9 +47,13 @@ function Show-Help {
     Write-Host '  v8-jsi developer tasks'
     Write-Host '  ======================'
     Write-Host ''
+    Write-Host '  .\dev build [args]              Build v8jsi'
     Write-Host '  .\dev fork-sync [args]          Run fork-sync tool'
     Write-Host ''
     Write-Host '  Examples:'
+    Write-Host '    .\dev build --help'
+    Write-Host '    .\dev build --configuration debug'
+    Write-Host '    .\dev build --no-build --test'
     Write-Host '    .\dev fork-sync --dep nodejs --status'
     Write-Host ''
 }
@@ -57,6 +63,10 @@ function Show-Help {
 # =============================================================================
 
 switch ($Command) {
+    'build' {
+        & node (Join-Path $ScriptDir 'scripts\build.ts') @Args
+    }
+
     'fork-sync' {
         Ensure-ScriptDeps
         & node (Join-Path $ScriptDir 'scripts\fork-sync\node_modules\@rnx-kit\fork-sync\lib\sync.js') @Args

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,34 @@
+# Versioning policy
+
+The `Microsoft.JavaScript.V8` NuGet uses a Node.js-aligned
+`MAJOR.MINOR.PATCH` scheme distinct from the legacy
+`ReactNative.V8Jsi.Windows` scheme (which tracks React Native Windows
+releases).
+
+## Format
+
+`MAJOR.MINOR.PATCH` — currently `24.x.y`.
+
+| Component | Meaning | Bump trigger |
+|---|---|---|
+| `MAJOR` | Node.js major LTS the build is on. | v8-jsi switches to a new Node.js major (e.g. v24 → v26). |
+| `MINOR` | API / Node-minor checkpoint. | (a) v8-jsi-side API change (JSI / JSI-ABI / public C surface), or (b) Node.js minor-version sync (v24.M → v24.M+1). |
+| `PATCH` | Node.js patch sync or bug-fix-only release. | Node.js patch-version sync without API change, or a v8-jsi bug-fix release on the current Node.js minor. |
+
+## Fields in `config.json`
+
+- `v8jsi_version` — the `MAJOR.MINOR.PATCH` value consumed by
+  `scripts/build.ts` and the `Microsoft.JavaScript.V8.nuspec` template.
+- `nodejs_version` — the upstream Node.js version that `deps/nodejs/`
+  is currently synced to. Authoritative source of the actual vendored
+  bits remains `deps/nodejs/sync-config.json` (commit + branch);
+  `nodejs_version` mirrors it as a human-readable label.
+
+## Sync check
+
+`scripts/build.ts` reads `NODE_MAJOR_VERSION` / `NODE_MINOR_VERSION` /
+`NODE_PATCH_VERSION` from `deps/nodejs/src/node_version.h` and compares
+the assembled version string against `config.json.nodejs_version`. A
+mismatch fails the build with a clear message: re-run the fork-sync to
+pick up the new Node.js bits, then update `nodejs_version` in
+`config.json` (and bump `v8jsi_version` per the table above).

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,865 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Build script for v8-jsi. Run with Node.js v24+ (TypeScript strip-types).
+// Usage: node scripts/build.ts [options]
+
+import { parseArgs } from "node:util";
+import { execSync, type ExecSyncOptions } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as https from "node:https";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const nodejsDir = path.join(repoRoot, "deps", "nodejs");
+const srcDir = path.join(repoRoot, "src");
+
+const binskimPackageName = "Microsoft.CodeAnalysis.BinSkim";
+const binskimVersion = "4.4.9";
+const binskimNuGetSource = "https://api.nuget.org/v3/index.json";
+const nugetDownloadUrl =
+  "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe";
+
+// =============================================================================
+// CLI Parsing
+// =============================================================================
+
+const options = {
+  help: { type: "boolean" as const, default: false },
+  build: { type: "boolean" as const, default: true },
+  test: { type: "boolean" as const, default: false },
+  pack: { type: "boolean" as const, default: false },
+  binskim: { type: "boolean" as const, default: false },
+  "clean-all": { type: "boolean" as const, default: false },
+  "clean-build": { type: "boolean" as const, default: false },
+  "clean-pkg": { type: "boolean" as const, default: false },
+  platform: { type: "string" as const, multiple: true, default: ["x64"] },
+  configuration: {
+    type: "string" as const,
+    multiple: true,
+    default: ["release"],
+  },
+  "output-path": { type: "string" as const, default: "./out" },
+  "semantic-version": { type: "string" as const },
+  "file-version": { type: "string" as const },
+};
+
+const { values: args } = parseArgs({ options, allowNegative: true });
+
+const validPlatforms = ["x64", "x86", "arm64"];
+const validConfigurations = ["debug", "release"];
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+function ensureDir(dirPath: string): void {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+function deleteDir(dirPath: string): void {
+  if (fs.existsSync(dirPath)) {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  }
+}
+
+function run(
+  command: string,
+  args: string[],
+  runOptions?: ExecSyncOptions,
+): void {
+  const cmdLine = [command, ...args].join(" ");
+  console.log(`> ${cmdLine}`);
+  try {
+    execSync(cmdLine, { stdio: "inherit", ...runOptions });
+  } catch (error: unknown) {
+    const exitCode =
+      error && typeof error === "object" && "status" in error
+        ? (error as { status: number }).status
+        : 1;
+    console.error(`Command failed with exit code: ${exitCode}`);
+    process.exit(exitCode || 1);
+  }
+}
+
+function copyFile(
+  fileName: string,
+  sourcePath: string,
+  targetPath: string,
+  optional = false,
+): void {
+  ensureDir(targetPath);
+  const sourceFile = path.join(sourcePath, fileName);
+  const targetFile = path.join(targetPath, fileName);
+
+  if (optional && !fs.existsSync(sourceFile)) {
+    console.log(`Skipping copy of ${fileName} (file not found, optional)`);
+    return;
+  }
+
+  fs.copyFileSync(sourceFile, targetFile);
+}
+
+function downloadFile(url: string, destPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ensureDir(path.dirname(destPath));
+    const file = fs.createWriteStream(destPath);
+
+    const request = (requestUrl: string) => {
+      https
+        .get(requestUrl, (response) => {
+          // Follow redirects
+          if (
+            response.statusCode &&
+            response.statusCode >= 300 &&
+            response.statusCode < 400 &&
+            response.headers.location
+          ) {
+            file.close();
+            fs.unlinkSync(destPath);
+            request(response.headers.location);
+            return;
+          }
+
+          if (response.statusCode !== 200) {
+            file.close();
+            fs.unlinkSync(destPath);
+            reject(new Error(`Download failed with status ${response.statusCode}`));
+            return;
+          }
+
+          response.pipe(file);
+          file.on("finish", () => {
+            file.close();
+            resolve();
+          });
+        })
+        .on("error", (err) => {
+          file.close();
+          fs.unlinkSync(destPath);
+          reject(err);
+        });
+    };
+
+    request(url);
+  });
+}
+
+async function ensureNuGet(toolsPath: string): Promise<string> {
+  // Check tools directory first
+  const localNuget = path.join(toolsPath, "nuget.exe");
+  if (fs.existsSync(localNuget)) {
+    return localNuget;
+  }
+
+  // Check PATH
+  try {
+    const result = execSync("where nuget.exe", { encoding: "utf-8" }).trim();
+    if (result) {
+      return result.split("\n")[0].trim();
+    }
+  } catch {
+    // Not on PATH
+  }
+
+  // Download
+  console.log("Downloading nuget.exe...");
+  await downloadFile(nugetDownloadUrl, localNuget);
+  console.log(`Downloaded nuget.exe to ${localNuget}`);
+  return localNuget;
+}
+
+function configDir(configuration: string): string {
+  return configuration.charAt(0).toUpperCase() + configuration.slice(1);
+}
+
+function buildOutputDir(configuration: string): string {
+  return path.join(nodejsDir, "out", configDir(configuration));
+}
+
+function isCrossPlatformBuild(platform: string): boolean {
+  const hostArch = process.arch; // "x64" or "arm64"
+  if (hostArch === "x64" && platform === "arm64") return true;
+  if (hostArch === "arm64" && platform !== "arm64") return true;
+  return false;
+}
+
+function readConfigJson(): {
+  version: string;
+  v8jsi_version?: string;
+  nodejs_version?: string;
+} {
+  const configPath = path.join(repoRoot, "config.json");
+  return JSON.parse(fs.readFileSync(configPath, "utf-8"));
+}
+
+// Read NODE_MAJOR/MINOR/PATCH_VERSION from the vendored
+// deps/nodejs/src/node_version.h and return them as "MAJOR.MINOR.PATCH".
+function readVendoredNodejsVersion(): string {
+  const headerPath = path.join(
+    nodejsDir,
+    "src",
+    "node_version.h",
+  );
+  const header = fs.readFileSync(headerPath, "utf-8");
+  const parts: Record<string, string> = {};
+  for (const key of ["MAJOR", "MINOR", "PATCH"]) {
+    const re = new RegExp(`#define\\s+NODE_${key}_VERSION\\s+(\\d+)`);
+    const m = re.exec(header);
+    if (!m) {
+      throw new Error(
+        `Failed to parse NODE_${key}_VERSION from ${headerPath}`,
+      );
+    }
+    parts[key] = m[1];
+  }
+  return `${parts["MAJOR"]}.${parts["MINOR"]}.${parts["PATCH"]}`;
+}
+
+// Verifies config.json.nodejs_version matches the actual vendored
+// Node.js version under deps/nodejs/. Hard-fails on mismatch.
+function checkNodejsVersionSync(): void {
+  const cfg = readConfigJson();
+  const declared = cfg.nodejs_version;
+  if (!declared) {
+    console.error(
+      "config.json is missing the 'nodejs_version' field. See docs/versioning.md.",
+    );
+    process.exit(1);
+  }
+  const actual = readVendoredNodejsVersion();
+  if (declared !== actual) {
+    console.error(
+      `Version mismatch: config.json.nodejs_version is "${declared}" but ` +
+        `deps/nodejs/src/node_version.h declares "${actual}". ` +
+        `Update config.json.nodejs_version to match the vendored Node.js, ` +
+        `or re-run the fork-sync if you intended a different version. ` +
+        `See docs/versioning.md.`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `Version sync OK: nodejs_version=${declared}, vendored=${actual}`,
+  );
+}
+
+// Maps a build platform (x64 / x86 / arm64) to the .NET RID convention
+// used in the Microsoft.JavaScript.V8 NuGet layout (LibNode pattern).
+function platformToRid(platform: string): string {
+  switch (platform.toLowerCase()) {
+    case "x64":
+      return "win-x64";
+    case "x86":
+      return "win-x86";
+    case "arm64":
+      return "win-arm64";
+    default:
+      throw new Error(`Unsupported platform for RID mapping: ${platform}`);
+  }
+}
+
+const ALL_WINDOWS_RIDS = ["win-x86", "win-x64", "win-arm64"] as const;
+
+// Substitute $rid$ and $v8jsiName$ placeholders in a .rid.{props,targets}
+// template. nuget pack does NOT run files through -Properties expansion
+// (only the .nuspec metadata), so .props/.targets must be pre-templated
+// at staging time. Mirrors prepareNugetFiles.js:copyPatchedRootRIDFile
+// from the Office libnode pipeline.
+function templateFile(
+  templatePath: string,
+  destPath: string,
+  rid: string,
+  v8jsiName: string,
+): void {
+  const template = fs.readFileSync(templatePath, "utf-8");
+  const rendered = template
+    .replaceAll("$rid$", rid)
+    .replaceAll("$v8jsiName$", v8jsiName);
+  fs.writeFileSync(destPath, rendered);
+}
+
+// =============================================================================
+// Help
+// =============================================================================
+
+function showHelp(): void {
+  console.log(`
+v8-jsi build script
+
+Usage: node scripts/build.ts [options]
+
+Boolean flags (all support --no- prefix):
+  --help              Show this help message
+  --build             Build v8jsi.dll (default: true)
+  --test              Run v8jsi_test.exe
+  --pack              Create NuGet package
+  --binskim           Run BinSkim security validation
+  --clean-all         Delete entire output folder
+  --clean-build       Delete build outputs for targeted configs
+  --clean-pkg         Delete pkg and pkg-staging folders
+
+String arguments:
+  --platform <p>      Target platform: x64, x86, arm64 (default: x64, multiple allowed)
+  --configuration <c> Build config: debug, release (default: release, multiple allowed)
+  --output-path <dir> Output directory (default: ./out)
+  --semantic-version  NuGet package version (default: from config.json)
+  --file-version      Version for binary files (X.Y.Z.W format)
+
+Examples:
+  node scripts/build.ts                          # Build release x64
+  node scripts/build.ts --configuration debug    # Build debug x64
+  node scripts/build.ts --no-build --test        # Run tests only
+  node scripts/build.ts --no-build --pack        # Package only
+  node scripts/build.ts --clean-all              # Clean everything
+`);
+}
+
+// =============================================================================
+// Build Operation
+// =============================================================================
+
+function runBuild(platform: string, configuration: string): void {
+  console.log(`\n=== Building v8jsi (${platform} ${configuration}) ===\n`);
+
+  if (platform !== "x64") {
+    console.log(
+      `WARNING: vcbuild.bat currently only supports x64 builds. Skipping ${platform}.`,
+    );
+    return;
+  }
+
+  const vcbuildArgs = [
+    ".\\vcbuild.bat",
+    configuration,
+    "v8jsi",
+    "without-intl",
+    "no-node",
+    "no-cctest",
+    "no-embedtest",
+    "no-openssl-cli",
+    "no-fuzzers",
+    "no-nop",
+    "no-overlapped-checker",
+  ];
+
+  if (args["file-version"]) {
+    // Pass file version as environment variable for the GYP version_gen action
+    process.env.V8JSI_FILE_VERSION = args["file-version"];
+  }
+
+  run("cmd.exe", ["/c", ...vcbuildArgs], { cwd: nodejsDir });
+}
+
+// =============================================================================
+// Test Operation
+// =============================================================================
+
+function runTests(platform: string, configuration: string): void {
+  console.log(`\n=== Testing v8jsi (${platform} ${configuration}) ===\n`);
+
+  if (isCrossPlatformBuild(platform)) {
+    console.log(
+      `Skipping tests for cross-platform build (${platform} on ${process.arch} host)`,
+    );
+    return;
+  }
+
+  const testExe = path.join(buildOutputDir(configuration), "v8jsi_test.exe");
+  if (!fs.existsSync(testExe)) {
+    console.error(`Test executable not found: ${testExe}`);
+    process.exit(1);
+  }
+
+  run(testExe, []);
+}
+
+// =============================================================================
+// BinSkim Operation
+// =============================================================================
+
+async function runBinSkim(
+  platform: string,
+  configuration: string,
+  toolsPath: string,
+): Promise<void> {
+  console.log(`\n=== BinSkim (${platform} ${configuration}) ===\n`);
+
+  const nugetExe = await ensureNuGet(toolsPath);
+  const binskimDir = path.join(toolsPath, "binskim");
+
+  // Install BinSkim if not present
+  const binskimPkgDir = path.join(
+    binskimDir,
+    `${binskimPackageName}.${binskimVersion}`,
+  );
+  if (!fs.existsSync(binskimPkgDir)) {
+    run(nugetExe, [
+      "install",
+      binskimPackageName,
+      "-Version",
+      binskimVersion,
+      "-Source",
+      `"${binskimNuGetSource}"`,
+      "-OutputDirectory",
+      `"${binskimDir}"`,
+    ]);
+  }
+
+  // Find BinSkim.exe
+  let binskimExe = "";
+  const toolsDir = path.join(binskimPkgDir, "tools");
+  if (fs.existsSync(toolsDir)) {
+    for (const runtime of fs.readdirSync(toolsDir)) {
+      const candidate = path.join(
+        toolsDir,
+        runtime,
+        "win-x64",
+        "BinSkim.exe",
+      );
+      if (fs.existsSync(candidate)) {
+        binskimExe = candidate;
+        break;
+      }
+    }
+  }
+
+  if (!binskimExe) {
+    console.error("BinSkim.exe not found in installed package");
+    process.exit(1);
+  }
+
+  // Collect files to scan
+  const outDir = buildOutputDir(configuration);
+  const filesToScan: string[] = [];
+  const dllPath = path.join(outDir, "v8jsi.dll");
+  if (fs.existsSync(dllPath)) {
+    filesToScan.push(dllPath);
+  }
+
+  if (filesToScan.length === 0) {
+    console.log("No binaries found to scan");
+    return;
+  }
+
+  const fileArgs = filesToScan.map((f) => `"${f}"`).join(" ");
+  run(binskimExe, [
+    "analyze",
+    "--config",
+    "default",
+    "--ignorePdbLoadError",
+    "--ignorePELoadErrors",
+    "True",
+    "--hashes",
+    "--statistics",
+    "--disable-telemetry",
+    "True",
+    fileArgs,
+  ]);
+}
+
+// =============================================================================
+// Pack Operation
+// =============================================================================
+
+function packNuGet(outputPath: string, platforms: string[], configurations: string[]): void {
+  console.log("\n=== Packing NuGet ===\n");
+
+  const pkgStagingPath = path.join(outputPath, "pkg-staging");
+  const pkgPath = path.join(outputPath, "pkg");
+  const nugetSourceDir = path.join(repoRoot, "scripts", "nuget");
+  const configJson = readConfigJson();
+  // Windows-only today; .so/.dylib substitutions land with Phase-2/3 multi-OS.
+  const v8jsiName = "v8jsi.dll";
+
+  // ---------------------------------------------------------------------
+  // Stage RID-specific content for each requested platform: DLL + import
+  // lib + (optional) PDB. The build host is assumed to have built each
+  // requested platform last (vcbuild.bat outputs to a single
+  // deps/nodejs/out/<Config>/ directory regardless of architecture, so
+  // multi-arch packing assumes prior matrix runs staged each arch).
+  // ---------------------------------------------------------------------
+  for (const platform of platforms) {
+    for (const configuration of configurations) {
+      // Stage B2: Debug v8jsi.dll variants are dropped from the shipped
+      // NuGet. Hybrid CRT (B1) makes a Debug-CRT consumer safe to link
+      // against the Release v8jsi.dll: App-CRT is statically private to
+      // the DLL, UCRT is the only shared runtime, and ucrtbase.dll /
+      // ucrtbased.dll are separate DLLs with separate heaps - so the
+      // Stage-A "no STL across the boundary" rule keeps the cross-CRT
+      // allocations sound. Debug builds may still run in CI for
+      // validation; they just don't get packaged.
+      // See: ../kb/v8-jsi/new-v8jsi-dll-phase1/impl-b2-results.md.
+      if (configuration === "debug") continue;
+      const rid = platformToRid(platform);
+      const outDir = buildOutputDir(configuration);
+      const ridDir = path.join(pkgStagingPath, "build", "native", rid);
+
+      // CI aggregator scenario: matrix jobs uploaded their per-RID
+      // staging; aggregator has no local build output. If the source
+      // build dir has no v8jsi.dll, fall back to whatever is already
+      // staged for this RID (idempotent re-run is fine).
+      if (!fs.existsSync(path.join(outDir, "v8jsi.dll"))) {
+        if (fs.existsSync(path.join(ridDir, "v8jsi.dll"))) {
+          console.log(
+            `Using pre-staged v8jsi.dll for ${rid} (no local build at ${outDir}).`,
+          );
+          continue;
+        }
+        throw new Error(
+          `Cannot stage ${rid}: no v8jsi.dll at ${outDir} or ${ridDir}.`,
+        );
+      }
+
+      copyFile("v8jsi.dll", outDir, ridDir);
+      // GYP build produces v8jsi.lib (MSBuild legacy emitted v8jsi.dll.lib);
+      // rename on copy so .targets resolves either way.
+      if (fs.existsSync(path.join(outDir, "v8jsi.dll.lib"))) {
+        copyFile("v8jsi.dll.lib", outDir, ridDir);
+      } else {
+        ensureDir(ridDir);
+        fs.copyFileSync(
+          path.join(outDir, "v8jsi.lib"),
+          path.join(ridDir, "v8jsi.dll.lib"),
+        );
+      }
+      // PDB is optional (Q2 decision: ship in per-RID .nupkg when present).
+      copyFile("v8jsi.dll.pdb", outDir, ridDir, true);
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Stage RID-INDEPENDENT shared content: headers, consumer-side source
+  // TUs, root assets, and the .nuspec templates. Idempotent — multiple
+  // matrix runs overwrite with identical content.
+  // ---------------------------------------------------------------------
+  const includeDir = path.join(pkgStagingPath, "build", "native", "include");
+  const jsiBaseDir = path.join(pkgStagingPath, "build", "native", "jsi");
+  const jsiHeaderDir = path.join(jsiBaseDir, "jsi");
+  const jsiAbiDir = path.join(jsiBaseDir, "jsi_abi");
+  const jsiPublicDir = path.join(jsiBaseDir, "public");
+  const nodeApiDir = path.join(includeDir, "node-api");
+  const nodeApiJsiDir = path.join(includeDir, "node-api-jsi");
+  const apiLoadersDir = path.join(nodeApiJsiDir, "ApiLoaders");
+
+  // Public headers
+  for (const file of [
+    "compat.h",
+    "Readme.md",
+    "ScriptStore.h",
+    "v8_api.h",
+    "V8JsiRuntime.h",
+  ]) {
+    copyFile(file, path.join(srcDir, "public"), includeDir);
+  }
+
+  // JSI headers + base-class impl + inline impl. jsi.cpp ships the JSI
+  // base-class implementations (Buffer/Value/JSError/Runtime destructors
+  // and virtual default impls) since v8jsi.dll does not export them
+  // (JSI_EXPORT is a no-op unless CREATE_SHARED_LIBRARY is set, which
+  // v8jsi.gyp doesn't define), so every consumer compiles jsi.cpp locally.
+  for (const file of ["jsi.h", "jsi-inl.h", "jsi.cpp", "instrumentation.h"]) {
+    copyFile(file, path.join(srcDir, "jsi"), jsiHeaderDir);
+  }
+
+  // JSI ABI headers + sources. Consumers compile JsiAbiRuntime.cpp locally;
+  // v8_jsi_config.h and v8_node_api_attach.h are the public C-stable surfaces
+  // for runtime configuration and the dual-API attach seam respectively.
+  for (const file of [
+    "jsi_abi.h",
+    "jsi_abi_helpers.h",
+    "JsiAbiRuntime.h",
+    "JsiAbiRuntime.cpp",
+    "v8_jsi_config.h",
+    "v8_node_api_attach.h",
+  ]) {
+    copyFile(file, path.join(srcDir, "jsi_abi"), jsiAbiDir);
+  }
+
+  // Public consumer-side TU. Holds makeV8Runtime + the V8ScriptCache (W3) and
+  // V8TaskRunner (W4) adapters. Compiled by the consumer via the .targets
+  // file's <ClCompile> include.
+  copyFile("V8JsiRuntime.cpp", path.join(srcDir, "public"), jsiPublicDir);
+
+  // Node-API headers
+  for (const file of [
+    "js_native_api_types.h",
+    "js_native_api.h",
+    "js_runtime_api.h",
+  ]) {
+    copyFile(file, path.join(srcDir, "node-api"), nodeApiDir, true);
+  }
+
+  // Node-API-JSI headers + consumer-side TU
+  for (const file of ["NodeApiJsiRuntime.h", "NodeApiJsiRuntime.cpp"]) {
+    copyFile(file, path.join(srcDir, "node-api-jsi"), nodeApiJsiDir, true);
+  }
+
+  // ApiLoaders headers + consumer-side TUs
+  for (const file of [
+    "JSRuntimeApi.cpp",
+    "JSRuntimeApi.h",
+    "JSRuntimeApi.inc",
+    "NodeApi_win.cpp",
+    "NodeApi.cpp",
+    "NodeApi.h",
+    "NodeApi.inc",
+    "V8Api.cpp",
+    "V8Api.h",
+    "V8Api.inc",
+  ]) {
+    copyFile(
+      file,
+      path.join(srcDir, "node-api-jsi", "ApiLoaders"),
+      apiLoadersDir,
+      true,
+    );
+  }
+
+  // Root assets (LICENSE, NOTICE.txt, README.md, _._ placeholder)
+  for (const file of ["LICENSE", "NOTICE.txt", "README.md", "_._"]) {
+    copyFile(file, nugetSourceDir, pkgStagingPath);
+  }
+
+  // Nuspec templates: meta + per-RID. No pre-templating — nuget pack
+  // expands $version$ / $rid$ / $v8jsiName$ / etc. from -Properties at
+  // pack time.
+  copyFile(
+    "Microsoft.JavaScript.V8.nuspec",
+    nugetSourceDir,
+    pkgStagingPath,
+  );
+  copyFile(
+    "Microsoft.JavaScript.V8.rid.nuspec",
+    nugetSourceDir,
+    pkgStagingPath,
+  );
+
+  // ---------------------------------------------------------------------
+  // Pre-template the 4 .rid.{props,targets} files for each RID staged
+  // under build/native/<rid>/. Unlike .nuspec, nuget pack does NOT expand
+  // $-placeholders in .props/.targets — they ship verbatim. So $rid$ and
+  // $v8jsiName$ must be substituted at staging time. Mirrors the Office
+  // libnode pipeline's prepareNugetFiles.js:copyPatchedRootRIDFile.
+  // ---------------------------------------------------------------------
+  const ridTemplateNames = [
+    "Microsoft.JavaScript.V8.native.rid.props",
+    "Microsoft.JavaScript.V8.native.rid.targets",
+    "Microsoft.JavaScript.V8.net461.rid.props",
+    "Microsoft.JavaScript.V8.net461.rid.targets",
+  ];
+  const stagedRids = new Set(platforms.map(platformToRid));
+  for (const rid of stagedRids) {
+    for (const templateName of ridTemplateNames) {
+      const ridFileName = templateName.replace(".rid.", `.${rid}.`);
+      templateFile(
+        path.join(nugetSourceDir, templateName),
+        path.join(pkgStagingPath, ridFileName),
+        rid,
+        v8jsiName,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Run nuget pack: once per RID present, plus the meta if all 3 Windows
+  // RIDs are present (aggregator-pack scenario). Local single-arch builds
+  // produce 1 per-RID .nupkg; the aggregator job produces 4 (meta + 3).
+  // ---------------------------------------------------------------------
+  const version = args["semantic-version"] || configJson.version;
+  const repoUrl = "https://github.com/microsoft/v8-jsi";
+
+  let repoCommit = "unknown";
+  try {
+    repoCommit = execSync("git rev-parse HEAD", {
+      encoding: "utf-8",
+      cwd: repoRoot,
+    }).trim();
+  } catch {
+    console.log("Warning: Could not determine git commit ID");
+  }
+
+  let repoBranch = "unknown";
+  try {
+    repoBranch = execSync("git rev-parse --abbrev-ref HEAD", {
+      encoding: "utf-8",
+      cwd: repoRoot,
+    }).trim();
+  } catch {
+    console.log("Warning: Could not determine git branch");
+  }
+
+  ensureDir(pkgPath);
+
+  const nugetExePath = execSync("where nuget.exe", { encoding: "utf-8" })
+    .trim()
+    .split("\n")[0]
+    .trim();
+
+  function packOne(nuspecFileName: string, extraProperties: string = ""): void {
+    const props =
+      [
+        `nugetroot=${pkgStagingPath}`,
+        `version=${version}`,
+        `repoUrl=${repoUrl}`,
+        `repoBranch=${repoBranch}`,
+        `repoCommit=${repoCommit}`,
+      ].join(";") + extraProperties;
+    run(nugetExePath, [
+      "pack",
+      `"${path.join(pkgStagingPath, nuspecFileName)}"`,
+      "-Properties",
+      `"${props}"`,
+      "-OutputDirectory",
+      `"${pkgPath}"`,
+    ]);
+  }
+
+  // Per-RID packages.
+  for (const rid of stagedRids) {
+    packOne(
+      "Microsoft.JavaScript.V8.rid.nuspec",
+      `;rid=${rid};v8jsiName=${v8jsiName}`,
+    );
+  }
+
+  // Meta package — only if all 3 Windows RIDs are present in staging.
+  // Otherwise its <dependencies> would resolve to packages that the local
+  // feed doesn't have, breaking consumer installs.
+  const allRidsPresent = ALL_WINDOWS_RIDS.every((r) =>
+    fs.existsSync(
+      path.join(pkgStagingPath, "build", "native", r, "v8jsi.dll"),
+    ),
+  );
+  if (allRidsPresent) {
+    packOne("Microsoft.JavaScript.V8.nuspec");
+  } else {
+    const missing = ALL_WINDOWS_RIDS.filter(
+      (r) =>
+        !fs.existsSync(
+          path.join(pkgStagingPath, "build", "native", r, "v8jsi.dll"),
+        ),
+    );
+    console.log(
+      `\nSkipping meta package: per-RID staging missing for ${missing.join(", ")}.`,
+    );
+  }
+
+  console.log(`\nNuGet packages created in ${pkgPath}`);
+}
+
+// =============================================================================
+// Clean Operations
+// =============================================================================
+
+function cleanAll(outputPath: string): void {
+  console.log(`Cleaning all: ${outputPath}`);
+  deleteDir(outputPath);
+}
+
+function cleanBuild(configuration: string): void {
+  const outDir = buildOutputDir(configuration);
+  console.log(`Cleaning build: ${outDir}`);
+  deleteDir(outDir);
+}
+
+function cleanPkg(outputPath: string): void {
+  console.log("Cleaning pkg and pkg-staging");
+  deleteDir(path.join(outputPath, "pkg-staging"));
+  deleteDir(path.join(outputPath, "pkg"));
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+async function main(): Promise<void> {
+  const startTime = Date.now();
+
+  if (args.help) {
+    showHelp();
+    return;
+  }
+
+  // Validate arguments
+  const platforms = (args.platform ?? ["x64"]).map((p) => p.toLowerCase());
+  const configurations = (args.configuration ?? ["release"]).map((c) =>
+    c.toLowerCase(),
+  );
+
+  for (const p of platforms) {
+    if (!validPlatforms.includes(p)) {
+      console.error(
+        `Invalid platform: ${p}. Valid values: ${validPlatforms.join(", ")}`,
+      );
+      process.exit(1);
+    }
+  }
+  for (const c of configurations) {
+    if (!validConfigurations.includes(c)) {
+      console.error(
+        `Invalid configuration: ${c}. Valid values: ${validConfigurations.join(", ")}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const outputPath = path.resolve(args["output-path"] ?? "./out");
+  ensureDir(outputPath);
+
+  const toolsPath = path.join(outputPath, "tools");
+
+  // Clean operations
+  if (args["clean-all"]) {
+    cleanAll(outputPath);
+  }
+  if (args["clean-pkg"]) {
+    cleanPkg(outputPath);
+  }
+
+  if (args.build) {
+    checkNodejsVersionSync();
+  }
+
+  // Per-platform × configuration operations
+  for (const platform of platforms) {
+    for (const configuration of configurations) {
+      if (args["clean-build"]) {
+        cleanBuild(configuration);
+      }
+      if (args.build) {
+        runBuild(platform, configuration);
+      }
+      if (args.test) {
+        runTests(platform, configuration);
+      }
+      if (args.binskim) {
+        await runBinSkim(platform, configuration, toolsPath);
+      }
+    }
+  }
+
+  // Package operation (after all builds)
+  if (args.pack) {
+    packNuGet(outputPath, platforms, configurations);
+  }
+
+  // Report elapsed time
+  const elapsed = Date.now() - startTime;
+  const seconds = Math.floor(elapsed / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  console.log(
+    `\nBuild took ${minutes}m ${remainingSeconds}s`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -327,16 +327,14 @@ Examples:
 function runBuild(platform: string, configuration: string): void {
   console.log(`\n=== Building v8jsi (${platform} ${configuration}) ===\n`);
 
-  if (platform !== "x64") {
-    console.log(
-      `WARNING: vcbuild.bat currently only supports x64 builds. Skipping ${platform}.`,
-    );
-    return;
-  }
-
+  // vcbuild.bat accepts x86 / x64 / arm64 as order-independent target-arch
+  // tokens and writes the binaries to out\<Config>\ regardless of arch, so
+  // we forward the platform straight through. x64 is vcbuild's default, but
+  // passing it explicitly is harmless and keeps the call uniform.
   const vcbuildArgs = [
     ".\\vcbuild.bat",
     configuration,
+    platform,
     "v8jsi",
     "without-intl",
     "no-node",

--- a/src/copy_test_js_files.ts
+++ b/src/copy_test_js_files.ts
@@ -1,0 +1,81 @@
+// Copy Node-API conformance test JS files into the build output directory,
+// preserving the source-target relative path under <dest-root>/.
+// Mirrors the BUILD.gn copy("node_api_test_js_files") rule but driven from
+// GYP via an action.
+//
+// Usage:
+//   node copy_test_js_files.ts --source-base <dir> --dest-root <dir> [--stamp <file>]
+//
+// All *.js files under <source-base> (recursive) are copied to
+// <dest-root>/<rel-path>. No manifest — the file list is derived from the
+// directory tree at action-execution time.
+//
+// Change-detection caveat: gyp's `inputs:` for the action only lists this
+// script. Adding a new .js file does NOT change the script's mtime, so an
+// incremental build won't re-run the copy on its own. To pick up newly-added
+// .js files, do a clean build (or touch this script).
+
+import {
+  copyFileSync,
+  mkdirSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+// On MSVS, `<(PRODUCT_DIR)` expands to `$(OutDir)` which ends with a backslash;
+// when emitted as `--dest-root "$(OutDir)"` in the project file, the trailing
+// backslash escapes the closing quote and the argument arrives with a trailing
+// `"` baked in. Strip it before resolving.
+function stripStrayQuote(s: string): string {
+  return s.endsWith('"') ? s.slice(0, -1) : s;
+}
+
+const { values } = parseArgs({
+  options: {
+    "source-base": { type: "string" },
+    "dest-root": { type: "string" },
+    stamp: { type: "string" },
+  },
+});
+
+if (!values["source-base"] || !values["dest-root"]) {
+  console.error(
+    "Usage: node copy_test_js_files.ts --source-base <dir> --dest-root <dir> [--stamp <file>]"
+  );
+  process.exit(1);
+}
+
+const sourceBase = resolve(stripStrayQuote(values["source-base"]));
+const destRoot = resolve(stripStrayQuote(values["dest-root"]));
+const stampPath = values.stamp ? resolve(stripStrayQuote(values.stamp)) : null;
+
+function* walkJsFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkJsFiles(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith(".js")) {
+      yield fullPath;
+    }
+  }
+}
+
+mkdirSync(destRoot, { recursive: true });
+
+let copied = 0;
+for (const src of walkJsFiles(sourceBase)) {
+  const rel = relative(sourceBase, src);
+  const dest = join(destRoot, rel);
+  mkdirSync(dirname(dest), { recursive: true });
+  copyFileSync(src, dest);
+  copied++;
+}
+
+if (stampPath) {
+  mkdirSync(dirname(stampPath), { recursive: true });
+  writeFileSync(stampPath, `${copied} files copied at ${new Date().toISOString()}\n`);
+}
+
+console.log(`Copied ${copied} test JS files to ${destRoot}`);

--- a/src/generate_version_rc.ts
+++ b/src/generate_version_rc.ts
@@ -1,0 +1,29 @@
+// Generate version_gen.rc from version.rc template and config.json
+// Usage: node generate_version_rc.ts [--config <path>] [--template <path>] [--output <path>]
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { parseArgs } from "node:util";
+
+const scriptDir = dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Z]:)/i, "$1"));
+
+const { values } = parseArgs({
+  options: {
+    config: { type: "string", default: join(scriptDir, "..", "config.json") },
+    template: { type: "string", default: join(scriptDir, "version.rc") },
+    output: { type: "string", default: join(scriptDir, "version_gen.rc") },
+  },
+});
+
+const config = JSON.parse(readFileSync(values.config!, "utf8"));
+const [major, minor, build] = (config.version as string).split(".");
+
+const template = readFileSync(values.template!, "utf8");
+const result = template
+  .replaceAll("V8JSIVER_MAJOR", major ?? "0")
+  .replaceAll("V8JSIVER_MINOR", minor ?? "0")
+  .replaceAll("V8JSIVER_BUILD", build ?? "0")
+  .replaceAll("V8JSIVER_V8REF", "0");
+
+writeFileSync(values.output!, result);
+console.log(`Generated ${values.output} (version ${major}.${minor}.${build})`);

--- a/src/inspector/inspector_agent.cpp
+++ b/src/inspector/inspector_agent.cpp
@@ -23,7 +23,11 @@
 
 #include "V8Windows.h"
 
+#ifdef JSI_ABI_BUILDING
 #include "../v8_core.h"
+#else
+#include "../IsolateData.h"
+#endif
 
 namespace inspector {
 
@@ -160,7 +164,11 @@ void InterruptCallback(v8::Isolate *, void *agent) {
   static_cast<AgentImpl *>(agent)->DispatchMessages();
 }
 
+#ifdef JSI_ABI_BUILDING
 class DispatchOnInspectorBackendTask : public v8rt::TaskRunner::Task {
+#else
+class DispatchOnInspectorBackendTask : public v8runtime::JSITask {
+#endif
  public:
   explicit DispatchOnInspectorBackendTask(AgentImpl& agent) : agent_(agent) {}
 
@@ -586,14 +594,18 @@ void AgentImpl::PostIncomingMessage(
 
   if (AppendMessage(&incoming_message_queue_, session_id, Utf8ToStringView(message))) {
     // Need to get the foreground runner from the isolate data slot.
-    // Both legacy V8Runtime and the ABI runtime store a v8rt::IsolateData
-    // here (the legacy path also uses kIsolateDataSlot==0 with the same
-    // layout via v8_core.h after W4); the inspector code is a shared
-    // consumer of that engine-internal task-runner interface.
+#ifdef JSI_ABI_BUILDING
+    // The ABI runtime stores a v8rt::IsolateData in the slot; the inspector is
+    // a shared consumer of that engine-internal task-runner interface.
     auto runner = v8rt::IsolateData::fromIsolate(isolate_)->taskRunner();
     if (runner) {
       runner->postTask(std::make_unique<DispatchOnInspectorBackendTask>(*this));
     }
+#else
+    // The legacy V8Runtime stores a v8runtime::IsolateData in the slot.
+    v8runtime::IsolateData* isolate_data = reinterpret_cast<v8runtime::IsolateData*>(isolate_->GetData(v8runtime::ISOLATE_DATA_SLOT));
+    isolate_data->foreground_task_runner_->postTask(std::make_unique<DispatchOnInspectorBackendTask>(*this));
+#endif
     isolate_->RequestInterrupt(InterruptCallback, this);
   }
 
@@ -742,10 +754,20 @@ bool Agent::IsStarted() {
 void Agent::addContext(v8::Local<v8::Context> context,
   const char* context_name) {
   impl->addContext(context, context_name);
+
+  if (impl->getInspectedContextsCount() == 1) {
+    std::lock_guard<std::mutex> lock(agents_s_mutex_);
+    agents_s_.insert(impl);
+  }
 }
 
 void Agent::removeContext(v8::Local<v8::Context> context) {
   impl->removeContext(context);
+
+  if (impl->getInspectedContextsCount() == 0) {
+    std::lock_guard<std::mutex> lock(agents_s_mutex_);
+    agents_s_.erase(impl);
+  }
 }
 
 bool Agent::IsConnected() {
@@ -759,6 +781,28 @@ void Agent::WaitForDisconnect() {
 void Agent::notifyLoadedUrl(const std::string& url) { impl->notifyLoadedUrl(url); }
 
 std::shared_ptr<Agent> Agent::getShared() { return shared_from_this(); }
+
+/*static*/ std::mutex Agent::agents_s_mutex_;
+/*static*/ std::set<
+    std::weak_ptr<inspector::AgentImpl>,
+    std::owner_less<std::weak_ptr<inspector::AgentImpl>>>
+    Agent::agents_s_;
+
+/*static */void Agent::startAll() {
+  std::vector<std::shared_ptr<AgentImpl>> snapshot;
+  {
+    std::lock_guard<std::mutex> lock(agents_s_mutex_);
+    snapshot.reserve(agents_s_.size());
+    for (auto& weak_agent : agents_s_) {
+      if (auto agent = weak_agent.lock()) {
+        snapshot.push_back(std::move(agent));
+      }
+    }
+  }
+  for (auto& agent : snapshot) {
+    agent->Start();
+  }
+}
 
 void Agent::FatalException(
     v8::Local<v8::Value> error,

--- a/src/inspector/inspector_agent.cpp
+++ b/src/inspector/inspector_agent.cpp
@@ -23,7 +23,7 @@
 
 #include "V8Windows.h"
 
-#include "../IsolateData.h"
+#include "../v8_core.h"
 
 namespace inspector {
 
@@ -160,7 +160,7 @@ void InterruptCallback(v8::Isolate *, void *agent) {
   static_cast<AgentImpl *>(agent)->DispatchMessages();
 }
 
-class DispatchOnInspectorBackendTask : public v8runtime::JSITask {
+class DispatchOnInspectorBackendTask : public v8rt::TaskRunner::Task {
  public:
   explicit DispatchOnInspectorBackendTask(AgentImpl& agent) : agent_(agent) {}
 
@@ -315,12 +315,12 @@ std::string GenerateID() {
 AgentImpl::AgentImpl(
     v8::Isolate *isolate,
     int port)
-    : isolate_(isolate),
-      port_(port),
+    : port_(port),
       wait_(false),
       shutting_down_(false),
       state_(State::kNew),
       inspector_(nullptr),
+      isolate_(isolate),
       dispatching_messages_(false),
       session_id_(0),
       targetId_(GenerateID()) {
@@ -357,13 +357,13 @@ void InspectorConsoleCall(const v8::FunctionCallbackInfo<v8::Value> &info) {
         config_object->Set(context, in_call_key, v8::True(isolate)).FromJust());
     CHECK(
         !inspector_method.As<v8::Function>()
-             ->Call(context, info.Holder(), static_cast<int>(call_args.size()), call_args.data())
+             ->Call(context, info.This(), static_cast<int>(call_args.size()), call_args.data())
              .IsEmpty());
   }
 
   v8::TryCatch try_catch(info.GetIsolate());
   static_cast<void>(node_method.As<v8::Function>()->Call(
-      context, info.Holder(), static_cast<int>(call_args.size()), call_args.data()));
+      context, info.This(), static_cast<int>(call_args.size()), call_args.data()));
   CHECK(config_object->Delete(context, in_call_key).FromJust());
   if (try_catch.HasCaught())
     try_catch.ReThrow();
@@ -585,9 +585,15 @@ void AgentImpl::PostIncomingMessage(
     const std::string &message) {
 
   if (AppendMessage(&incoming_message_queue_, session_id, Utf8ToStringView(message))) {
-    // Need to get the foreground runner from the isolate data slot
-    v8runtime::IsolateData* isolate_data = reinterpret_cast<v8runtime::IsolateData*>(isolate_->GetData(v8runtime::ISOLATE_DATA_SLOT));
-    isolate_data->foreground_task_runner_->postTask(std::make_unique<DispatchOnInspectorBackendTask>(*this));
+    // Need to get the foreground runner from the isolate data slot.
+    // Both legacy V8Runtime and the ABI runtime store a v8rt::IsolateData
+    // here (the legacy path also uses kIsolateDataSlot==0 with the same
+    // layout via v8_core.h after W4); the inspector code is a shared
+    // consumer of that engine-internal task-runner interface.
+    auto runner = v8rt::IsolateData::fromIsolate(isolate_)->taskRunner();
+    if (runner) {
+      runner->postTask(std::make_unique<DispatchOnInspectorBackendTask>(*this));
+    }
     isolate_->RequestInterrupt(InterruptCallback, this);
   }
 
@@ -664,7 +670,6 @@ void AgentImpl::Write(
   MessageQueue outgoing_messages;
   SwapBehindLock(&outgoing_message_queue_, &outgoing_messages);
   for (const MessageQueue::value_type& outgoing : outgoing_messages) {
-    v8_inspector::StringView view = outgoing.second->string();
     std::string message = StringViewToUtf8(outgoing.second->string());
     TRACEV8INSPECTOR_VERBOSE("OutMessage",
                              TraceLoggingString(message.c_str(), "message"));
@@ -737,20 +742,10 @@ bool Agent::IsStarted() {
 void Agent::addContext(v8::Local<v8::Context> context,
   const char* context_name) {
   impl->addContext(context, context_name);
-
-  if (impl->getInspectedContextsCount() == 1) {
-    std::lock_guard<std::mutex> lock(agents_s_mutex_);
-    agents_s_.insert(impl);
-  }
 }
 
 void Agent::removeContext(v8::Local<v8::Context> context) {
   impl->removeContext(context);
-
-  if (impl->getInspectedContextsCount() == 0) {
-    std::lock_guard<std::mutex> lock(agents_s_mutex_);
-    agents_s_.erase(impl);
-  }
 }
 
 bool Agent::IsConnected() {
@@ -764,28 +759,6 @@ void Agent::WaitForDisconnect() {
 void Agent::notifyLoadedUrl(const std::string& url) { impl->notifyLoadedUrl(url); }
 
 std::shared_ptr<Agent> Agent::getShared() { return shared_from_this(); }
-
-/*static*/ std::mutex Agent::agents_s_mutex_;
-/*static*/ std::set<
-    std::weak_ptr<inspector::AgentImpl>,
-    std::owner_less<std::weak_ptr<inspector::AgentImpl>>>
-    Agent::agents_s_;
-
-/*static */void Agent::startAll() {
-  std::vector<std::shared_ptr<AgentImpl>> snapshot;
-  {
-    std::lock_guard<std::mutex> lock(agents_s_mutex_);
-    snapshot.reserve(agents_s_.size());
-    for (auto& weak_agent : agents_s_) {
-      if (auto agent = weak_agent.lock()) {
-        snapshot.push_back(std::move(agent));
-      }
-    }
-  }
-  for (auto& agent : snapshot) {
-    agent->Start();
-  }
-}
 
 void Agent::FatalException(
     v8::Local<v8::Value> error,

--- a/src/inspector/inspector_agent.h
+++ b/src/inspector/inspector_agent.h
@@ -5,8 +5,6 @@
 
 #include <stddef.h>
 #include <memory>
-#include <mutex>
-#include <set>
 
 #include <public/V8JsiRuntime.h>
 
@@ -39,21 +37,8 @@ class Agent : public std::enable_shared_from_this<Agent> {
   void notifyLoadedUrl(const std::string& url);
   std::shared_ptr<Agent> getShared();
 
-  static void startAll();
-
  private:
   std::shared_ptr<AgentImpl> impl;
-
-  // Tracks every AgentImpl that currently has at least one inspected context,
-  // so the debugger-invoked startAll() can iterate live agents process-wide.
-  // Held as weak_ptr so the set never extends AgentImpl lifetime past natural
-  // V8Runtime teardown. Mutated/read concurrently by V8Runtime ctor/dtor on
-  // arbitrary threads, so all access is serialized by agents_s_mutex_.
-  static std::mutex agents_s_mutex_;
-  static std::set<
-      std::weak_ptr<inspector::AgentImpl>,
-      std::owner_less<std::weak_ptr<inspector::AgentImpl>>>
-      agents_s_;
 };
 
 } // namespace inspector

--- a/src/inspector/inspector_agent.h
+++ b/src/inspector/inspector_agent.h
@@ -5,6 +5,8 @@
 
 #include <stddef.h>
 #include <memory>
+#include <mutex>
+#include <set>
 
 #include <public/V8JsiRuntime.h>
 
@@ -37,8 +39,21 @@ class Agent : public std::enable_shared_from_this<Agent> {
   void notifyLoadedUrl(const std::string& url);
   std::shared_ptr<Agent> getShared();
 
+  static void startAll();
+
  private:
   std::shared_ptr<AgentImpl> impl;
+
+  // Tracks every AgentImpl that currently has at least one inspected context,
+  // so the debugger-invoked startAll() can iterate live agents process-wide.
+  // Held as weak_ptr so the set never extends AgentImpl lifetime past natural
+  // V8Runtime teardown. Mutated/read concurrently by V8Runtime ctor/dtor on
+  // arbitrary threads, so all access is serialized by agents_s_mutex_.
+  static std::mutex agents_s_mutex_;
+  static std::set<
+      std::weak_ptr<inspector::AgentImpl>,
+      std::owner_less<std::weak_ptr<inspector::AgentImpl>>>
+      agents_s_;
 };
 
 } // namespace inspector

--- a/src/inspector/inspector_socket.cpp
+++ b/src/inspector/inspector_socket.cpp
@@ -631,8 +631,9 @@ std::string ProtocolHandler::GetHost() const {
 
 // RAII uv_tcp_t wrapper
 TcpHolder::TcpHolder(std::shared_ptr<tcp_connection> connection, std::unique_ptr<InspectorSocket::Delegate> delegate)
-                     : delegate_(std::move(delegate)),
-                       connection_(connection), handler_(nullptr) {
+                     : connection_(connection),
+                       delegate_(std::move(delegate)),
+                       handler_(nullptr) {
   connection_->registerReadCallback(TcpHolder::OnDataReceivedCb, this);
   connection_->read_loop_async();
 }

--- a/src/inspector/inspector_socket_server.cpp
+++ b/src/inspector/inspector_socket_server.cpp
@@ -18,11 +18,6 @@ namespace inspector {
 
 namespace {
 
-  // We don't support protocol http end point.
-  static const uint8_t PROTOCOL_JSON[] = { 0 };
-  //    #include "v8_inspector_protocol_json.h"  // NOLINT(build/include_order)
-  //};
-
   void Escape(std::string* string) {
     for (char& c : *string) {
       c = (c == '\"' || c == '\\') ? '_' : c;
@@ -53,14 +48,6 @@ namespace {
     url << host << '/' << target_id;
     return url.str();
   }
-
-  std::string FormatWsAddress(const std::string& host, int port,
-                              const std::string& target_id,
-                              bool include_protocol) {
-    return FormatAddress(FormatHostPort(host, port), target_id,
-                         include_protocol);
-  }
-
 
   std::string MapToString(const std::map<std::string, std::string>& object) {
     bool first = true;
@@ -99,22 +86,6 @@ namespace {
       if (path[len] == '\0') return path + len;
     }
     return nullptr;
-  }
-
-  void PrintDebuggerReadyMessage(const std::string& host,
-    int port,
-    const std::vector<std::string>& ids,
-    FILE* out) {
-    if (out == nullptr) {
-      return;
-    }
-    for (const std::string& id : ids) {
-      fprintf(out, "Debugger listening on %s\n",
-        FormatWsAddress(host, port, id, true).c_str());
-    }
-    fprintf(out, "For help, see: %s\n",
-      "https://nodejs.org/en/docs/inspector");
-    fflush(out);
   }
 
   void SendHttpResponse(InspectorSocket* socket, const std::string& response) {

--- a/src/inspector/inspector_tcp.cpp
+++ b/src/inspector/inspector_tcp.cpp
@@ -10,7 +10,7 @@
 namespace inspector {
 
 tcp_server::tcp_server(int port, ConnectionCallback callback, void* data)
-  : io_context_(), acceptor_(io_context_), socket_(io_context_), connectioncallback_(callback), callbackData_(data)
+  : io_context_(), acceptor_(io_context_), socket_(io_context_), callbackData_(data), connectioncallback_(callback)
 {
   asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v4(), port);
   acceptor_.open(endpoint.protocol());
@@ -137,7 +137,7 @@ void tcp_connection::do_write(bool cont) {
   std::transform(messageToWrite_.begin(), messageToWrite_.end(), std::back_inserter(str), [](char c) { return c; });
 
   socket_.async_send(asio::buffer(messageToWrite_),
-    [this, self](asio::error_code ec, std::size_t bytes_transferred)
+    [self](asio::error_code ec, std::size_t bytes_transferred)
   {
     if (!ec)
     {

--- a/src/inspector/inspector_tcp.h
+++ b/src/inspector/inspector_tcp.h
@@ -28,8 +28,6 @@ private:
   void do_write(bool cont);
 
 private:
-  int port_;
-
   asio::ip::tcp::socket socket_;
   std::string message_;
 

--- a/src/inspector/inspector_utils.h
+++ b/src/inspector/inspector_utils.h
@@ -23,7 +23,6 @@ size_t base64_encode(const char* src, size_t slen, char* dst, size_t dlen);
 std::string utf16toUTF8(const uint16_t* utf16String, size_t utf16Len) noexcept;
 std::wstring Utf8ToUtf16(const char* utf8, size_t utf8Len);
 
-static char ToLower(char c);
 std::string ToLower(const std::string& in);
 bool StringEqualNoCase(const char* a, const char* b);
 bool StringEqualNoCaseN(const char* a, const char* b, size_t length);

--- a/src/jsi/test/testlib.cpp
+++ b/src/jsi/test/testlib.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <jsi/test/testlib.h>
+#include <jsi/test/testlib_abi.h>
 
 #include <gtest/gtest.h>
 #include <jsi/decorator.h>

--- a/src/jsi/test/testlib_abi.h
+++ b/src/jsi/test/testlib_abi.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/// \file testlib_abi.h
+/// \brief Helper utilities for ABI runtime testing.
+
+#ifndef TESTLIB_ABI_H
+#define TESTLIB_ABI_H
+
+namespace facebook::jsi {
+
+/// Check if the current test is running with the ABI runtime.
+/// Use in tests to skip tests not yet supported:
+///   if (isAbiRuntime()) GTEST_SKIP() << "Not yet supported in ABI runtime";
+bool isAbiRuntime();
+
+} // namespace facebook::jsi
+
+#endif // TESTLIB_ABI_H

--- a/src/jsi/test/testlib_ext.cpp
+++ b/src/jsi/test/testlib_ext.cpp
@@ -8,6 +8,7 @@
 // These tests are adopted from the Hermes API tests
 
 #include <jsi/test/testlib.h>
+#include <jsi/test/testlib_abi.h>
 
 #include <gtest/gtest.h>
 #include <jsi/decorator.h>
@@ -22,10 +23,6 @@
 #include <unordered_set>
 
 #include <gtest/gtest.h>
-#include <fstream>
-#include <iterator>
-#include <sstream>
-#include <unordered_map>
 
 using namespace facebook::jsi;
 
@@ -571,108 +568,6 @@ TEST_P(JSITestExt, NativeExceptionDoesNotUseGlobalError) {
       "typeof Error is number; Exception in HostFunction: Native "
       "std::logic_error C++ exception in Host Function",
       test.call(rt).getString(rt).utf8(rt));
-}
-
-TEST_P(JSITestExt, V8Instrumentation_GetRecordedGCStats) {
-  auto& instrumentation = rt.instrumentation();
-  std::string gcStats = instrumentation.getRecordedGCStats();
-
-  EXPECT_FALSE(gcStats.empty());
-  EXPECT_NE(gcStats.find("totalHeapSize"), std::string::npos);
-}
-
-TEST_P(JSITestExt, V8Instrumentation_GetHeapInfo) {
-  auto& instrumentation = rt.instrumentation();
-  auto heapInfoBefore = instrumentation.getHeapInfo(false);
-
-  // Allocate objects to increase heap usage
-  eval(R"(
-    globalThis.arr = new Array(10000).fill(0);
-    globalThis.obj = {}; for (let i = 0; i < 10000; i++) obj[i] = {val:i};
-    )");
-
-  auto heapInfoAfter = instrumentation.getHeapInfo(false);
-
-  // The heap is growing by chunks, it is possible that the totalHeapSize may
-  // not change.
-  EXPECT_GE(heapInfoAfter["totalHeapSize"], heapInfoBefore["totalHeapSize"]);
-  EXPECT_GT(heapInfoAfter["usedHeapSize"], heapInfoBefore["usedHeapSize"]);
-
-  eval(R"(
-    globalThis.arr = undefined;
-    globalThis.obj = undefined;
-    )");
-}
-
-// Disabling this test for now, since GC is not deterministic and it may fail
-// TEST_P(JSITestExt, V8Instrumentation_CollectGarbage) {
-//   auto& instrumentation = rt.instrumentation();
-
-//   // Allocate objects to increase heap usage
-//   eval(R"(
-//     globalThis.arr = new Array(10000).fill(0);
-//     globalThis.obj = {}; for (let i = 0; i < 10000; i++) obj[i] = {val:i};
-//     )");
-
-//   auto heapInfoBefore = instrumentation.getHeapInfo(false);
-
-//   eval(R"(
-//     globalThis.arr = undefined;
-//     globalThis.obj = undefined;
-//     )");
-
-//   instrumentation.collectGarbage("Test GC");
-
-//   auto heapInfoAfter = instrumentation.getHeapInfo(false);
-
-//   // The heap is growing by chunks, it is possible that the totalHeapSize may
-//   // not change.
-//   EXPECT_LE(heapInfoAfter["totalHeapSize"], heapInfoBefore["totalHeapSize"]);
-//   EXPECT_LT(heapInfoAfter["usedHeapSize"], heapInfoBefore["usedHeapSize"]);
-// }
-
-TEST_P(JSITestExt, V8Instrumentation_CreateHeapSnapshotToFile) {
-  auto& instrumentation = rt.instrumentation();
-  const std::string snapshotPath = "test.heapsnapshot";
-
-  Instrumentation::HeapSnapshotOptions options;
-  options.captureNumericValue = true;
-
-  // Allocate objects to increase heap usage
-  eval(R"(
-    globalThis.arr = []; for (let i = 0; i < 1000000; i++) arr.push(i);
-    globalThis.obj = {}; for (let i = 0; i < 10000; i++) obj[i] = JSON.stringify(i);
-    globalThis.obj2 = {x: 42};
-    )");
-
-  instrumentation.createSnapshotToFile(snapshotPath, options);
-
-  // Verify that the snapshot file is created and not empty
-  std::ifstream snapshotFile(snapshotPath);
-  ASSERT_TRUE(snapshotFile.is_open());
-  std::string content(
-      (std::istreambuf_iterator<char>(snapshotFile)),
-      std::istreambuf_iterator<char>());
-  snapshotFile.close();
-
-  EXPECT_FALSE(content.empty());
-
-  eval(R"(
-    globalThis.arr = undefined;
-    globalThis.obj = undefined;
-    globalThis.obj2 = undefined;
-    )");
-}
-
-TEST_P(JSITestExt, V8Instrumentation_CreateHeapSnapshotToStream) {
-  auto& instrumentation = rt.instrumentation();
-  std::ostringstream snapshotStream;
-
-  instrumentation.createSnapshotToStream(snapshotStream);
-
-  // Verify that the snapshot stream is not empty
-  std::string content = snapshotStream.str();
-  EXPECT_FALSE(content.empty());
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/jsi_abi/JsiAbiRuntime.cpp
+++ b/src/jsi_abi/JsiAbiRuntime.cpp
@@ -1,0 +1,1510 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Portions derived from facebook/hermes (Hermes ABI):
+ *   Copyright (c) Meta Platforms, Inc. and affiliates.
+ *   Licensed under the MIT license.
+ *
+ * JsiAbiRuntime — C++ wrapper that wraps the jsi_runtime C interface
+ * into a facebook::jsi::Runtime C++ class.
+ *
+ * Modeled after HermesABIRuntimeWrapper.cpp with jsi_* naming.
+ */
+
+#include "jsi_abi/JsiAbiRuntime.h"
+
+#include "jsi_abi/jsi_abi.h"
+#include "jsi_abi/jsi_abi_helpers.h"
+
+#include <atomic>
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace jsi::abi {
+
+//==============================================================================
+// StringByteBuffer — growable buffer backed by std::string
+//==============================================================================
+
+namespace {
+
+struct StringByteBuffer : public jsi_growable_buffer {
+  std::string buf_;
+
+  StringByteBuffer() : buf_(256, '\0') {
+    static const jsi_growable_buffer_vtable bufVt{&tryGrowTo};
+    vtable = const_cast<jsi_growable_buffer_vtable *>(&bufVt);
+    data = reinterpret_cast<uint8_t *>(buf_.data());
+    size = buf_.size();
+    used = 0;
+  }
+
+  static void JSI_CDECL tryGrowTo(jsi_growable_buffer *buf, size_t sz) {
+    auto *self = static_cast<StringByteBuffer *>(buf);
+    if (sz > self->buf_.size()) {
+      self->buf_.resize(sz);
+      buf->data = reinterpret_cast<uint8_t *>(self->buf_.data());
+      buf->size = self->buf_.size();
+    }
+  }
+
+  std::string get() && {
+    buf_.resize(used);
+    return std::move(buf_);
+  }
+};
+
+//==============================================================================
+// SaveAndRestore — RAII helper to save and restore a value
+//==============================================================================
+
+template <typename T>
+struct SaveAndRestore {
+  T &target_;
+  T oldVal_;
+  explicit SaveAndRestore(T &target) : target_(target), oldVal_(target) {}
+  ~SaveAndRestore() { target_ = oldVal_; }
+};
+
+//==============================================================================
+// BufferWrapper — wraps facebook::jsi::Buffer as jsi_buffer
+//==============================================================================
+
+struct BufferWrapper : public jsi_buffer {
+  std::shared_ptr<const facebook::jsi::Buffer> buf_;
+
+  explicit BufferWrapper(std::shared_ptr<const facebook::jsi::Buffer> buf)
+      : buf_(std::move(buf)) {
+    static const jsi_buffer_vtable bufVt{&release};
+    vtable = const_cast<jsi_buffer_vtable *>(&bufVt);
+    data = buf_->data();
+    size = buf_->size();
+  }
+
+  static void JSI_CDECL release(jsi_buffer *self) {
+    delete static_cast<BufferWrapper *>(self);
+  }
+};
+
+//==============================================================================
+// MutableBufferWrapper — wraps facebook::jsi::MutableBuffer
+//==============================================================================
+
+struct MutableBufferWrapper : public jsi_mutable_buffer {
+  std::shared_ptr<facebook::jsi::MutableBuffer> buf_;
+
+  explicit MutableBufferWrapper(
+      std::shared_ptr<facebook::jsi::MutableBuffer> buf)
+      : buf_(std::move(buf)) {
+    static const jsi_mutable_buffer_vtable bufVt{&release};
+    vtable = const_cast<jsi_mutable_buffer_vtable *>(&bufVt);
+    data = buf_->data();
+    size = buf_->size();
+  }
+
+  static void JSI_CDECL release(jsi_mutable_buffer *self) {
+    delete static_cast<MutableBufferWrapper *>(self);
+  }
+};
+
+//==============================================================================
+// PreparedJSWrapper — wraps a jsi_prepared_javascript handle
+//==============================================================================
+
+struct PreparedJSWrapper : public facebook::jsi::PreparedJavaScript {
+  jsi_prepared_javascript *prepared;
+  const jsi_runtime_vtable *vt;
+  jsi_runtime *rt;
+
+  ~PreparedJSWrapper() override {
+    prepared->vtable->release(prepared);
+  }
+};
+
+//==============================================================================
+// JsiAbiRuntime — facebook::jsi::Runtime implementation over the JSI ABI.
+// Internal to this TU; consumers see only the factory functions declared in
+// JsiAbiRuntime.h.
+//==============================================================================
+
+class JsiAbiRuntime : public facebook::jsi::Runtime {
+ public:
+  // Adopts one ref on abiRuntime. Destructor calls release on abiRuntime->vt.
+  explicit JsiAbiRuntime(jsi_runtime *abiRuntime);
+
+  ~JsiAbiRuntime() override;
+
+  JsiAbiRuntime(const JsiAbiRuntime &) = delete;
+  JsiAbiRuntime &operator=(const JsiAbiRuntime &) = delete;
+
+  facebook::jsi::Value evaluateJavaScript(
+      const std::shared_ptr<const facebook::jsi::Buffer> &buffer,
+      const std::string &sourceURL) override;
+
+  std::shared_ptr<const facebook::jsi::PreparedJavaScript> prepareJavaScript(
+      const std::shared_ptr<const facebook::jsi::Buffer> &buffer,
+      std::string sourceURL) override;
+
+  facebook::jsi::Value evaluatePreparedJavaScript(
+      const std::shared_ptr<const facebook::jsi::PreparedJavaScript> &js)
+      override;
+
+#if JSI_VERSION >= 4
+  bool drainMicrotasks(int maxMicrotasksHint = -1) override;
+#endif
+
+#if JSI_VERSION >= 12
+  void queueMicrotask(const facebook::jsi::Function &callback) override;
+#endif
+
+  facebook::jsi::Object global() override;
+  std::string description() override;
+  bool isInspectable() override;
+
+  jsi_runtime *abiRuntime() const noexcept { return abiRt_; }
+
+ protected:
+  PointerValue *cloneSymbol(const PointerValue *pv) override;
+  PointerValue *cloneString(const PointerValue *pv) override;
+#if JSI_VERSION >= 6
+  PointerValue *cloneBigInt(const PointerValue *pv) override;
+#endif
+  PointerValue *cloneObject(const PointerValue *pv) override;
+  PointerValue *clonePropNameID(const PointerValue *pv) override;
+
+  facebook::jsi::PropNameID createPropNameIDFromAscii(
+      const char *str,
+      size_t length) override;
+  facebook::jsi::PropNameID createPropNameIDFromUtf8(
+      const uint8_t *utf8,
+      size_t length) override;
+  facebook::jsi::PropNameID createPropNameIDFromString(
+      const facebook::jsi::String &str) override;
+#if JSI_VERSION >= 5
+  facebook::jsi::PropNameID createPropNameIDFromSymbol(
+      const facebook::jsi::Symbol &sym) override;
+#endif
+  std::string utf8(const facebook::jsi::PropNameID &) override;
+  bool compare(
+      const facebook::jsi::PropNameID &,
+      const facebook::jsi::PropNameID &) override;
+
+  std::string symbolToString(const facebook::jsi::Symbol &) override;
+
+#if JSI_VERSION >= 8
+  facebook::jsi::BigInt createBigIntFromInt64(int64_t) override;
+  facebook::jsi::BigInt createBigIntFromUint64(uint64_t) override;
+  bool bigintIsInt64(const facebook::jsi::BigInt &) override;
+  bool bigintIsUint64(const facebook::jsi::BigInt &) override;
+  uint64_t truncate(const facebook::jsi::BigInt &) override;
+  facebook::jsi::String bigintToString(
+      const facebook::jsi::BigInt &,
+      int) override;
+#endif
+
+  facebook::jsi::String createStringFromAscii(
+      const char *str,
+      size_t length) override;
+  facebook::jsi::String createStringFromUtf8(
+      const uint8_t *utf8,
+      size_t length) override;
+  std::string utf8(const facebook::jsi::String &) override;
+
+  facebook::jsi::Object createObject() override;
+  facebook::jsi::Object createObject(
+      std::shared_ptr<facebook::jsi::HostObject> ho) override;
+  std::shared_ptr<facebook::jsi::HostObject> getHostObject(
+      const facebook::jsi::Object &) override;
+  facebook::jsi::HostFunctionType &getHostFunction(
+      const facebook::jsi::Function &) override;
+
+#if JSI_VERSION >= 7
+  bool hasNativeState(const facebook::jsi::Object &) override;
+  std::shared_ptr<facebook::jsi::NativeState> getNativeState(
+      const facebook::jsi::Object &) override;
+  void setNativeState(
+      const facebook::jsi::Object &,
+      std::shared_ptr<facebook::jsi::NativeState> state) override;
+#endif
+
+#if JSI_VERSION >= 17
+  void setPrototypeOf(
+      const facebook::jsi::Object &object,
+      const facebook::jsi::Value &prototype) override;
+  facebook::jsi::Value getPrototypeOf(
+      const facebook::jsi::Object &object) override;
+#endif
+
+  facebook::jsi::Value getProperty(
+      const facebook::jsi::Object &,
+      const facebook::jsi::PropNameID &name) override;
+  facebook::jsi::Value getProperty(
+      const facebook::jsi::Object &,
+      const facebook::jsi::String &name) override;
+  bool hasProperty(
+      const facebook::jsi::Object &,
+      const facebook::jsi::PropNameID &name) override;
+  bool hasProperty(
+      const facebook::jsi::Object &,
+      const facebook::jsi::String &name) override;
+  void setPropertyValue(
+      JSI_CONST_10 facebook::jsi::Object &,
+      const facebook::jsi::PropNameID &name,
+      const facebook::jsi::Value &value) override;
+  void setPropertyValue(
+      JSI_CONST_10 facebook::jsi::Object &,
+      const facebook::jsi::String &name,
+      const facebook::jsi::Value &value) override;
+
+  bool isArray(const facebook::jsi::Object &) const override;
+  bool isArrayBuffer(const facebook::jsi::Object &) const override;
+  bool isFunction(const facebook::jsi::Object &) const override;
+  bool isHostObject(const facebook::jsi::Object &) const override;
+  bool isHostFunction(const facebook::jsi::Function &) const override;
+  facebook::jsi::Array getPropertyNames(
+      const facebook::jsi::Object &) override;
+
+  facebook::jsi::WeakObject createWeakObject(
+      const facebook::jsi::Object &) override;
+  facebook::jsi::Value lockWeakObject(
+      JSI_NO_CONST_3 JSI_CONST_10 facebook::jsi::WeakObject &) override;
+
+  facebook::jsi::Array createArray(size_t length) override;
+#if JSI_VERSION >= 9
+  facebook::jsi::ArrayBuffer createArrayBuffer(
+      std::shared_ptr<facebook::jsi::MutableBuffer> buffer) override;
+#endif
+  size_t size(const facebook::jsi::Array &) override;
+  size_t size(const facebook::jsi::ArrayBuffer &) override;
+  uint8_t *data(const facebook::jsi::ArrayBuffer &) override;
+  facebook::jsi::Value getValueAtIndex(
+      const facebook::jsi::Array &,
+      size_t i) override;
+  void setValueAtIndexImpl(
+      JSI_CONST_10 facebook::jsi::Array &,
+      size_t i,
+      const facebook::jsi::Value &value) override;
+
+  facebook::jsi::Function createFunctionFromHostFunction(
+      const facebook::jsi::PropNameID &name,
+      unsigned int paramCount,
+      facebook::jsi::HostFunctionType func) override;
+  facebook::jsi::Value call(
+      const facebook::jsi::Function &,
+      const facebook::jsi::Value &jsThis,
+      const facebook::jsi::Value *args,
+      size_t count) override;
+  facebook::jsi::Value callAsConstructor(
+      const facebook::jsi::Function &,
+      const facebook::jsi::Value *args,
+      size_t count) override;
+
+  bool strictEquals(
+      const facebook::jsi::Symbol &a,
+      const facebook::jsi::Symbol &b) const override;
+#if JSI_VERSION >= 6
+  bool strictEquals(
+      const facebook::jsi::BigInt &a,
+      const facebook::jsi::BigInt &b) const override;
+#endif
+  bool strictEquals(
+      const facebook::jsi::String &a,
+      const facebook::jsi::String &b) const override;
+  bool strictEquals(
+      const facebook::jsi::Object &a,
+      const facebook::jsi::Object &b) const override;
+
+  bool instanceOf(
+      const facebook::jsi::Object &o,
+      const facebook::jsi::Function &f) override;
+
+#if JSI_VERSION >= 11
+  void setExternalMemoryPressure(
+      const facebook::jsi::Object &,
+      size_t) override;
+#endif
+
+  ScopeState *pushScope() override;
+  void popScope(ScopeState *) override;
+
+ private:
+  class ManagedPointerHolder;
+  class HostFunctionWrapper;
+  class HostObjectWrapper;
+  class NativeStateWrapper;
+
+  jsi_pointer *getABIPointer(const PointerValue *pv) const;
+
+  jsi_object toABIObject(const facebook::jsi::Object &obj) const;
+  jsi_string toABIString(const facebook::jsi::String &str) const;
+  jsi_symbol toABISymbol(const facebook::jsi::Symbol &sym) const;
+  jsi_propnameid toABIPropNameID(
+      const facebook::jsi::PropNameID &name) const;
+  jsi_function toABIFunction(const facebook::jsi::Function &fn) const;
+  jsi_array toABIArray(const facebook::jsi::Array &arr) const;
+  jsi_arraybuffer toABIArrayBuffer(
+      const facebook::jsi::ArrayBuffer &ab) const;
+  jsi_weak_object toABIWeakObject(
+      const facebook::jsi::WeakObject &wo) const;
+#if JSI_VERSION >= 6
+  jsi_bigint toABIBigInt(const facebook::jsi::BigInt &bi) const;
+#endif
+
+  jsi_value toABIValue(const facebook::jsi::Value &val) const;
+  jsi_value cloneToABIValue(const facebook::jsi::Value &val) const;
+  facebook::jsi::Value cloneToJSIValue(const jsi_value &val);
+  facebook::jsi::PropNameID cloneToJSIPropNameID(jsi_propnameid name);
+  facebook::jsi::Value intoJSIValue(jsi_value val);
+
+  [[noreturn]] void throwError(jsi_error_code err);
+  void checkStatus(jsi_error_code err);
+
+  template <typename OrError>
+  void checkResult(const OrError &result);
+
+  template <typename T, typename Fn>
+  T abiRethrow(T (*wrapErr)(jsi_error_code), Fn fn);
+
+  const jsi_runtime_vtable *vt_;
+  jsi_runtime *abiRt_;
+  bool activeJSError_ = false;
+};
+
+} // namespace
+
+//==============================================================================
+// ManagedPointerHolder — nested inside JsiAbiRuntime
+// Bridges PointerValue to jsi_pointer with refcounting.
+//==============================================================================
+
+class JsiAbiRuntime::ManagedPointerHolder : public PointerValue {
+  jsi_pointer *pointer_;
+  std::atomic<uint32_t> refCount_{1};
+
+ public:
+  explicit ManagedPointerHolder(jsi_pointer *pointer) : pointer_(pointer) {}
+
+  jsi_pointer *pointer() const {
+    return pointer_;
+  }
+
+  void inc() noexcept {
+    refCount_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  void invalidate() JSI_NOEXCEPT_15 override {
+    auto oldCount = refCount_.fetch_sub(1, std::memory_order_acq_rel);
+    if (oldCount == 1) {
+      if (pointer_) {
+        pointer_->vtable->invalidate(pointer_);
+      }
+      delete this;
+    }
+  }
+};
+
+//==============================================================================
+// HostFunctionWrapper — nested inside JsiAbiRuntime
+//==============================================================================
+
+class JsiAbiRuntime::HostFunctionWrapper : public jsi_host_function {
+  JsiAbiRuntime &rtw_;
+  facebook::jsi::HostFunctionType hf_;
+
+ public:
+  static const jsi_host_function_vtable *getVt() {
+    static const jsi_host_function_vtable hfVt{&release, &call};
+    return &hfVt;
+  }
+
+  HostFunctionWrapper(
+      JsiAbiRuntime &rt,
+      facebook::jsi::HostFunctionType hf)
+      : rtw_(rt), hf_(std::move(hf)) {
+    vtable = const_cast<jsi_host_function_vtable *>(getVt());
+  }
+
+  facebook::jsi::HostFunctionType &getHostFunction() {
+    return hf_;
+  }
+
+  static void JSI_CDECL release(jsi_host_function *self) {
+    delete static_cast<HostFunctionWrapper *>(self);
+  }
+
+  static jsi_value_or_error JSI_CDECL call(
+      jsi_host_function *self,
+      jsi_runtime * /*abiRt*/,
+      const jsi_value *thisArg,
+      const jsi_value *args,
+      size_t argCount) {
+    auto *wrapper = static_cast<HostFunctionWrapper *>(self);
+    auto &rtw = wrapper->rtw_;
+    return rtw.abiRethrow(
+        abi::create_value_or_error, [&]() -> jsi_value_or_error {
+          facebook::jsi::Value jsThis = rtw.cloneToJSIValue(*thisArg);
+          std::vector<facebook::jsi::Value> jsArgs;
+          jsArgs.reserve(argCount);
+          for (size_t i = 0; i < argCount; ++i)
+            jsArgs.push_back(rtw.cloneToJSIValue(args[i]));
+
+          facebook::jsi::Value result =
+              wrapper->hf_(rtw, jsThis, jsArgs.data(), argCount);
+
+          return abi::create_value_or_error(rtw.cloneToABIValue(result));
+        });
+  }
+};
+
+//==============================================================================
+// HostObjectWrapper — nested inside JsiAbiRuntime
+//==============================================================================
+
+class JsiAbiRuntime::HostObjectWrapper : public jsi_host_object {
+  JsiAbiRuntime &rtw_;
+  std::shared_ptr<facebook::jsi::HostObject> ho_;
+
+  struct PropNameIDListWrapper : public jsi_propnameid_list {
+    std::vector<facebook::jsi::PropNameID> jsiProps_;
+    std::vector<jsi_propnameid> abiProps_;
+
+    PropNameIDListWrapper(
+        std::vector<facebook::jsi::PropNameID> jsiProps,
+        std::vector<jsi_propnameid> abiProps)
+        : jsiProps_(std::move(jsiProps)), abiProps_(std::move(abiProps)) {
+      static const jsi_propnameid_list_vtable listVt{&release};
+      vtable = const_cast<jsi_propnameid_list_vtable *>(&listVt);
+      props = abiProps_.data();
+      size = abiProps_.size();
+    }
+
+    static void JSI_CDECL release(jsi_propnameid_list *self) {
+      delete static_cast<PropNameIDListWrapper *>(self);
+    }
+  };
+
+ public:
+  static const jsi_host_object_vtable *getVt() {
+    static const jsi_host_object_vtable hoVt{
+        &release, &get, &set, &getOwnKeys};
+    return &hoVt;
+  }
+
+  HostObjectWrapper(
+      JsiAbiRuntime &rt,
+      std::shared_ptr<facebook::jsi::HostObject> ho)
+      : rtw_(rt), ho_(std::move(ho)) {
+    vtable = const_cast<jsi_host_object_vtable *>(getVt());
+  }
+
+  std::shared_ptr<facebook::jsi::HostObject> getHostObject() const {
+    return ho_;
+  }
+
+  static void JSI_CDECL release(jsi_host_object *self) {
+    delete static_cast<HostObjectWrapper *>(self);
+  }
+
+  static jsi_value_or_error JSI_CDECL get(
+      jsi_host_object *self,
+      jsi_runtime * /*abiRt*/,
+      jsi_propnameid name) {
+    auto *wrapper = static_cast<HostObjectWrapper *>(self);
+    auto &rtw = wrapper->rtw_;
+    return rtw.abiRethrow(
+        abi::create_value_or_error, [&]() -> jsi_value_or_error {
+          facebook::jsi::PropNameID jsiName =
+              rtw.cloneToJSIPropNameID(name);
+          facebook::jsi::Value result = wrapper->ho_->get(rtw, jsiName);
+          return abi::create_value_or_error(rtw.cloneToABIValue(result));
+        });
+  }
+
+  static jsi_error_code JSI_CDECL set(
+      jsi_host_object *self,
+      jsi_runtime * /*abiRt*/,
+      jsi_propnameid name,
+      const jsi_value *value) {
+    auto *wrapper = static_cast<HostObjectWrapper *>(self);
+    auto &rtw = wrapper->rtw_;
+    return rtw.abiRethrow(
+        abi::identity_error,
+        [&]() -> jsi_error_code {
+          facebook::jsi::PropNameID jsiName =
+              rtw.cloneToJSIPropNameID(name);
+          facebook::jsi::Value jsiVal = rtw.cloneToJSIValue(*value);
+          wrapper->ho_->set(rtw, jsiName, jsiVal);
+          return jsi_no_error;
+        });
+  }
+
+  static jsi_propnameid_list_or_error JSI_CDECL getOwnKeys(
+      jsi_host_object *self,
+      jsi_runtime * /*abiRt*/) {
+    auto *wrapper = static_cast<HostObjectWrapper *>(self);
+    auto &rtw = wrapper->rtw_;
+    return rtw.abiRethrow(
+        abi::create_propnameid_list_or_error,
+        [&]() -> jsi_propnameid_list_or_error {
+          auto names = wrapper->ho_->getPropertyNames(rtw);
+          std::vector<jsi_propnameid> abiProps;
+          abiProps.reserve(names.size());
+          for (auto &n : names) {
+            abiProps.push_back({rtw.getABIPointer(getPointerValue(n))});
+          }
+          auto *list = new PropNameIDListWrapper(
+              std::move(names), std::move(abiProps));
+          return abi::create_propnameid_list_or_error(list);
+        });
+  }
+};
+
+//==============================================================================
+// NativeStateWrapper — nested inside JsiAbiRuntime
+//==============================================================================
+
+class JsiAbiRuntime::NativeStateWrapper : public jsi_native_state {
+  std::shared_ptr<facebook::jsi::NativeState> state_;
+
+ public:
+  static const jsi_native_state_vtable *getVt() {
+    static const jsi_native_state_vtable nsVt{&release};
+    return &nsVt;
+  }
+
+  explicit NativeStateWrapper(
+      std::shared_ptr<facebook::jsi::NativeState> state)
+      : state_(std::move(state)) {
+    vtable = const_cast<jsi_native_state_vtable *>(getVt());
+  }
+
+  std::shared_ptr<facebook::jsi::NativeState> getNativeState() const {
+    return state_;
+  }
+
+  static void JSI_CDECL release(jsi_native_state *self) {
+    delete static_cast<NativeStateWrapper *>(self);
+  }
+};
+
+//==============================================================================
+// Private helper methods
+//==============================================================================
+
+jsi_pointer *JsiAbiRuntime::getABIPointer(const PointerValue *pv) const {
+  return static_cast<const ManagedPointerHolder *>(pv)->pointer();
+}
+
+jsi_object JsiAbiRuntime::toABIObject(
+    const facebook::jsi::Object &obj) const {
+  return {getABIPointer(getPointerValue(obj))};
+}
+jsi_string JsiAbiRuntime::toABIString(
+    const facebook::jsi::String &str) const {
+  return {getABIPointer(getPointerValue(str))};
+}
+jsi_symbol JsiAbiRuntime::toABISymbol(
+    const facebook::jsi::Symbol &sym) const {
+  return {getABIPointer(getPointerValue(sym))};
+}
+jsi_propnameid JsiAbiRuntime::toABIPropNameID(
+    const facebook::jsi::PropNameID &name) const {
+  return {getABIPointer(getPointerValue(name))};
+}
+jsi_function JsiAbiRuntime::toABIFunction(
+    const facebook::jsi::Function &fn) const {
+  return {getABIPointer(getPointerValue(fn))};
+}
+jsi_array JsiAbiRuntime::toABIArray(
+    const facebook::jsi::Array &arr) const {
+  return {getABIPointer(getPointerValue(arr))};
+}
+jsi_arraybuffer JsiAbiRuntime::toABIArrayBuffer(
+    const facebook::jsi::ArrayBuffer &ab) const {
+  return {getABIPointer(getPointerValue(ab))};
+}
+jsi_weak_object JsiAbiRuntime::toABIWeakObject(
+    const facebook::jsi::WeakObject &wo) const {
+  return {getABIPointer(getPointerValue(wo))};
+}
+#if JSI_VERSION >= 6
+jsi_bigint JsiAbiRuntime::toABIBigInt(
+    const facebook::jsi::BigInt &bi) const {
+  return {getABIPointer(getPointerValue(bi))};
+}
+#endif
+
+jsi_value JsiAbiRuntime::toABIValue(
+    const facebook::jsi::Value &val) const {
+  if (val.isUndefined())
+    return abi::create_undefined_value();
+  if (val.isNull())
+    return abi::create_null_value();
+  if (val.isBool())
+    return abi::create_bool_value(val.getBool());
+  if (val.isNumber())
+    return abi::create_number_value(val.getNumber());
+  auto *pv = getPointerValue(val);
+  if (pv) {
+    auto *mp = getABIPointer(pv);
+    if (val.isString())
+      return abi::create_string_value(mp);
+    if (val.isObject())
+      return abi::create_object_value(mp);
+    if (val.isSymbol())
+      return abi::create_symbol_value(mp);
+#if JSI_VERSION >= 6
+    if (val.isBigInt())
+      return abi::create_bigint_value(mp);
+#endif
+  }
+  return abi::create_undefined_value();
+}
+
+jsi_value JsiAbiRuntime::cloneToABIValue(
+    const facebook::jsi::Value &val) const {
+  if (val.isUndefined())
+    return abi::create_undefined_value();
+  if (val.isNull())
+    return abi::create_null_value();
+  if (val.isBool())
+    return abi::create_bool_value(val.getBool());
+  if (val.isNumber())
+    return abi::create_number_value(val.getNumber());
+  auto *pv = getPointerValue(val);
+  if (pv) {
+    auto *mp = getABIPointer(pv);
+    if (val.isString())
+      return abi::create_string_value(
+          vt_->clone_string(abiRt_, {mp}).pointer);
+    if (val.isObject())
+      return abi::create_object_value(
+          vt_->clone_object(abiRt_, {mp}).pointer);
+    if (val.isSymbol())
+      return abi::create_symbol_value(
+          vt_->clone_symbol(abiRt_, {mp}).pointer);
+#if JSI_VERSION >= 6
+    if (val.isBigInt())
+      return abi::create_bigint_value(
+          vt_->clone_bigint(abiRt_, {mp}).pointer);
+#endif
+  }
+  return abi::create_undefined_value();
+}
+
+facebook::jsi::Value JsiAbiRuntime::cloneToJSIValue(const jsi_value &val) {
+  switch (abi::get_value_kind(val)) {
+    case jsi_valuekind_undefined:
+      return facebook::jsi::Value::undefined();
+    case jsi_valuekind_null:
+      return facebook::jsi::Value::null();
+    case jsi_valuekind_boolean:
+      return facebook::jsi::Value(abi::get_bool_value(val));
+    case jsi_valuekind_number:
+      return facebook::jsi::Value(abi::get_number_value(val));
+    case jsi_valuekind_string: {
+      auto cloned = vt_->clone_string(abiRt_, {val.data.pointer});
+      return facebook::jsi::Value(make<facebook::jsi::String>(
+          new ManagedPointerHolder(cloned.pointer)));
+    }
+    case jsi_valuekind_object: {
+      auto cloned = vt_->clone_object(abiRt_, {val.data.pointer});
+      return facebook::jsi::Value(make<facebook::jsi::Object>(
+          new ManagedPointerHolder(cloned.pointer)));
+    }
+    case jsi_valuekind_symbol: {
+      auto cloned = vt_->clone_symbol(abiRt_, {val.data.pointer});
+      return facebook::jsi::Value(make<facebook::jsi::Symbol>(
+          new ManagedPointerHolder(cloned.pointer)));
+    }
+    case jsi_valuekind_bigint: {
+      auto cloned = vt_->clone_bigint(abiRt_, {val.data.pointer});
+      return facebook::jsi::Value(make<facebook::jsi::BigInt>(
+          new ManagedPointerHolder(cloned.pointer)));
+    }
+    default:
+      return facebook::jsi::Value::undefined();
+  }
+}
+
+facebook::jsi::Value JsiAbiRuntime::intoJSIValue(jsi_value val) {
+  switch (abi::get_value_kind(val)) {
+    case jsi_valuekind_undefined:
+      return facebook::jsi::Value::undefined();
+    case jsi_valuekind_null:
+      return facebook::jsi::Value::null();
+    case jsi_valuekind_boolean:
+      return facebook::jsi::Value(abi::get_bool_value(val));
+    case jsi_valuekind_number:
+      return facebook::jsi::Value(abi::get_number_value(val));
+    case jsi_valuekind_string:
+      return facebook::jsi::Value(make<facebook::jsi::String>(
+          new ManagedPointerHolder(val.data.pointer)));
+    case jsi_valuekind_object:
+      return facebook::jsi::Value(make<facebook::jsi::Object>(
+          new ManagedPointerHolder(val.data.pointer)));
+    case jsi_valuekind_symbol:
+      return facebook::jsi::Value(make<facebook::jsi::Symbol>(
+          new ManagedPointerHolder(val.data.pointer)));
+    case jsi_valuekind_bigint:
+      return facebook::jsi::Value(make<facebook::jsi::BigInt>(
+          new ManagedPointerHolder(val.data.pointer)));
+    default:
+      abi::release_value(val);
+      return facebook::jsi::Value::undefined();
+  }
+}
+
+//==============================================================================
+// Error handling
+//==============================================================================
+
+void JsiAbiRuntime::throwError(jsi_error_code err) {
+  if (err == jsi_error_js) {
+    jsi_value jsErr = vt_->get_and_clear_js_error_value(abiRt_);
+    facebook::jsi::Value errVal = intoJSIValue(jsErr);
+
+    if (activeJSError_)
+      throw facebook::jsi::JSINativeException(
+          "Error thrown while handling error.");
+
+    SaveAndRestore<bool> s(activeJSError_);
+    activeJSError_ = true;
+    throw facebook::jsi::JSError(*this, std::move(errVal));
+  }
+  if (err == jsi_error_native) {
+    StringByteBuffer gb;
+    vt_->get_and_clear_native_exception_message(abiRt_, &gb);
+    throw facebook::jsi::JSINativeException(std::move(gb).get());
+  }
+  throw facebook::jsi::JSINativeException("Unknown ABI error");
+}
+
+void JsiAbiRuntime::checkStatus(jsi_error_code err) {
+  throwError(err);
+}
+
+template <typename OrError>
+void JsiAbiRuntime::checkResult(const OrError &result) {
+  if (abi::is_error(result)) {
+    throwError(abi::get_error(result));
+  }
+}
+
+template <typename T, typename Fn>
+T JsiAbiRuntime::abiRethrow(T (*wrapErr)(jsi_error_code), Fn fn) {
+  try {
+    return fn();
+  } catch (const facebook::jsi::JSError &e) {
+    jsi_value errVal = cloneToABIValue(e.value());
+    vt_->set_js_error_value(abiRt_, &errVal);
+    abi::release_value(errVal);
+    return wrapErr(jsi_error_js);
+  } catch (const std::exception &e) {
+    auto *msg = e.what();
+    vt_->set_native_exception_message(
+        abiRt_, reinterpret_cast<const uint8_t *>(msg), strlen(msg));
+    return wrapErr(jsi_error_native);
+  } catch (...) {
+    const char *msg = "Unknown exception in host callback";
+    vt_->set_native_exception_message(
+        abiRt_, reinterpret_cast<const uint8_t *>(msg), strlen(msg));
+    return wrapErr(jsi_error_native);
+  }
+}
+
+facebook::jsi::PropNameID JsiAbiRuntime::cloneToJSIPropNameID(
+    jsi_propnameid name) {
+  jsi_propnameid cloned = vt_->clone_propnameid(abiRt_, name);
+  return make<facebook::jsi::PropNameID>(
+      new ManagedPointerHolder(cloned.pointer));
+}
+
+//==============================================================================
+// Constructor / Destructor
+//==============================================================================
+
+JsiAbiRuntime::JsiAbiRuntime(jsi_runtime *abiRuntime)
+    : vt_(abiRuntime->vt), abiRt_(abiRuntime) {}
+
+JsiAbiRuntime::~JsiAbiRuntime() {
+  vt_->release(abiRt_);
+}
+
+//==============================================================================
+// Script evaluation
+//==============================================================================
+
+facebook::jsi::Value JsiAbiRuntime::evaluateJavaScript(
+    const std::shared_ptr<const facebook::jsi::Buffer> &buffer,
+    const std::string &sourceURL) {
+  auto *abiBuf = new BufferWrapper(buffer);
+  auto result = vt_->evaluate_javascript_source(
+      abiRt_, abiBuf, sourceURL.c_str(), sourceURL.size());
+  if (abi::is_error(result))
+    throwError(abi::get_error(result));
+  return intoJSIValue(abi::get_value(result));
+}
+
+std::shared_ptr<const facebook::jsi::PreparedJavaScript>
+JsiAbiRuntime::prepareJavaScript(
+    const std::shared_ptr<const facebook::jsi::Buffer> &buffer,
+    std::string sourceURL) {
+  auto *abiBuf = new BufferWrapper(buffer);
+  auto result = vt_->prepare_javascript(
+      abiRt_, abiBuf, sourceURL.c_str(), sourceURL.size());
+  checkResult(result);
+  auto wrapper = std::make_shared<PreparedJSWrapper>();
+  wrapper->prepared = abi::get_prepared_javascript(result);
+  wrapper->vt = vt_;
+  wrapper->rt = abiRt_;
+  return wrapper;
+}
+
+facebook::jsi::Value JsiAbiRuntime::evaluatePreparedJavaScript(
+    const std::shared_ptr<const facebook::jsi::PreparedJavaScript> &js) {
+  auto *wrapper = static_cast<const PreparedJSWrapper *>(js.get());
+  // Pass the prepared handle by pointer (borrow); the wrapper retains
+  // ownership and releases on destruction.
+  auto result = vt_->evaluate_prepared_javascript(abiRt_, wrapper->prepared);
+  if (abi::is_error(result))
+    throwError(abi::get_error(result));
+  return intoJSIValue(abi::get_value(result));
+}
+
+//==============================================================================
+// Microtasks
+//==============================================================================
+
+#if JSI_VERSION >= 4
+bool JsiAbiRuntime::drainMicrotasks(int maxMicrotasksHint) {
+  auto result = vt_->drain_microtasks(abiRt_, maxMicrotasksHint);
+  checkResult(result);
+  return abi::get_bool(result);
+}
+#endif
+
+#if JSI_VERSION >= 12
+void JsiAbiRuntime::queueMicrotask(
+    const facebook::jsi::Function &callback) {
+  auto result = vt_->queue_microtask(abiRt_, toABIFunction(callback));
+  checkResult(result);
+}
+#endif
+
+//==============================================================================
+// Global / Description / Inspectable
+//==============================================================================
+
+facebook::jsi::Object JsiAbiRuntime::global() {
+  auto obj = vt_->get_global_object(abiRt_);
+  return make<facebook::jsi::Object>(
+      new ManagedPointerHolder(obj.pointer));
+}
+
+std::string JsiAbiRuntime::description() {
+  StringByteBuffer gb;
+  vt_->get_description(abiRt_, &gb);
+  return std::move(gb).get();
+}
+
+bool JsiAbiRuntime::isInspectable() {
+  return vt_->is_inspectable(abiRt_);
+}
+
+//==============================================================================
+// Clone operations
+//==============================================================================
+
+JsiAbiRuntime::PointerValue *JsiAbiRuntime::cloneSymbol(
+    const PointerValue *pv) {
+  auto sym = vt_->clone_symbol(abiRt_, {getABIPointer(pv)});
+  return new ManagedPointerHolder(sym.pointer);
+}
+
+JsiAbiRuntime::PointerValue *JsiAbiRuntime::cloneString(
+    const PointerValue *pv) {
+  auto str = vt_->clone_string(abiRt_, {getABIPointer(pv)});
+  return new ManagedPointerHolder(str.pointer);
+}
+
+#if JSI_VERSION >= 6
+JsiAbiRuntime::PointerValue *JsiAbiRuntime::cloneBigInt(
+    const PointerValue *pv) {
+  auto bi = vt_->clone_bigint(abiRt_, {getABIPointer(pv)});
+  return new ManagedPointerHolder(bi.pointer);
+}
+#endif
+
+JsiAbiRuntime::PointerValue *JsiAbiRuntime::cloneObject(
+    const PointerValue *pv) {
+  auto obj = vt_->clone_object(abiRt_, {getABIPointer(pv)});
+  return new ManagedPointerHolder(obj.pointer);
+}
+
+JsiAbiRuntime::PointerValue *JsiAbiRuntime::clonePropNameID(
+    const PointerValue *pv) {
+  auto name = vt_->clone_propnameid(abiRt_, {getABIPointer(pv)});
+  return new ManagedPointerHolder(name.pointer);
+}
+
+//==============================================================================
+// PropNameID operations
+//==============================================================================
+
+facebook::jsi::PropNameID JsiAbiRuntime::createPropNameIDFromAscii(
+    const char *str,
+    size_t length) {
+  return createPropNameIDFromUtf8(
+      reinterpret_cast<const uint8_t *>(str), length);
+}
+
+facebook::jsi::PropNameID JsiAbiRuntime::createPropNameIDFromUtf8(
+    const uint8_t *utf8,
+    size_t length) {
+  auto result = vt_->create_propnameid_from_utf8(abiRt_, utf8, length);
+  checkResult(result);
+  return make<facebook::jsi::PropNameID>(
+      new ManagedPointerHolder(abi::get_propnameid(result).pointer));
+}
+
+facebook::jsi::PropNameID JsiAbiRuntime::createPropNameIDFromString(
+    const facebook::jsi::String &str) {
+  auto result =
+      vt_->create_propnameid_from_string(abiRt_, toABIString(str));
+  checkResult(result);
+  return make<facebook::jsi::PropNameID>(
+      new ManagedPointerHolder(abi::get_propnameid(result).pointer));
+}
+
+#if JSI_VERSION >= 5
+facebook::jsi::PropNameID JsiAbiRuntime::createPropNameIDFromSymbol(
+    const facebook::jsi::Symbol &sym) {
+  auto result =
+      vt_->create_propnameid_from_symbol(abiRt_, toABISymbol(sym));
+  checkResult(result);
+  return make<facebook::jsi::PropNameID>(
+      new ManagedPointerHolder(abi::get_propnameid(result).pointer));
+}
+#endif
+
+std::string JsiAbiRuntime::utf8(const facebook::jsi::PropNameID &name) {
+  StringByteBuffer gb;
+  vt_->get_utf8_from_propnameid(abiRt_, toABIPropNameID(name), &gb);
+  return std::move(gb).get();
+}
+
+bool JsiAbiRuntime::compare(
+    const facebook::jsi::PropNameID &a,
+    const facebook::jsi::PropNameID &b) {
+  return vt_->prop_name_id_equals(
+      abiRt_, toABIPropNameID(a), toABIPropNameID(b));
+}
+
+//==============================================================================
+// Symbol operations
+//==============================================================================
+
+std::string JsiAbiRuntime::symbolToString(
+    const facebook::jsi::Symbol &sym) {
+  StringByteBuffer gb;
+  vt_->get_utf8_from_symbol(abiRt_, toABISymbol(sym), &gb);
+  return std::move(gb).get();
+}
+
+//==============================================================================
+// BigInt operations
+//==============================================================================
+
+#if JSI_VERSION >= 8
+facebook::jsi::BigInt JsiAbiRuntime::createBigIntFromInt64(int64_t val) {
+  auto result = vt_->create_bigint_from_int64(abiRt_, val);
+  checkResult(result);
+  return make<facebook::jsi::BigInt>(
+      new ManagedPointerHolder(abi::get_bigint(result).pointer));
+}
+
+facebook::jsi::BigInt JsiAbiRuntime::createBigIntFromUint64(uint64_t val) {
+  auto result = vt_->create_bigint_from_uint64(abiRt_, val);
+  checkResult(result);
+  return make<facebook::jsi::BigInt>(
+      new ManagedPointerHolder(abi::get_bigint(result).pointer));
+}
+
+bool JsiAbiRuntime::bigintIsInt64(const facebook::jsi::BigInt &bi) {
+  return vt_->bigint_is_int64(abiRt_, toABIBigInt(bi));
+}
+
+bool JsiAbiRuntime::bigintIsUint64(const facebook::jsi::BigInt &bi) {
+  return vt_->bigint_is_uint64(abiRt_, toABIBigInt(bi));
+}
+
+uint64_t JsiAbiRuntime::truncate(const facebook::jsi::BigInt &bi) {
+  return vt_->bigint_truncate_to_uint64(abiRt_, toABIBigInt(bi));
+}
+
+facebook::jsi::String JsiAbiRuntime::bigintToString(
+    const facebook::jsi::BigInt &bi,
+    int radix) {
+  auto result = vt_->bigint_to_string(
+      abiRt_, toABIBigInt(bi), static_cast<uint32_t>(radix));
+  checkResult(result);
+  return make<facebook::jsi::String>(
+      new ManagedPointerHolder(abi::get_string(result).pointer));
+}
+#endif
+
+//==============================================================================
+// String operations
+//==============================================================================
+
+facebook::jsi::String JsiAbiRuntime::createStringFromAscii(
+    const char *str,
+    size_t length) {
+  return createStringFromUtf8(
+      reinterpret_cast<const uint8_t *>(str), length);
+}
+
+facebook::jsi::String JsiAbiRuntime::createStringFromUtf8(
+    const uint8_t *utf8,
+    size_t length) {
+  auto result = vt_->create_string_from_utf8(abiRt_, utf8, length);
+  checkResult(result);
+  return make<facebook::jsi::String>(
+      new ManagedPointerHolder(abi::get_string(result).pointer));
+}
+
+std::string JsiAbiRuntime::utf8(const facebook::jsi::String &str) {
+  StringByteBuffer gb;
+  vt_->get_utf8_from_string(abiRt_, toABIString(str), &gb);
+  return std::move(gb).get();
+}
+
+//==============================================================================
+// Object operations
+//==============================================================================
+
+facebook::jsi::Object JsiAbiRuntime::createObject() {
+  auto result = vt_->create_object(abiRt_);
+  checkResult(result);
+  return make<facebook::jsi::Object>(
+      new ManagedPointerHolder(abi::get_object(result).pointer));
+}
+
+facebook::jsi::Object JsiAbiRuntime::createObject(
+    std::shared_ptr<facebook::jsi::HostObject> ho) {
+  auto *wrapper = new HostObjectWrapper(*this, std::move(ho));
+  auto result = vt_->create_object_from_host_object(abiRt_, wrapper);
+  checkResult(result);
+  return make<facebook::jsi::Object>(
+      new ManagedPointerHolder(abi::get_object(result).pointer));
+}
+
+std::shared_ptr<facebook::jsi::HostObject> JsiAbiRuntime::getHostObject(
+    const facebook::jsi::Object &obj) {
+  auto *ho = vt_->get_host_object(abiRt_, toABIObject(obj));
+  if (!ho)
+    return nullptr;
+  if (ho->vtable == HostObjectWrapper::getVt())
+    return static_cast<HostObjectWrapper *>(ho)->getHostObject();
+  return nullptr;
+}
+
+facebook::jsi::HostFunctionType &JsiAbiRuntime::getHostFunction(
+    const facebook::jsi::Function &fn) {
+  auto *hf = vt_->get_host_function(abiRt_, toABIFunction(fn));
+  assert(hf && "Not a host function");
+  return static_cast<HostFunctionWrapper *>(hf)->getHostFunction();
+}
+
+#if JSI_VERSION >= 7
+bool JsiAbiRuntime::hasNativeState(const facebook::jsi::Object &obj) {
+  return vt_->has_native_state(abiRt_, toABIObject(obj));
+}
+
+std::shared_ptr<facebook::jsi::NativeState>
+JsiAbiRuntime::getNativeState(const facebook::jsi::Object &obj) {
+  auto *ns = vt_->get_native_state(abiRt_, toABIObject(obj));
+  if (!ns)
+    return nullptr;
+  if (ns->vtable == NativeStateWrapper::getVt())
+    return static_cast<NativeStateWrapper *>(ns)->getNativeState();
+  return nullptr;
+}
+
+void JsiAbiRuntime::setNativeState(
+    const facebook::jsi::Object &obj,
+    std::shared_ptr<facebook::jsi::NativeState> state) {
+  auto *wrapper = new NativeStateWrapper(std::move(state));
+  auto result = vt_->set_native_state(abiRt_, toABIObject(obj), wrapper);
+  checkResult(result);
+}
+#endif
+
+//==============================================================================
+// Prototype operations
+//==============================================================================
+
+#if JSI_VERSION >= 17
+void JsiAbiRuntime::setPrototypeOf(
+    const facebook::jsi::Object &object,
+    const facebook::jsi::Value &prototype) {
+  jsi_value proto = toABIValue(prototype);
+  auto result =
+      vt_->set_prototype_of(abiRt_, toABIObject(object), &proto);
+  checkResult(result);
+}
+
+facebook::jsi::Value JsiAbiRuntime::getPrototypeOf(
+    const facebook::jsi::Object &object) {
+  auto result = vt_->get_prototype_of(abiRt_, toABIObject(object));
+  if (abi::is_error(result))
+    throwError(abi::get_error(result));
+  return intoJSIValue(abi::get_value(result));
+}
+#endif
+
+//==============================================================================
+// Property operations
+//==============================================================================
+
+facebook::jsi::Value JsiAbiRuntime::getProperty(
+    const facebook::jsi::Object &obj,
+    const facebook::jsi::PropNameID &name) {
+  auto result = vt_->get_object_property_from_propnameid(
+      abiRt_, toABIObject(obj), toABIPropNameID(name));
+  if (abi::is_error(result))
+    throwError(abi::get_error(result));
+  return intoJSIValue(abi::get_value(result));
+}
+
+facebook::jsi::Value JsiAbiRuntime::getProperty(
+    const facebook::jsi::Object &obj,
+    const facebook::jsi::String &name) {
+  jsi_value key =
+      abi::create_string_value(getABIPointer(getPointerValue(name)));
+  auto result = vt_->get_object_property_from_value(
+      abiRt_, toABIObject(obj), &key);
+  if (abi::is_error(result))
+    throwError(abi::get_error(result));
+  return intoJSIValue(abi::get_value(result));
+}
+
+bool JsiAbiRuntime::hasProperty(
+    const facebook::jsi::Object &obj,
+    const facebook::jsi::PropNameID &name) {
+  auto result = vt_->has_object_property_from_propnameid(
+      abiRt_, toABIObject(obj), toABIPropNameID(name));
+  checkResult(result);
+  return abi::get_bool(result);
+}
+
+bool JsiAbiRuntime::hasProperty(
+    const facebook::jsi::Object &obj,
+    const facebook::jsi::String &name) {
+  jsi_value key =
+      abi::create_string_value(getABIPointer(getPointerValue(name)));
+  auto result = vt_->has_object_property_from_value(
+      abiRt_, toABIObject(obj), &key);
+  checkResult(result);
+  return abi::get_bool(result);
+}
+
+void JsiAbiRuntime::setPropertyValue(
+    JSI_CONST_10 facebook::jsi::Object &obj,
+    const facebook::jsi::PropNameID &name,
+    const facebook::jsi::Value &value) {
+  jsi_value val = toABIValue(value);
+  auto result = vt_->set_object_property_from_propnameid(
+      abiRt_, toABIObject(obj), toABIPropNameID(name), &val);
+  checkResult(result);
+}
+
+void JsiAbiRuntime::setPropertyValue(
+    JSI_CONST_10 facebook::jsi::Object &obj,
+    const facebook::jsi::String &name,
+    const facebook::jsi::Value &value) {
+  jsi_value key =
+      abi::create_string_value(getABIPointer(getPointerValue(name)));
+  jsi_value val = toABIValue(value);
+  auto result = vt_->set_object_property_from_value(
+      abiRt_, toABIObject(obj), &key, &val);
+  checkResult(result);
+}
+
+//==============================================================================
+// Type checks
+//==============================================================================
+
+bool JsiAbiRuntime::isArray(const facebook::jsi::Object &obj) const {
+  return vt_->object_is_array(abiRt_, toABIObject(obj));
+}
+
+bool JsiAbiRuntime::isArrayBuffer(
+    const facebook::jsi::Object &obj) const {
+  return vt_->object_is_arraybuffer(abiRt_, toABIObject(obj));
+}
+
+bool JsiAbiRuntime::isFunction(const facebook::jsi::Object &obj) const {
+  return vt_->object_is_function(abiRt_, toABIObject(obj));
+}
+
+bool JsiAbiRuntime::isHostObject(
+    const facebook::jsi::Object &obj) const {
+  auto *ho = vt_->get_host_object(abiRt_, toABIObject(obj));
+  return ho && ho->vtable == HostObjectWrapper::getVt();
+}
+
+bool JsiAbiRuntime::isHostFunction(
+    const facebook::jsi::Function &fn) const {
+  auto *hf = vt_->get_host_function(abiRt_, toABIFunction(fn));
+  return hf && hf->vtable == HostFunctionWrapper::getVt();
+}
+
+facebook::jsi::Array JsiAbiRuntime::getPropertyNames(
+    const facebook::jsi::Object &obj) {
+  auto result = vt_->get_object_property_names(abiRt_, toABIObject(obj));
+  checkResult(result);
+  return make<facebook::jsi::Object>(
+             new ManagedPointerHolder(abi::get_array(result).pointer))
+      .getArray(*this);
+}
+
+//==============================================================================
+// Weak references
+//==============================================================================
+
+facebook::jsi::WeakObject JsiAbiRuntime::createWeakObject(
+    const facebook::jsi::Object &obj) {
+  auto result = vt_->create_weak_object(abiRt_, toABIObject(obj));
+  checkResult(result);
+  return make<facebook::jsi::WeakObject>(
+      new ManagedPointerHolder(abi::get_weak_object(result).pointer));
+}
+
+facebook::jsi::Value JsiAbiRuntime::lockWeakObject(
+    JSI_NO_CONST_3 JSI_CONST_10 facebook::jsi::WeakObject &wo) {
+  auto val = vt_->lock_weak_object(abiRt_, toABIWeakObject(wo));
+  return intoJSIValue(val);
+}
+
+//==============================================================================
+// Array operations
+//==============================================================================
+
+facebook::jsi::Array JsiAbiRuntime::createArray(size_t length) {
+  auto result = vt_->create_array(abiRt_, length);
+  checkResult(result);
+  return make<facebook::jsi::Object>(
+             new ManagedPointerHolder(abi::get_array(result).pointer))
+      .getArray(*this);
+}
+
+#if JSI_VERSION >= 9
+facebook::jsi::ArrayBuffer JsiAbiRuntime::createArrayBuffer(
+    std::shared_ptr<facebook::jsi::MutableBuffer> buffer) {
+  auto *abiBuf = new MutableBufferWrapper(std::move(buffer));
+  auto result =
+      vt_->create_arraybuffer_from_external_data(abiRt_, abiBuf);
+  checkResult(result);
+  return make<facebook::jsi::Object>(
+             new ManagedPointerHolder(
+                 abi::get_arraybuffer(result).pointer))
+      .getArrayBuffer(*this);
+}
+#endif
+
+size_t JsiAbiRuntime::size(const facebook::jsi::Array &arr) {
+  return vt_->get_array_length(abiRt_, toABIArray(arr));
+}
+
+size_t JsiAbiRuntime::size(const facebook::jsi::ArrayBuffer &ab) {
+  auto result = vt_->get_arraybuffer_size(abiRt_, toABIArrayBuffer(ab));
+  if (abi::is_error(result))
+    throwError(abi::get_error(result));
+  return abi::get_size(result);
+}
+
+uint8_t *JsiAbiRuntime::data(const facebook::jsi::ArrayBuffer &ab) {
+  auto result = vt_->get_arraybuffer_data(abiRt_, toABIArrayBuffer(ab));
+  if (abi::is_error(result))
+    throwError(abi::get_error(result));
+  return abi::get_uint8_ptr(result);
+}
+
+facebook::jsi::Value JsiAbiRuntime::getValueAtIndex(
+    const facebook::jsi::Array &arr,
+    size_t i) {
+  auto result =
+      vt_->get_array_element(abiRt_, toABIObject(arr), i);
+  if (abi::is_error(result))
+    throwError(abi::get_error(result));
+  return intoJSIValue(abi::get_value(result));
+}
+
+void JsiAbiRuntime::setValueAtIndexImpl(
+    JSI_CONST_10 facebook::jsi::Array &arr,
+    size_t i,
+    const facebook::jsi::Value &value) {
+  jsi_value val = toABIValue(value);
+  auto result =
+      vt_->set_array_element(abiRt_, toABIObject(arr), i, &val);
+  checkResult(result);
+}
+
+//==============================================================================
+// Function operations
+//==============================================================================
+
+facebook::jsi::Function JsiAbiRuntime::createFunctionFromHostFunction(
+    const facebook::jsi::PropNameID &name,
+    unsigned int paramCount,
+    facebook::jsi::HostFunctionType func) {
+  auto *wrapper = new HostFunctionWrapper(*this, std::move(func));
+  auto result = vt_->create_function_from_host_function(
+      abiRt_, toABIPropNameID(name), paramCount, wrapper);
+  checkResult(result);
+  return make<facebook::jsi::Object>(
+             new ManagedPointerHolder(
+                 abi::get_function(result).pointer))
+      .getFunction(*this);
+}
+
+facebook::jsi::Value JsiAbiRuntime::call(
+    const facebook::jsi::Function &fn,
+    const facebook::jsi::Value &jsThis,
+    const facebook::jsi::Value *args,
+    size_t count) {
+  std::vector<jsi_value> abiArgs(count);
+  for (size_t i = 0; i < count; ++i)
+    abiArgs[i] = toABIValue(args[i]);
+  jsi_value abiThis = toABIValue(jsThis);
+  auto result = vt_->call(
+      abiRt_, toABIFunction(fn), &abiThis, abiArgs.data(), count);
+  if (abi::is_error(result))
+    throwError(abi::get_error(result));
+  return intoJSIValue(abi::get_value(result));
+}
+
+facebook::jsi::Value JsiAbiRuntime::callAsConstructor(
+    const facebook::jsi::Function &fn,
+    const facebook::jsi::Value *args,
+    size_t count) {
+  std::vector<jsi_value> abiArgs(count);
+  for (size_t i = 0; i < count; ++i)
+    abiArgs[i] = toABIValue(args[i]);
+  auto result = vt_->call_as_constructor(
+      abiRt_, toABIFunction(fn), abiArgs.data(), count);
+  if (abi::is_error(result))
+    throwError(abi::get_error(result));
+  return intoJSIValue(abi::get_value(result));
+}
+
+//==============================================================================
+// Comparison
+//==============================================================================
+
+bool JsiAbiRuntime::strictEquals(
+    const facebook::jsi::Symbol &a,
+    const facebook::jsi::Symbol &b) const {
+  return vt_->strict_equals_symbol(
+      abiRt_, toABISymbol(a), toABISymbol(b));
+}
+
+#if JSI_VERSION >= 6
+bool JsiAbiRuntime::strictEquals(
+    const facebook::jsi::BigInt &a,
+    const facebook::jsi::BigInt &b) const {
+  return vt_->strict_equals_bigint(
+      abiRt_, toABIBigInt(a), toABIBigInt(b));
+}
+#endif
+
+bool JsiAbiRuntime::strictEquals(
+    const facebook::jsi::String &a,
+    const facebook::jsi::String &b) const {
+  return vt_->strict_equals_string(
+      abiRt_, toABIString(a), toABIString(b));
+}
+
+bool JsiAbiRuntime::strictEquals(
+    const facebook::jsi::Object &a,
+    const facebook::jsi::Object &b) const {
+  return vt_->strict_equals_object(
+      abiRt_, toABIObject(a), toABIObject(b));
+}
+
+bool JsiAbiRuntime::instanceOf(
+    const facebook::jsi::Object &o,
+    const facebook::jsi::Function &f) {
+  auto result =
+      vt_->instance_of(abiRt_, toABIObject(o), toABIFunction(f));
+  checkResult(result);
+  return abi::get_bool(result);
+}
+
+//==============================================================================
+// External memory pressure
+//==============================================================================
+
+#if JSI_VERSION >= 11
+void JsiAbiRuntime::setExternalMemoryPressure(
+    const facebook::jsi::Object &obj,
+    size_t amount) {
+  auto result = vt_->set_object_external_memory_pressure(
+      abiRt_, toABIObject(obj), amount);
+  checkResult(result);
+}
+#endif
+
+//==============================================================================
+// Scopes
+//==============================================================================
+
+facebook::jsi::Runtime::ScopeState *JsiAbiRuntime::pushScope() {
+  void *scope = nullptr;
+  vt_->push_scope(abiRt_, &scope);
+  return reinterpret_cast<ScopeState *>(scope);
+}
+
+void JsiAbiRuntime::popScope(ScopeState *state) {
+  vt_->pop_scope(abiRt_, reinterpret_cast<void *>(state));
+}
+
+//==============================================================================
+// Factory functions (exported via JsiAbiRuntime.h)
+//==============================================================================
+
+std::unique_ptr<facebook::jsi::Runtime> makeJsiAbiRuntime(
+    jsi_create_runtime_fn create_runtime,
+    jsi_configure_runtime_cb configure,
+    void *configure_data) {
+  // Inject the consumer's compiled JSI_ABI_VERSION (Node-API Model B). The
+  // create function hands back a runtime with refcount 1; the wrapper adopts
+  // that ref (destructor releases). nullptr means the implementation is too old
+  // for this consumer's version, or the configure callback returned an error.
+  jsi_runtime *rt = create_runtime(JSI_ABI_VERSION, configure, configure_data);
+  if (!rt) {
+    throw facebook::jsi::JSINativeException(
+        "JSI ABI runtime creation failed: version unsupported or configure error");
+  }
+  return std::make_unique<JsiAbiRuntime>(rt);
+}
+
+std::unique_ptr<facebook::jsi::Runtime> wrapJsiRuntime(
+    jsi_runtime *abiRuntime) {
+  // Add a ref on entry; the wrapper adopts that fresh ref. The caller's
+  // ref (if any) is independent.
+  abiRuntime->vt->add_ref(abiRuntime);
+  return std::make_unique<JsiAbiRuntime>(abiRuntime);
+}
+
+jsi_runtime *getAbiRuntime(facebook::jsi::Runtime &runtime) noexcept {
+  // Caller asserts the supplied Runtime was created via the factories above.
+  return static_cast<JsiAbiRuntime &>(runtime).abiRuntime();
+}
+
+} // namespace jsi::abi

--- a/src/jsi_abi/JsiAbiRuntime.h
+++ b/src/jsi_abi/JsiAbiRuntime.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Portions derived from facebook/hermes (Hermes ABI):
+ *   Copyright (c) Meta Platforms, Inc. and affiliates.
+ *   Licensed under the MIT license.
+ *
+ * JsiAbiRuntime — a facebook::jsi::Runtime implementation backed by the
+ * JSI ABI C interface. Engine-agnostic; compiled on the consumer side.
+ *
+ * The implementation class lives entirely in JsiAbiRuntime.cpp. Consumers
+ * see only the factory + accessor functions declared here.
+ */
+
+/* ===========================================================================
+ * EXPERIMENTAL API - NOT YET ABI-STABLE
+ *
+ * This is the consumer-compiled C++ wrapper over the experimental JSI ABI. It
+ * tracks the ABI's stability: while the ABI is in experimental mode this header
+ * is subject to change and is NOT ABI-safe. Do not depend on binary
+ * compatibility across builds. The notice will be removed once the underlying
+ * ABI leaves experimental mode.
+ * =========================================================================== */
+
+#ifndef JSI_ABI_RUNTIME_H
+#define JSI_ABI_RUNTIME_H
+
+#include "jsi_abi/jsi_abi.h"
+
+#include <jsi/jsi.h>
+
+#include <memory>
+
+namespace jsi::abi {
+
+/// The engine's flat runtime-creation export, as a function-pointer type.
+/// Each engine provides one (e.g. v8_create_runtime). Takes the consumer's
+/// compiled JSI_ABI_VERSION + a configure callback/context; returns a runtime
+/// with refcount 1, or nullptr on version mismatch / configure failure.
+using jsi_create_runtime_fn = jsi_runtime *(JSI_CDECL *)(
+    uint32_t requested_abi_version,
+    jsi_configure_runtime_cb configure,
+    void *configure_data);
+
+/// Create a new JSI runtime via the engine's flat create function. This wrapper
+/// is compiled into the consumer, so it injects the consumer's JSI_ABI_VERSION
+/// for free (Node-API Model B).
+/// \param create_runtime The engine's create export (e.g. v8_create_runtime).
+/// \param configure Optional callback that populates the factory-owned config
+///   via engine-specific setters (e.g. v8_jsi_config_set_*); nullptr = defaults.
+/// \param configure_data Opaque context passed through to configure.
+/// \return A facebook::jsi::Runtime that owns one ref on the new runtime.
+std::unique_ptr<facebook::jsi::Runtime> makeJsiAbiRuntime(
+    jsi_create_runtime_fn create_runtime,
+    jsi_configure_runtime_cb configure = nullptr,
+    void *configure_data = nullptr);
+
+/// Wrap an existing jsi_runtime. The returned wrapper holds its own ref
+/// (add_ref is called on entry), so the caller's ref is independent.
+///
+/// Used when a runtime created via jsr_create_runtime (the Node-API entry
+/// point) also needs to be driven through facebook::jsi::Runtime — the same
+/// V8 isolate exposed through both surfaces. Retrieve the jsi_runtime with
+/// jsr_runtime_get_jsi_runtime, then pass it here.
+std::unique_ptr<facebook::jsi::Runtime> wrapJsiRuntime(jsi_runtime *abiRuntime);
+
+/// Retrieve the underlying jsi_runtime pointer from a facebook::jsi::Runtime
+/// that was created by one of the factories above. The returned pointer is
+/// borrowed (no add_ref); it stays alive as long as the wrapping Runtime does.
+///
+/// Intended for test hooks and advanced consumers that need to call
+/// ABI-specific extensions (e.g., v8_open_inspector). Returns nullptr if
+/// the supplied Runtime was not created by this factory.
+jsi_runtime *getAbiRuntime(facebook::jsi::Runtime &runtime) noexcept;
+
+} // namespace jsi::abi
+
+#endif /* JSI_ABI_RUNTIME_H */

--- a/src/jsi_abi/jsi_abi.h
+++ b/src/jsi_abi/jsi_abi.h
@@ -1,0 +1,911 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Portions derived from facebook/hermes (Hermes ABI):
+ *   Copyright (c) Meta Platforms, Inc. and affiliates.
+ *   Licensed under the MIT license.
+ *
+ * JSI ABI — an ABI-stable C interface for JSI (JavaScript Interface).
+ *
+ * Derived from Meta's Hermes ABI: renamed to be engine-agnostic, with
+ * additional changes and improvements.
+ *
+ * Pure C header. No engine-specific types. Can be used by any JS engine
+ * (Hermes, V8, JSC).
+ */
+
+/* ===========================================================================
+ * EXPERIMENTAL API - NOT YET ABI-STABLE
+ *
+ * This API is experimental and subject to change. Although it is C-based, it is
+ * NOT ABI-safe yet: function signatures, vtable layouts, struct fields, enum
+ * values, and error codes may change without notice while the API remains in
+ * experimental mode. Do not depend on binary compatibility across builds. Once
+ * the API leaves experimental mode it will become ABI-stable and this notice
+ * will be removed.
+ * =========================================================================== */
+
+#ifndef JSI_ABI_H
+#define JSI_ABI_H
+
+#ifdef __cplusplus
+#include <cstddef>
+#include <cstdint>
+#else
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==========================================================================
+ * Platform Macros
+ *==========================================================================*/
+
+/* Calling convention — explicit __cdecl on Windows x86 for DLL safety. */
+#ifdef _WIN32
+#define JSI_CDECL __cdecl
+#else
+#define JSI_CDECL
+#endif
+
+/* DLL export/import macros.
+ * If you need __declspec(dllimport), define JSI_API as __declspec(dllimport)
+ * on the compiler's command line. */
+#ifndef JSI_API
+#ifdef _WIN32
+#define JSI_API __declspec(dllexport)
+#else
+#define JSI_API __attribute__((visibility("default")))
+#endif
+#endif
+
+/*==========================================================================
+ * ABI Version
+ *
+ * Monotonic integer (Node-API NAPI_VERSION style). Bump by 1 for every
+ * additive change — there is no major/minor split because the ABI is strictly
+ * append-only with behavioral pinning. The consumer's compiled-against value is
+ * passed to the engine's create function (e.g. v8_create_runtime), which pins
+ * the runtime to it or fails if it exceeds the implementation's max (Model B).
+ *==========================================================================*/
+
+#define JSI_ABI_VERSION 1u
+
+/*==========================================================================
+ * Forward Declarations
+ *==========================================================================*/
+
+struct jsi_runtime;
+struct jsi_pointer;
+struct jsi_growable_buffer;
+struct jsi_buffer;
+struct jsi_mutable_buffer;
+struct jsi_prepared_javascript;
+struct jsi_host_function;
+struct jsi_host_object;
+struct jsi_native_state;
+struct jsi_propnameid_list;
+
+/* Opaque, engine-agnostic configuration object. The runtime factory (e.g.
+ * v8_create_runtime) allocates one and hands it to a jsi_configure_runtime_cb
+ * so the consumer can populate it via engine-specific setters (e.g.
+ * v8_jsi_config_set_*); the handle is valid ONLY for that callback's duration.
+ * Layout is owned by the engine implementation. */
+typedef struct jsi_config_s* jsi_config;
+
+/* Standard data-deleter callback used when ownership of a buffer or other
+ * pointer crosses the DLL boundary. The implementation that handed the
+ * pointer over also supplies this callback so the consumer can free it
+ * with the same allocator that allocated it. */
+typedef void(JSI_CDECL *jsi_data_delete_cb)(void *data, void *deleter_data);
+
+/*==========================================================================
+ * Error Codes
+ *==========================================================================*/
+
+/* Error codes are odd values (bit 0 = 1) and 0 means "no error".
+ * This lets bit-packed OrError variants encode the error directly
+ * (no shift), and lets void-returning operations return jsi_error_code
+ * directly with 0 = success / odd = error. Future codes must be odd. */
+enum jsi_error_code {
+  jsi_no_error = 0,
+  jsi_error_native = 1, /* Native C++ exception (message available) */
+  jsi_error_js = 3 /* JavaScript exception (JS value available) */
+};
+
+/*==========================================================================
+ * Configure callback (factory-owned pull model)
+ *==========================================================================*/
+
+/* The runtime factory allocates a jsi_config and invokes this callback so the
+ * consumer can populate it via the engine's typed setters. The config handle is
+ * valid ONLY for the duration of the call. Return jsi_no_error to proceed, or
+ * an odd jsi_error_code to abort creation (the factory then frees the config
+ * and the create call returns NULL). May be NULL at the create site, meaning
+ * "all defaults". */
+typedef enum jsi_error_code(JSI_CDECL *jsi_configure_runtime_cb)(
+    void *cb_data,
+    jsi_config config);
+
+/*==========================================================================
+ * Pointer Types (from Hermes ABI pattern)
+ *
+ * ManagedPointer — reference-counted GC root with vtable-based release.
+ * Each pointer type wraps a jsi_pointer* to indicate the JS type.
+ *
+ * OrError variants come in two layouts, depending on whether the success
+ * payload leaves a free bit for tagging:
+ *
+ * (A) Bit-packed (single uintptr_t). Used by every jsi_<ptr>_or_error
+ *     (jsi_object_or_error, jsi_string_or_error, ...) and by
+ *     jsi_bool_or_error. Discriminated by bit 0:
+ *
+ *       bit 0 = 0 : success.
+ *                     pointer types — field is jsi_pointer* cast to
+ *                                     uintptr_t (relies on jsi_pointer
+ *                                     alignment >= 2 so bit 0 is 0).
+ *                     jsi_bool_or_error — field is (val << 1):
+ *                                         false = 0, true = 2.
+ *                                         Decoder: field != 0.
+ *       bit 0 = 1 : error. Field is the jsi_error_code value directly
+ *                          (all error codes are odd; see enum above).
+ *                          No shift is needed for either construction
+ *                          or decoding.
+ *
+ * (B) Struct with explicit is_error flag + union. Used by
+ *     jsi_size_or_error and jsi_uint8_ptr_or_error — their payloads use
+ *     the full uintptr_t and leave no room for a tag bit.
+ *
+ * Void-returning operations skip the OrError wrapper entirely and return
+ * jsi_error_code directly (0 = success, odd = error).
+ *
+ * Note: layout (A) stores a bare uintptr_t (not a union of jsi_pointer*
+ * and uintptr_t). The tag bit shares the word with the pointer, so checking
+ * it via a union would mean reading a non-active member — strict-reading
+ * UB in C++. The pointer<->uintptr_t round-trip via reinterpret_cast is
+ * explicitly well-defined ([expr.reinterpret.cast]/5).
+ *
+ * Construction and decoding helpers for both layouts live in
+ * jsi_abi_helpers.h (create_*_or_error, is_error, get_error, get_*).
+ *
+ * NOTE: We intentionally spell out each type explicitly instead of using
+ * X-macros (like Hermes ABI's HERMES_ABI_POINTER_TYPES macro). Explicit
+ * declarations are debugger-friendly (F12/Go to Definition works), visible
+ * to IntelliSense, and easier to read and maintain.
+ *==========================================================================*/
+
+struct jsi_pointer_vtable {
+  void(JSI_CDECL *invalidate)(struct jsi_pointer *self);
+};
+struct jsi_pointer {
+  const struct jsi_pointer_vtable *vtable;
+};
+
+/* --- Object --- */
+struct jsi_object {
+  struct jsi_pointer *pointer;
+};
+struct jsi_object_or_error {
+  uintptr_t ptr_or_error;
+};
+
+/* --- Array --- */
+struct jsi_array {
+  struct jsi_pointer *pointer;
+};
+struct jsi_array_or_error {
+  uintptr_t ptr_or_error;
+};
+
+/* --- String --- */
+struct jsi_string {
+  struct jsi_pointer *pointer;
+};
+struct jsi_string_or_error {
+  uintptr_t ptr_or_error;
+};
+
+/* --- BigInt --- */
+struct jsi_bigint {
+  struct jsi_pointer *pointer;
+};
+struct jsi_bigint_or_error {
+  uintptr_t ptr_or_error;
+};
+
+/* --- Symbol --- */
+struct jsi_symbol {
+  struct jsi_pointer *pointer;
+};
+struct jsi_symbol_or_error {
+  uintptr_t ptr_or_error;
+};
+
+/* --- Function --- */
+struct jsi_function {
+  struct jsi_pointer *pointer;
+};
+struct jsi_function_or_error {
+  uintptr_t ptr_or_error;
+};
+
+/* --- ArrayBuffer --- */
+struct jsi_arraybuffer {
+  struct jsi_pointer *pointer;
+};
+struct jsi_arraybuffer_or_error {
+  uintptr_t ptr_or_error;
+};
+
+/* --- PropNameID --- */
+struct jsi_propnameid {
+  struct jsi_pointer *pointer;
+};
+struct jsi_propnameid_or_error {
+  uintptr_t ptr_or_error;
+};
+
+/* --- WeakObject --- */
+struct jsi_weak_object {
+  struct jsi_pointer *pointer;
+};
+struct jsi_weak_object_or_error {
+  uintptr_t ptr_or_error;
+};
+
+/* --- Bool-or-error (bit-packing scheme; see big-box comment above) ---
+ * Void-returning operations return jsi_error_code directly (no wrapper);
+ * 0 means success, odd values are errors. */
+struct jsi_bool_or_error {
+  uintptr_t bool_or_error;
+};
+
+/* --- Size and uint8_t* or-error (explicit is_error field) --- */
+struct jsi_size_or_error {
+  bool is_error;
+  union {
+    size_t val;
+    enum jsi_error_code error;
+  } data;
+};
+struct jsi_uint8_ptr_or_error {
+  bool is_error;
+  union {
+    uint8_t *val;
+    enum jsi_error_code error;
+  } data;
+};
+
+/*==========================================================================
+ * Value Representation (inline tagged union — from Hermes ABI)
+ *==========================================================================*/
+
+/* The POINTER_MASK marks value kinds that contain a jsi_pointer*. */
+#define JSI_POINTER_MASK (1u << (sizeof(uint32_t) * 8u - 1u))
+
+enum jsi_valuekind {
+  jsi_valuekind_undefined = 0,
+  jsi_valuekind_null = 1,
+  jsi_valuekind_boolean = 2,
+  jsi_valuekind_error = 3, /* Internal: used in jsi_value_or_error */
+  jsi_valuekind_number = 4,
+  jsi_valuekind_symbol = 5 | JSI_POINTER_MASK,
+  jsi_valuekind_bigint = 6 | JSI_POINTER_MASK,
+  jsi_valuekind_string = 7 | JSI_POINTER_MASK,
+  jsi_valuekind_object = 9 | JSI_POINTER_MASK
+};
+
+struct jsi_value {
+  enum jsi_valuekind kind;
+  union {
+    bool boolean;
+    double number;
+    struct jsi_pointer *pointer;
+    enum jsi_error_code error; /* Only when kind == jsi_valuekind_error */
+  } data;
+};
+
+struct jsi_value_or_error {
+  struct jsi_value value;
+};
+
+/*==========================================================================
+ * Buffer Types (from Hermes ABI)
+ *
+ * Three flavors with different ownership / lifetime semantics:
+ *
+ *   jsi_growable_buffer  — short-lived output parameter. Caller stack-
+ *                          allocates and passes &buf for the DLL to fill
+ *                          in during one call. The DLL only ever calls
+ *                          try_grow_to to expand it; ownership stays with
+ *                          the caller, so no release callback is needed.
+ *
+ *   jsi_buffer           — read-only input the DLL retains past the call
+ *                          (e.g., script source). Consumer heap-allocates;
+ *                          the DLL calls vtable->release when done.
+ *
+ *   jsi_mutable_buffer   — writable backing the DLL retains past the call
+ *                          (e.g., ArrayBuffer storage). Same release
+ *                          contract as jsi_buffer.
+ *==========================================================================*/
+
+struct jsi_growable_buffer_vtable {
+  void(JSI_CDECL *try_grow_to)(struct jsi_growable_buffer *buf, size_t sz);
+};
+struct jsi_growable_buffer {
+  const struct jsi_growable_buffer_vtable *vtable;
+  uint8_t *data;
+  size_t size;
+  size_t used;
+};
+
+struct jsi_buffer_vtable {
+  void(JSI_CDECL *release)(struct jsi_buffer *self);
+};
+struct jsi_buffer {
+  const struct jsi_buffer_vtable *vtable;
+  const uint8_t *data;
+  size_t size;
+};
+
+struct jsi_mutable_buffer_vtable {
+  void(JSI_CDECL *release)(struct jsi_mutable_buffer *self);
+};
+struct jsi_mutable_buffer {
+  const struct jsi_mutable_buffer_vtable *vtable;
+  uint8_t *data;
+  size_t size;
+};
+
+/*==========================================================================
+ * PreparedJavaScript
+ *
+ * Opaque engine-managed handle to a compiled script. Returned by
+ * prepare_javascript; passed (by pointer) to evaluate_prepared_javascript.
+ * Always carried by pointer so the implementation can append fields beyond
+ * the vtable header without breaking ABI for callers that only see the
+ * base layout.
+ *
+ * Lifecycle: the consumer owns the returned pointer and calls
+ * vtable->release(p) when done.
+ *==========================================================================*/
+
+struct jsi_prepared_javascript_vtable {
+  void(JSI_CDECL *release)(struct jsi_prepared_javascript *self);
+};
+struct jsi_prepared_javascript {
+  const struct jsi_prepared_javascript_vtable *vtable;
+  /* Implementation may append fields after this header. */
+};
+struct jsi_prepared_javascript_or_error {
+  uintptr_t ptr_or_error;
+};
+
+/*==========================================================================
+ * Callback Types (embedded-struct pattern — from Hermes ABI)
+ *==========================================================================*/
+
+/* Host function: called when JS invokes a native function. */
+struct jsi_host_function_vtable {
+  void(JSI_CDECL *release)(struct jsi_host_function *);
+  struct jsi_value_or_error(JSI_CDECL *call)(
+      struct jsi_host_function *self,
+      struct jsi_runtime *rt,
+      const struct jsi_value *this_arg,
+      const struct jsi_value *args,
+      size_t arg_count);
+};
+struct jsi_host_function {
+  const struct jsi_host_function_vtable *vtable;
+};
+
+/* PropNameID list: returned by host object get_own_keys. */
+struct jsi_propnameid_list_vtable {
+  void(JSI_CDECL *release)(struct jsi_propnameid_list *);
+};
+struct jsi_propnameid_list {
+  const struct jsi_propnameid_list_vtable *vtable;
+  const struct jsi_propnameid *props;
+  size_t size;
+};
+
+struct jsi_propnameid_list_or_error {
+  uintptr_t ptr_or_error;
+};
+
+/* Host object: JS object backed by native callbacks. */
+struct jsi_host_object_vtable {
+  void(JSI_CDECL *release)(struct jsi_host_object *);
+  struct jsi_value_or_error(JSI_CDECL *get)(
+      struct jsi_host_object *self,
+      struct jsi_runtime *rt,
+      struct jsi_propnameid name);
+  enum jsi_error_code(JSI_CDECL *set)(
+      struct jsi_host_object *self,
+      struct jsi_runtime *rt,
+      struct jsi_propnameid name,
+      const struct jsi_value *value);
+  struct jsi_propnameid_list_or_error(JSI_CDECL *get_own_keys)(
+      struct jsi_host_object *self,
+      struct jsi_runtime *rt);
+};
+struct jsi_host_object {
+  const struct jsi_host_object_vtable *vtable;
+};
+
+/* Native state: attached to JS objects, released on GC. */
+struct jsi_native_state_vtable {
+  void(JSI_CDECL *release)(struct jsi_native_state *self);
+};
+struct jsi_native_state {
+  const struct jsi_native_state_vtable *vtable;
+};
+
+/*==========================================================================
+ * Interface Query (for optional extensions — like JSI C++ ICast)
+ *==========================================================================*/
+
+struct jsi_interface_id {
+  uint64_t lower;
+  uint64_t upper;
+};
+
+/*==========================================================================
+ * Runtime VTable
+ *==========================================================================*/
+
+struct jsi_runtime_vtable {
+  /* Pure function table — no version/reserved data fields. Version negotiation
+   * happens once at create time (see JSI_ABI_VERSION / v8_create_runtime). New
+   * functions are appended at the END of this struct. */
+
+  /*----------------------------------------------------------------------
+   * QueryInterface / ICast (C++ JSI: castInterface)
+   * Placed first — like COM's QueryInterface at slot 0. Allows consumers to
+   * discover capabilities before calling anything else.
+   *----------------------------------------------------------------------*/
+
+  /* Query for an optional interface extension.
+   * Returns jsi_error_native with empty message if not supported. */
+  enum jsi_error_code(JSI_CDECL *query_interface)(
+      struct jsi_runtime *rt,
+      const struct jsi_interface_id *iid,
+      const void **vtable_out,
+      void **instance_out);
+
+  /* Report the implementation's max supported ABI version (Node-API
+   * napi_get_version analog). Optional feature-probe — the create-time version
+   * negotiation in v8_create_runtime is what actually gates. */
+  uint32_t(JSI_CDECL *get_abi_version)(struct jsi_runtime *rt);
+
+  /*----------------------------------------------------------------------
+   * Lifecycle
+   *
+   * The runtime is reference-counted. v8_create_runtime / jsr_create_runtime
+   * hand back a runtime with refcount 1. Each add_ref increments; each
+   * release decrements and destroys the runtime when the count reaches 0.
+   *----------------------------------------------------------------------*/
+
+  void(JSI_CDECL *add_ref)(struct jsi_runtime *);
+  void(JSI_CDECL *release)(struct jsi_runtime *);
+
+  /*----------------------------------------------------------------------
+   * Error retrieval (from Hermes ABI pattern)
+   *----------------------------------------------------------------------*/
+
+  /* Get and clear the JS exception value (after jsi_error_js). */
+  struct jsi_value(JSI_CDECL *get_and_clear_js_error_value)(
+      struct jsi_runtime *rt);
+
+  /* Get and clear native exception message (after jsi_error_native). */
+  void(JSI_CDECL *get_and_clear_native_exception_message)(
+      struct jsi_runtime *rt,
+      struct jsi_growable_buffer *buf);
+
+  /* Set errors before returning from host function/object callbacks. */
+  void(JSI_CDECL *set_js_error_value)(
+      struct jsi_runtime *rt,
+      const struct jsi_value *error_value);
+  void(JSI_CDECL *set_native_exception_message)(
+      struct jsi_runtime *rt,
+      const uint8_t *utf8,
+      size_t length);
+
+  /*----------------------------------------------------------------------
+   * Clone operations (from Hermes ABI)
+   *----------------------------------------------------------------------*/
+
+  struct jsi_propnameid(JSI_CDECL *clone_propnameid)(
+      struct jsi_runtime *rt,
+      struct jsi_propnameid name);
+  struct jsi_string(JSI_CDECL *clone_string)(
+      struct jsi_runtime *rt,
+      struct jsi_string str);
+  struct jsi_symbol(JSI_CDECL *clone_symbol)(
+      struct jsi_runtime *rt,
+      struct jsi_symbol sym);
+  struct jsi_object(JSI_CDECL *clone_object)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj);
+  struct jsi_bigint(JSI_CDECL *clone_bigint)(
+      struct jsi_runtime *rt,
+      struct jsi_bigint bigint);
+
+  /*----------------------------------------------------------------------
+   * Runtime description and capabilities
+   *----------------------------------------------------------------------*/
+
+  void(JSI_CDECL *get_description)(
+      struct jsi_runtime *rt,
+      struct jsi_growable_buffer *buf);
+  bool(JSI_CDECL *is_inspectable)(struct jsi_runtime *rt);
+
+  /*----------------------------------------------------------------------
+   * Handle scopes
+   *----------------------------------------------------------------------*/
+
+  /* Push a new handle scope. All pointer types created after this call
+   * are valid until pop_scope. Engines that don't need scopes (Hermes)
+   * can implement these as no-ops. */
+  enum jsi_error_code(JSI_CDECL *push_scope)(
+      struct jsi_runtime *rt,
+      void **scope);
+  enum jsi_error_code(JSI_CDECL *pop_scope)(
+      struct jsi_runtime *rt,
+      void *scope);
+
+  /*----------------------------------------------------------------------
+   * Script evaluation
+   *----------------------------------------------------------------------*/
+
+  struct jsi_value_or_error(JSI_CDECL *evaluate_javascript_source)(
+      struct jsi_runtime *rt,
+      struct jsi_buffer *buf,
+      const char *source_url,
+      size_t source_url_len);
+
+  /* Prepare (compile) a script for later execution. The returned
+   * jsi_prepared_javascript* is owned by the caller and freed via
+   * vtable->release. */
+  struct jsi_prepared_javascript_or_error(JSI_CDECL *prepare_javascript)(
+      struct jsi_runtime *rt,
+      struct jsi_buffer *buf,
+      const char *source_url,
+      size_t source_url_len);
+  struct jsi_value_or_error(JSI_CDECL *evaluate_prepared_javascript)(
+      struct jsi_runtime *rt,
+      struct jsi_prepared_javascript *prepared);
+
+  /*----------------------------------------------------------------------
+   * Microtasks
+   *----------------------------------------------------------------------*/
+
+  struct jsi_bool_or_error(JSI_CDECL *drain_microtasks)(
+      struct jsi_runtime *rt,
+      int32_t max_hint);
+  enum jsi_error_code(JSI_CDECL *queue_microtask)(
+      struct jsi_runtime *rt,
+      struct jsi_function callback);
+
+  /*----------------------------------------------------------------------
+   * Global object
+   *----------------------------------------------------------------------*/
+
+  struct jsi_object(JSI_CDECL *get_global_object)(struct jsi_runtime *rt);
+
+  /*----------------------------------------------------------------------
+   * String operations
+   *----------------------------------------------------------------------*/
+
+  struct jsi_string_or_error(JSI_CDECL *create_string_from_utf8)(
+      struct jsi_runtime *rt,
+      const uint8_t *utf8,
+      size_t len);
+  struct jsi_string_or_error(JSI_CDECL *create_string_from_utf16)(
+      struct jsi_runtime *rt,
+      const uint16_t *utf16,
+      size_t len);
+  void(JSI_CDECL *get_utf8_from_string)(
+      struct jsi_runtime *rt,
+      struct jsi_string str,
+      struct jsi_growable_buffer *buf);
+  void(JSI_CDECL *get_utf16_from_string)(
+      struct jsi_runtime *rt,
+      struct jsi_string str,
+      struct jsi_growable_buffer *buf);
+
+  /*----------------------------------------------------------------------
+   * Symbol operations
+   *----------------------------------------------------------------------*/
+
+  void(JSI_CDECL *get_utf8_from_symbol)(
+      struct jsi_runtime *rt,
+      struct jsi_symbol sym,
+      struct jsi_growable_buffer *buf);
+
+  /*----------------------------------------------------------------------
+   * PropNameID operations
+   *----------------------------------------------------------------------*/
+
+  struct jsi_propnameid_or_error(JSI_CDECL *create_propnameid_from_utf8)(
+      struct jsi_runtime *rt,
+      const uint8_t *utf8,
+      size_t len);
+  struct jsi_propnameid_or_error(JSI_CDECL *create_propnameid_from_string)(
+      struct jsi_runtime *rt,
+      struct jsi_string str);
+  struct jsi_propnameid_or_error(JSI_CDECL *create_propnameid_from_symbol)(
+      struct jsi_runtime *rt,
+      struct jsi_symbol sym);
+  bool(JSI_CDECL *prop_name_id_equals)(
+      struct jsi_runtime *rt,
+      struct jsi_propnameid a,
+      struct jsi_propnameid b);
+  void(JSI_CDECL *get_utf8_from_propnameid)(
+      struct jsi_runtime *rt,
+      struct jsi_propnameid name,
+      struct jsi_growable_buffer *buf);
+
+  /*----------------------------------------------------------------------
+   * Object operations
+   *----------------------------------------------------------------------*/
+
+  struct jsi_object_or_error(JSI_CDECL *create_object)(
+      struct jsi_runtime *rt);
+  struct jsi_object_or_error(JSI_CDECL *create_object_with_prototype)(
+      struct jsi_runtime *rt,
+      const struct jsi_value *prototype);
+
+  /* Prototype access */
+  struct jsi_value_or_error(JSI_CDECL *get_prototype_of)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj);
+  enum jsi_error_code(JSI_CDECL *set_prototype_of)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      const struct jsi_value *prototype);
+
+  /* Property operations (PropNameID-based) */
+  struct jsi_bool_or_error(JSI_CDECL *has_object_property_from_propnameid)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      struct jsi_propnameid name);
+  struct jsi_value_or_error(JSI_CDECL *get_object_property_from_propnameid)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      struct jsi_propnameid name);
+  enum jsi_error_code(JSI_CDECL *set_object_property_from_propnameid)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      struct jsi_propnameid name,
+      const struct jsi_value *value);
+  enum jsi_error_code(JSI_CDECL *delete_property_from_propnameid)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      struct jsi_propnameid name);
+
+  /* Property operations (Value-based — key can be string, symbol, number) */
+  struct jsi_bool_or_error(JSI_CDECL *has_object_property_from_value)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      const struct jsi_value *key);
+  struct jsi_value_or_error(JSI_CDECL *get_object_property_from_value)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      const struct jsi_value *key);
+  enum jsi_error_code(JSI_CDECL *set_object_property_from_value)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      const struct jsi_value *key,
+      const struct jsi_value *value);
+  enum jsi_error_code(JSI_CDECL *delete_property_from_value)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      const struct jsi_value *key);
+
+  /* Get enumerable string property names. */
+  struct jsi_array_or_error(JSI_CDECL *get_object_property_names)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj);
+
+  /* External memory pressure hint for GC. */
+  enum jsi_error_code(JSI_CDECL *set_object_external_memory_pressure)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      size_t amount);
+
+  /* Error object creation */
+  struct jsi_object_or_error(JSI_CDECL *create_error)(
+      struct jsi_runtime *rt,
+      const uint8_t *utf8_msg,
+      size_t len);
+
+  /*----------------------------------------------------------------------
+   * Array operations
+   *----------------------------------------------------------------------*/
+
+  struct jsi_array_or_error(JSI_CDECL *create_array)(
+      struct jsi_runtime *rt,
+      size_t length);
+  size_t(JSI_CDECL *get_array_length)(
+      struct jsi_runtime *rt,
+      struct jsi_array arr);
+  struct jsi_value_or_error(JSI_CDECL *get_array_element)(
+      struct jsi_runtime *rt,
+      struct jsi_object arr,
+      size_t index);
+  enum jsi_error_code(JSI_CDECL *set_array_element)(
+      struct jsi_runtime *rt,
+      struct jsi_object arr,
+      size_t index,
+      const struct jsi_value *value);
+
+  /*----------------------------------------------------------------------
+   * ArrayBuffer operations
+   *----------------------------------------------------------------------*/
+
+  struct jsi_arraybuffer_or_error(JSI_CDECL *create_arraybuffer)(
+      struct jsi_runtime *rt,
+      size_t byte_length);
+  struct jsi_arraybuffer_or_error(
+      JSI_CDECL *create_arraybuffer_from_external_data)(
+      struct jsi_runtime *rt,
+      struct jsi_mutable_buffer *buf);
+  struct jsi_uint8_ptr_or_error(JSI_CDECL *get_arraybuffer_data)(
+      struct jsi_runtime *rt,
+      struct jsi_arraybuffer ab);
+  struct jsi_size_or_error(JSI_CDECL *get_arraybuffer_size)(
+      struct jsi_runtime *rt,
+      struct jsi_arraybuffer ab);
+
+  /*----------------------------------------------------------------------
+   * Function operations
+   *----------------------------------------------------------------------*/
+
+  struct jsi_value_or_error(JSI_CDECL *call)(
+      struct jsi_runtime *rt,
+      struct jsi_function fn,
+      const struct jsi_value *js_this,
+      const struct jsi_value *args,
+      size_t arg_count);
+  struct jsi_value_or_error(JSI_CDECL *call_as_constructor)(
+      struct jsi_runtime *rt,
+      struct jsi_function fn,
+      const struct jsi_value *args,
+      size_t arg_count);
+  struct jsi_function_or_error(JSI_CDECL *create_function_from_host_function)(
+      struct jsi_runtime *rt,
+      struct jsi_propnameid name,
+      uint32_t param_count,
+      struct jsi_host_function *hf);
+  struct jsi_host_function *(JSI_CDECL *get_host_function)(
+      struct jsi_runtime *rt,
+      struct jsi_function fn);
+
+  /*----------------------------------------------------------------------
+   * Host object operations
+   *----------------------------------------------------------------------*/
+
+  struct jsi_object_or_error(JSI_CDECL *create_object_from_host_object)(
+      struct jsi_runtime *rt,
+      struct jsi_host_object *ho);
+  struct jsi_host_object *(JSI_CDECL *get_host_object)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj);
+
+  /*----------------------------------------------------------------------
+   * Native state
+   *----------------------------------------------------------------------*/
+
+  bool(JSI_CDECL *has_native_state)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj);
+  struct jsi_native_state *(JSI_CDECL *get_native_state)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj);
+  enum jsi_error_code(JSI_CDECL *set_native_state)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      struct jsi_native_state *ns);
+
+  /*----------------------------------------------------------------------
+   * Type checks
+   *----------------------------------------------------------------------*/
+
+  bool(JSI_CDECL *object_is_array)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj);
+  bool(JSI_CDECL *object_is_arraybuffer)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj);
+  bool(JSI_CDECL *object_is_function)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj);
+
+  /*----------------------------------------------------------------------
+   * Weak references
+   *----------------------------------------------------------------------*/
+
+  struct jsi_weak_object_or_error(JSI_CDECL *create_weak_object)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj);
+  struct jsi_value(JSI_CDECL *lock_weak_object)(
+      struct jsi_runtime *rt,
+      struct jsi_weak_object wo);
+
+  /*----------------------------------------------------------------------
+   * Comparison
+   *----------------------------------------------------------------------*/
+
+  struct jsi_bool_or_error(JSI_CDECL *instance_of)(
+      struct jsi_runtime *rt,
+      struct jsi_object obj,
+      struct jsi_function ctor);
+  bool(JSI_CDECL *strict_equals_symbol)(
+      struct jsi_runtime *rt,
+      struct jsi_symbol a,
+      struct jsi_symbol b);
+  bool(JSI_CDECL *strict_equals_bigint)(
+      struct jsi_runtime *rt,
+      struct jsi_bigint a,
+      struct jsi_bigint b);
+  bool(JSI_CDECL *strict_equals_string)(
+      struct jsi_runtime *rt,
+      struct jsi_string a,
+      struct jsi_string b);
+  bool(JSI_CDECL *strict_equals_object)(
+      struct jsi_runtime *rt,
+      struct jsi_object a,
+      struct jsi_object b);
+
+  /*----------------------------------------------------------------------
+   * BigInt
+   *----------------------------------------------------------------------*/
+
+  struct jsi_bigint_or_error(JSI_CDECL *create_bigint_from_int64)(
+      struct jsi_runtime *rt,
+      int64_t value);
+  struct jsi_bigint_or_error(JSI_CDECL *create_bigint_from_uint64)(
+      struct jsi_runtime *rt,
+      uint64_t value);
+  bool(JSI_CDECL *bigint_is_int64)(
+      struct jsi_runtime *rt,
+      struct jsi_bigint bigint);
+  bool(JSI_CDECL *bigint_is_uint64)(
+      struct jsi_runtime *rt,
+      struct jsi_bigint bigint);
+  uint64_t(JSI_CDECL *bigint_truncate_to_uint64)(
+      struct jsi_runtime *rt,
+      struct jsi_bigint bigint);
+  int64_t(JSI_CDECL *bigint_to_int64)(
+      struct jsi_runtime *rt,
+      struct jsi_bigint bigint,
+      bool *lossless);
+  uint64_t(JSI_CDECL *bigint_to_uint64)(
+      struct jsi_runtime *rt,
+      struct jsi_bigint bigint,
+      bool *lossless);
+  struct jsi_string_or_error(JSI_CDECL *bigint_to_string)(
+      struct jsi_runtime *rt,
+      struct jsi_bigint bigint,
+      uint32_t radix);
+};
+
+/*==========================================================================
+ * Runtime Instance
+ *==========================================================================*/
+
+struct jsi_runtime {
+  const struct jsi_runtime_vtable *vt;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* JSI_ABI_H */

--- a/src/jsi_abi/jsi_abi_helpers.h
+++ b/src/jsi_abi/jsi_abi_helpers.h
@@ -1,0 +1,563 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Portions derived from facebook/hermes (Hermes ABI):
+ *   Copyright (c) Meta Platforms, Inc. and affiliates.
+ *   Licensed under the MIT license.
+ *
+ * JSI ABI Helpers — C++ inline helpers for encoding/decoding OrError types,
+ * creating values, and checking value kinds.
+ *
+ * Same role as Hermes' HermesABIHelpers.h but with jsi_* naming.
+ * No X-macros — every type and helper spelled out explicitly.
+ */
+
+/* ===========================================================================
+ * EXPERIMENTAL API - NOT YET ABI-STABLE
+ *
+ * This API is experimental and subject to change. Although it is C-based, it is
+ * NOT ABI-safe yet: function signatures, vtable layouts, struct fields, enum
+ * values, and error codes may change without notice while the API remains in
+ * experimental mode. Do not depend on binary compatibility across builds. Once
+ * the API leaves experimental mode it will become ABI-stable and this notice
+ * will be removed.
+ * =========================================================================== */
+
+#ifndef JSI_ABI_HELPERS_H
+#define JSI_ABI_HELPERS_H
+
+#include "jsi_abi.h"
+
+#include <cassert>
+
+namespace jsi::abi {
+
+/* --- jsi_error_code helpers (for void-returning operations) --- */
+
+inline bool is_error(jsi_error_code err) {
+  return err != jsi_no_error;
+}
+inline jsi_error_code get_error(jsi_error_code err) {
+  assert(is_error(err));
+  return err;
+}
+/* Identity for jsi_error_code. Same signature shape as the create_*_or_error
+ * helpers, so template code that wraps an error into a result type via a
+ * function-pointer hook can use it as a no-op wrap when the result type
+ * already IS jsi_error_code. */
+inline jsi_error_code identity_error(jsi_error_code err) {
+  return err;
+}
+
+/*==========================================================================
+ * OrError helpers (bit-packing)
+ *
+ * Error encoding for pointer types:
+ *   low bit = 1 means error, error code = bits >> 2
+ *   low bit = 0 means success, pointer value in remaining bits
+ *
+ * Each pointer type gets explicit helper functions (no X-macros).
+ *==========================================================================*/
+
+/* --- Object --- */
+
+inline jsi_object create_object(jsi_pointer *ptr) {
+  return {ptr};
+}
+inline jsi_object_or_error create_object_or_error(jsi_pointer *ptr) {
+  return {reinterpret_cast<uintptr_t>(ptr)};
+}
+inline jsi_object_or_error create_object_or_error(jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_object_or_error &p) {
+  return p.ptr_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_object_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.ptr_or_error);
+}
+inline jsi_object get_object(jsi_object_or_error p) {
+  assert(!is_error(p));
+  return create_object(reinterpret_cast<jsi_pointer *>(p.ptr_or_error));
+}
+
+/* --- Array --- */
+
+inline jsi_array create_array(jsi_pointer *ptr) {
+  return {ptr};
+}
+inline jsi_array_or_error create_array_or_error(jsi_pointer *ptr) {
+  return {reinterpret_cast<uintptr_t>(ptr)};
+}
+inline jsi_array_or_error create_array_or_error(jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_array_or_error &p) {
+  return p.ptr_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_array_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.ptr_or_error);
+}
+inline jsi_array get_array(jsi_array_or_error p) {
+  assert(!is_error(p));
+  return create_array(reinterpret_cast<jsi_pointer *>(p.ptr_or_error));
+}
+
+/* --- String --- */
+
+inline jsi_string create_string(jsi_pointer *ptr) {
+  return {ptr};
+}
+inline jsi_string_or_error create_string_or_error(jsi_pointer *ptr) {
+  return {reinterpret_cast<uintptr_t>(ptr)};
+}
+inline jsi_string_or_error create_string_or_error(jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_string_or_error &p) {
+  return p.ptr_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_string_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.ptr_or_error);
+}
+inline jsi_string get_string(jsi_string_or_error p) {
+  assert(!is_error(p));
+  return create_string(reinterpret_cast<jsi_pointer *>(p.ptr_or_error));
+}
+
+/* --- BigInt --- */
+
+inline jsi_bigint create_bigint(jsi_pointer *ptr) {
+  return {ptr};
+}
+inline jsi_bigint_or_error create_bigint_or_error(jsi_pointer *ptr) {
+  return {reinterpret_cast<uintptr_t>(ptr)};
+}
+inline jsi_bigint_or_error create_bigint_or_error(jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_bigint_or_error &p) {
+  return p.ptr_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_bigint_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.ptr_or_error);
+}
+inline jsi_bigint get_bigint(jsi_bigint_or_error p) {
+  assert(!is_error(p));
+  return create_bigint(reinterpret_cast<jsi_pointer *>(p.ptr_or_error));
+}
+
+/* --- Symbol --- */
+
+inline jsi_symbol create_symbol(jsi_pointer *ptr) {
+  return {ptr};
+}
+inline jsi_symbol_or_error create_symbol_or_error(jsi_pointer *ptr) {
+  return {reinterpret_cast<uintptr_t>(ptr)};
+}
+inline jsi_symbol_or_error create_symbol_or_error(jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_symbol_or_error &p) {
+  return p.ptr_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_symbol_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.ptr_or_error);
+}
+inline jsi_symbol get_symbol(jsi_symbol_or_error p) {
+  assert(!is_error(p));
+  return create_symbol(reinterpret_cast<jsi_pointer *>(p.ptr_or_error));
+}
+
+/* --- Function --- */
+
+inline jsi_function create_function(jsi_pointer *ptr) {
+  return {ptr};
+}
+inline jsi_function_or_error create_function_or_error(jsi_pointer *ptr) {
+  return {reinterpret_cast<uintptr_t>(ptr)};
+}
+inline jsi_function_or_error create_function_or_error(jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_function_or_error &p) {
+  return p.ptr_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_function_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.ptr_or_error);
+}
+inline jsi_function get_function(jsi_function_or_error p) {
+  assert(!is_error(p));
+  return create_function(reinterpret_cast<jsi_pointer *>(p.ptr_or_error));
+}
+
+/* --- ArrayBuffer --- */
+
+inline jsi_arraybuffer create_arraybuffer(jsi_pointer *ptr) {
+  return {ptr};
+}
+inline jsi_arraybuffer_or_error create_arraybuffer_or_error(jsi_pointer *ptr) {
+  return {reinterpret_cast<uintptr_t>(ptr)};
+}
+inline jsi_arraybuffer_or_error create_arraybuffer_or_error(
+    jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_arraybuffer_or_error &p) {
+  return p.ptr_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_arraybuffer_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.ptr_or_error);
+}
+inline jsi_arraybuffer get_arraybuffer(jsi_arraybuffer_or_error p) {
+  assert(!is_error(p));
+  return create_arraybuffer(reinterpret_cast<jsi_pointer *>(p.ptr_or_error));
+}
+
+/* --- PropNameID --- */
+
+inline jsi_propnameid create_propnameid(jsi_pointer *ptr) {
+  return {ptr};
+}
+inline jsi_propnameid_or_error create_propnameid_or_error(jsi_pointer *ptr) {
+  return {reinterpret_cast<uintptr_t>(ptr)};
+}
+inline jsi_propnameid_or_error create_propnameid_or_error(jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_propnameid_or_error &p) {
+  return p.ptr_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_propnameid_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.ptr_or_error);
+}
+inline jsi_propnameid get_propnameid(jsi_propnameid_or_error p) {
+  assert(!is_error(p));
+  return create_propnameid(reinterpret_cast<jsi_pointer *>(p.ptr_or_error));
+}
+
+/* --- WeakObject --- */
+
+inline jsi_weak_object create_weak_object(jsi_pointer *ptr) {
+  return {ptr};
+}
+inline jsi_weak_object_or_error create_weak_object_or_error(jsi_pointer *ptr) {
+  return {reinterpret_cast<uintptr_t>(ptr)};
+}
+inline jsi_weak_object_or_error create_weak_object_or_error(
+    jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_weak_object_or_error &p) {
+  return p.ptr_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_weak_object_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.ptr_or_error);
+}
+inline jsi_weak_object get_weak_object(jsi_weak_object_or_error p) {
+  assert(!is_error(p));
+  return create_weak_object(reinterpret_cast<jsi_pointer *>(p.ptr_or_error));
+}
+
+/* --- PreparedJavaScript ---
+ * Pointer-based handle: get_prepared_javascript returns the raw pointer
+ * (not a wrapper struct) because jsi_prepared_javascript is itself the
+ * handle type. */
+
+inline jsi_prepared_javascript_or_error create_prepared_javascript_or_error(
+    jsi_prepared_javascript *ptr) {
+  return {reinterpret_cast<uintptr_t>(ptr)};
+}
+inline jsi_prepared_javascript_or_error create_prepared_javascript_or_error(
+    jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_prepared_javascript_or_error &p) {
+  return p.ptr_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_prepared_javascript_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.ptr_or_error);
+}
+inline jsi_prepared_javascript *get_prepared_javascript(
+    jsi_prepared_javascript_or_error p) {
+  assert(!is_error(p));
+  return reinterpret_cast<jsi_prepared_javascript *>(p.ptr_or_error);
+}
+
+/*==========================================================================
+ * BoolOrError / SizeTOrError / Uint8PtrOrError helpers
+ *==========================================================================*/
+
+/* --- BoolOrError --- */
+
+inline jsi_bool_or_error create_bool_or_error(bool val) {
+  return {val ? 2u : 0u};
+}
+inline jsi_bool_or_error create_bool_or_error(jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_bool_or_error &p) {
+  return p.bool_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_bool_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.bool_or_error);
+}
+inline bool get_bool(const jsi_bool_or_error &p) {
+  assert(!is_error(p));
+  return p.bool_or_error != 0;
+}
+
+/* --- SizeTOrError --- */
+
+inline jsi_size_or_error create_size_or_error(size_t val) {
+  jsi_size_or_error r;
+  r.is_error = false;
+  r.data.val = val;
+  return r;
+}
+inline jsi_size_or_error create_size_or_error(jsi_error_code err) {
+  jsi_size_or_error r;
+  r.is_error = true;
+  r.data.error = err;
+  return r;
+}
+inline bool is_error(const jsi_size_or_error &r) {
+  return r.is_error;
+}
+inline jsi_error_code get_error(const jsi_size_or_error &r) {
+  assert(is_error(r));
+  return r.data.error;
+}
+inline size_t get_size(const jsi_size_or_error &r) {
+  assert(!is_error(r));
+  return r.data.val;
+}
+
+/* --- Uint8PtrOrError --- */
+
+inline jsi_uint8_ptr_or_error create_uint8_ptr_or_error(uint8_t *val) {
+  jsi_uint8_ptr_or_error r;
+  r.is_error = false;
+  r.data.val = val;
+  return r;
+}
+inline jsi_uint8_ptr_or_error create_uint8_ptr_or_error(jsi_error_code err) {
+  jsi_uint8_ptr_or_error r;
+  r.is_error = true;
+  r.data.error = err;
+  return r;
+}
+inline bool is_error(const jsi_uint8_ptr_or_error &r) {
+  return r.is_error;
+}
+inline jsi_error_code get_error(const jsi_uint8_ptr_or_error &r) {
+  assert(is_error(r));
+  return r.data.error;
+}
+inline uint8_t *get_uint8_ptr(const jsi_uint8_ptr_or_error &r) {
+  assert(!is_error(r));
+  return r.data.val;
+}
+
+/* --- PropNameIDListPtrOrError --- */
+
+inline jsi_propnameid_list_or_error create_propnameid_list_or_error(
+    jsi_propnameid_list *ptr) {
+  return {reinterpret_cast<uintptr_t>(ptr)};
+}
+inline jsi_propnameid_list_or_error create_propnameid_list_or_error(
+    jsi_error_code err) {
+  return {static_cast<uintptr_t>(err)};
+}
+inline bool is_error(const jsi_propnameid_list_or_error &p) {
+  return p.ptr_or_error & 1;
+}
+inline jsi_error_code get_error(const jsi_propnameid_list_or_error &p) {
+  assert(is_error(p));
+  return static_cast<jsi_error_code>(p.ptr_or_error);
+}
+inline jsi_propnameid_list *get_propnameid_list(
+    jsi_propnameid_list_or_error p) {
+  assert(!is_error(p));
+  return reinterpret_cast<jsi_propnameid_list *>(p.ptr_or_error);
+}
+
+/*==========================================================================
+ * Value helpers
+ *==========================================================================*/
+
+/* --- Value constructors --- */
+
+inline jsi_value create_undefined_value() {
+  jsi_value v;
+  v.kind = jsi_valuekind_undefined;
+  return v;
+}
+inline jsi_value create_null_value() {
+  jsi_value v;
+  v.kind = jsi_valuekind_null;
+  return v;
+}
+inline jsi_value create_bool_value(bool b) {
+  jsi_value v;
+  v.kind = jsi_valuekind_boolean;
+  v.data.boolean = b;
+  return v;
+}
+inline jsi_value create_number_value(double d) {
+  jsi_value v;
+  v.kind = jsi_valuekind_number;
+  v.data.number = d;
+  return v;
+}
+inline jsi_value create_object_value(jsi_pointer *ptr) {
+  jsi_value v;
+  v.kind = jsi_valuekind_object;
+  v.data.pointer = ptr;
+  return v;
+}
+inline jsi_value create_object_value(const jsi_object &obj) {
+  return create_object_value(obj.pointer);
+}
+inline jsi_value create_string_value(jsi_pointer *ptr) {
+  jsi_value v;
+  v.kind = jsi_valuekind_string;
+  v.data.pointer = ptr;
+  return v;
+}
+inline jsi_value create_string_value(const jsi_string &str) {
+  return create_string_value(str.pointer);
+}
+inline jsi_value create_symbol_value(jsi_pointer *ptr) {
+  jsi_value v;
+  v.kind = jsi_valuekind_symbol;
+  v.data.pointer = ptr;
+  return v;
+}
+inline jsi_value create_symbol_value(const jsi_symbol &sym) {
+  return create_symbol_value(sym.pointer);
+}
+inline jsi_value create_bigint_value(jsi_pointer *ptr) {
+  jsi_value v;
+  v.kind = jsi_valuekind_bigint;
+  v.data.pointer = ptr;
+  return v;
+}
+inline jsi_value create_bigint_value(const jsi_bigint &bigint) {
+  return create_bigint_value(bigint.pointer);
+}
+
+/* --- Value type checks --- */
+
+inline jsi_valuekind get_value_kind(const jsi_value &v) {
+  return v.kind;
+}
+inline bool is_pointer_value(const jsi_value &v) {
+  return v.kind & JSI_POINTER_MASK;
+}
+inline bool is_undefined_value(const jsi_value &v) {
+  return v.kind == jsi_valuekind_undefined;
+}
+inline bool is_null_value(const jsi_value &v) {
+  return v.kind == jsi_valuekind_null;
+}
+inline bool is_bool_value(const jsi_value &v) {
+  return v.kind == jsi_valuekind_boolean;
+}
+inline bool is_number_value(const jsi_value &v) {
+  return v.kind == jsi_valuekind_number;
+}
+inline bool is_object_value(const jsi_value &v) {
+  return v.kind == jsi_valuekind_object;
+}
+inline bool is_string_value(const jsi_value &v) {
+  return v.kind == jsi_valuekind_string;
+}
+inline bool is_symbol_value(const jsi_value &v) {
+  return v.kind == jsi_valuekind_symbol;
+}
+inline bool is_bigint_value(const jsi_value &v) {
+  return v.kind == jsi_valuekind_bigint;
+}
+
+/* --- Value extraction --- */
+
+inline bool get_bool_value(const jsi_value &v) {
+  assert(is_bool_value(v));
+  return v.data.boolean;
+}
+inline double get_number_value(const jsi_value &v) {
+  assert(is_number_value(v));
+  return v.data.number;
+}
+inline jsi_object get_object_value(const jsi_value &v) {
+  assert(is_object_value(v));
+  return {v.data.pointer};
+}
+inline jsi_string get_string_value(const jsi_value &v) {
+  assert(is_string_value(v));
+  return {v.data.pointer};
+}
+inline jsi_symbol get_symbol_value(const jsi_value &v) {
+  assert(is_symbol_value(v));
+  return {v.data.pointer};
+}
+inline jsi_bigint get_bigint_value(const jsi_value &v) {
+  assert(is_bigint_value(v));
+  return {v.data.pointer};
+}
+inline jsi_pointer *get_pointer_value(const jsi_value &v) {
+  assert(is_pointer_value(v));
+  return v.data.pointer;
+}
+
+/* --- Cleanup --- */
+
+inline void release_pointer(jsi_pointer *mp) {
+  mp->vtable->invalidate(mp);
+}
+inline void release_value(const jsi_value &v) {
+  if (is_pointer_value(v))
+    v.data.pointer->vtable->invalidate(v.data.pointer);
+}
+
+/*==========================================================================
+ * ValueOrError helpers
+ *==========================================================================*/
+
+inline jsi_value_or_error create_value_or_error(jsi_value val) {
+  return {val};
+}
+inline jsi_value_or_error create_value_or_error(jsi_error_code err) {
+  jsi_value_or_error r;
+  r.value.kind = jsi_valuekind_error;
+  r.value.data.error = err;
+  return r;
+}
+inline bool is_error(const jsi_value_or_error &v) {
+  return v.value.kind == jsi_valuekind_error;
+}
+inline jsi_error_code get_error(const jsi_value_or_error &v) {
+  assert(is_error(v));
+  return v.value.data.error;
+}
+inline jsi_value get_value(const jsi_value_or_error &v) {
+  assert(!is_error(v));
+  return v.value;
+}
+
+} // namespace jsi::abi
+
+#endif /* JSI_ABI_HELPERS_H */

--- a/src/jsi_abi/jsi_abi_v8.cpp
+++ b/src/jsi_abi/jsi_abi_v8.cpp
@@ -1,0 +1,2994 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Portions derived from facebook/hermes (Hermes ABI):
+ *   Copyright (c) Meta Platforms, Inc. and affiliates.
+ *   Licensed under the MIT license.
+ */
+
+/// \file jsi_abi_v8.cpp
+/// \brief Implementation of the JSI ABI v2 interface for V8.
+///
+/// This file implements the jsi_abi.h v2 interface using V8 directly via
+/// v8_core.h. It follows the Hermes ABI patterns: jsi_runtime inheritance,
+/// jsi_pointer-based handles, *_or_error return types, and separate JS/native
+/// error storage.
+///
+/// Error Handling Design
+/// =====================
+/// Two error types following the Hermes ABI pattern:
+/// - jsi_error_js: JavaScript exception (value stored in pendingJSError)
+/// - jsi_error_native: Native exception (message in nativeExceptionMessage)
+///
+/// The TryCatch class inherits from v8::TryCatch and automatically captures
+/// JavaScript exceptions in its destructor.
+///
+/// This file is designed to work without C++ exceptions.
+
+#include "jsi_abi/jsi_abi.h"
+#include "jsi_abi/jsi_abi_helpers.h"
+#include "jsi_abi/v8_jsi_config.h"
+#include "jsi_abi/jsi_abi_v8_internal.h"
+#include "../v8_core.h"
+#include "../MurmurHash.h"
+#include "v8-profiler.h"
+
+#if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
+#include "../inspector/inspector_agent.h"
+#endif
+
+#include <atomic>
+#include <string>
+#include <vector>
+#include <memory>
+#include <cstring>
+#include <cstdio>
+#include <list>
+#include <optional>
+#include <sstream>
+#include <ostream>
+#include <fstream>
+
+namespace abi = jsi::abi;
+
+//==============================================================================
+// V8 jsi_config (opaque type definition)
+//==============================================================================
+//
+// jsi_config is forward-declared in jsi_abi.h as `typedef struct jsi_config_s*
+// jsi_config`. The struct definition lives here in the V8 implementation —
+// only setter functions cross the DLL boundary.
+//
+// Mirrors v8runtime::V8RuntimeArgs field-for-field so a future W2
+// applyArgs() helper can simply call the setters one-to-one.
+struct jsi_config_s {
+  // Heap / threading
+  size_t initial_heap_size_in_bytes{0};
+  size_t maximum_heap_size_in_bytes{0};
+  uint8_t thread_pool_size{0};
+
+  // Inspector / debugger (W5 — wired into JsiRuntimeState::create).
+  std::string debugger_runtime_name;
+  uint16_t inspector_port{9223};
+  bool enable_inspector{false};
+  bool inspector_break_on_start{false};
+
+  // Microtasks / promises
+  bool explicit_microtask_policy{false};
+  bool ignore_unhandled_promises{false};
+
+  // GC
+  bool enable_gc_api{false};
+
+  // Concurrency (stored for future W6; currently inert)
+  bool enable_multi_thread{false};
+
+  // Tracing (stored for future W6; currently inert except for system instr)
+  bool enable_jit_tracing{false};
+  bool enable_message_tracing{false};
+  bool enable_gc_tracing{false};
+  bool enable_system_instrumentation{false};
+
+  // Note: process-global V8 engine flags (sparkplug, predictable,
+  // optimize_for_size, always_compact, jitless, lite_mode) are NOT per-runtime
+  // config — they are set via the process-level v8_jsi_set_v8_flags before the
+  // first runtime. See v8_jsi_config.h.
+
+  // Script cache (W3) — null callbacks mean "no cache".
+  // The config takes ownership of script_cache_data when the setter is called.
+  // On v8_create_runtime the runtime takes over (we clear these pointers so
+  // ~jsi_config_s does not double-delete). If the config is destroyed before
+  // any runtime claims the data, ~jsi_config_s runs the deleter once.
+  void *script_cache_data{nullptr};
+  v8_jsi_script_cache_load_cb script_cache_load_cb{nullptr};
+  v8_jsi_script_cache_store_cb script_cache_store_cb{nullptr};
+  jsi_data_delete_cb script_cache_data_delete_cb{nullptr};
+  void *script_cache_deleter_data{nullptr};
+
+  // Task runner (W4) — null callbacks mean "no task runner".
+  // Same lifetime contract as the script-cache fields above: config takes
+  // ownership at setter time; on v8_create_runtime the runtime takes over
+  // (these pointers are cleared); the deleter runs exactly once via the
+  // internal adapter's destructor (held inside IsolateData by shared_ptr).
+  // If the config is destroyed before any runtime claims the data,
+  // ~jsi_config_s runs the deleter once.
+  void *task_runner_data{nullptr};
+  v8_jsi_task_runner_post_task_cb task_runner_post_task_cb{nullptr};
+  jsi_data_delete_cb task_runner_data_delete_cb{nullptr};
+  void *task_runner_deleter_data{nullptr};
+
+  ~jsi_config_s() {
+    if (script_cache_data_delete_cb) {
+      script_cache_data_delete_cb(script_cache_data, script_cache_deleter_data);
+    }
+    if (task_runner_data_delete_cb) {
+      task_runner_data_delete_cb(task_runner_data, task_runner_deleter_data);
+    }
+  }
+};
+
+namespace {
+
+//==============================================================================
+// Forward Declarations
+//==============================================================================
+
+struct JsiRuntimeState;
+struct AbiHostObjectProxy;
+struct HostFunctionContext;
+
+//==============================================================================
+// W4: TaskRunner adapter (C-callbacks → v8rt::TaskRunner)
+//==============================================================================
+//
+// Internal-only adapter held inside v8rt::IsolateData via shared_ptr. The
+// engine-internal v8rt::TaskRunner interface is what V8's inspector and other
+// platform plumbing speak; this adapter forwards postTask() calls into the
+// consumer-supplied C callback pair.
+//
+// The adapter owns task_runner_data and runs task_runner_data_delete_cb
+// exactly once in its destructor — that's the single point where the
+// consumer's runner is released.
+class CTaskRunner final : public v8rt::TaskRunner {
+ public:
+  CTaskRunner(void *task_runner_data,
+              v8_jsi_task_runner_post_task_cb post_task_cb,
+              jsi_data_delete_cb task_runner_data_delete_cb,
+              void *deleter_data) noexcept
+      : task_runner_data_(task_runner_data),
+        post_task_cb_(post_task_cb),
+        task_runner_data_delete_cb_(task_runner_data_delete_cb),
+        deleter_data_(deleter_data) {}
+
+  ~CTaskRunner() override {
+    if (task_runner_data_delete_cb_) {
+      task_runner_data_delete_cb_(task_runner_data_, deleter_data_);
+    }
+  }
+
+  CTaskRunner(const CTaskRunner &) = delete;
+  CTaskRunner &operator=(const CTaskRunner &) = delete;
+
+  void postTask(std::unique_ptr<Task> task) override {
+    post_task_cb_(
+        task_runner_data_,
+        static_cast<void *>(task.release()),
+        [](void *task_data) {
+          static_cast<Task *>(task_data)->run();
+        },
+        [](void *task_data, void * /*deleter_data*/) {
+          delete static_cast<Task *>(task_data);
+        },
+        /*deleter_data:*/ nullptr);
+  }
+
+ private:
+  void *task_runner_data_;
+  v8_jsi_task_runner_post_task_cb post_task_cb_;
+  jsi_data_delete_cb task_runner_data_delete_cb_;
+  void *deleter_data_;
+};
+
+//==============================================================================
+// Handle Wrapper Types (inherit from jsi_pointer)
+//==============================================================================
+
+/// Base wrapper for ABI handles that wrap V8 persistent handles.
+/// Inherits from jsi_pointer so the wrapper IS a jsi_pointer with an
+/// invalidate callback in its vtable.
+template <typename V8Type>
+struct HandleWrapper : public jsi_pointer {
+  static void JSI_CDECL invalidate(jsi_pointer *self) {
+    delete static_cast<HandleWrapper *>(self);
+  }
+  static constexpr jsi_pointer_vtable pointerVt{invalidate};
+
+  v8::Persistent<V8Type> persistent;
+
+  HandleWrapper(v8::Isolate *iso, v8::Local<V8Type> local)
+      : jsi_pointer{&pointerVt} {
+    persistent.Reset(iso, local);
+  }
+
+  ~HandleWrapper() { persistent.Reset(); }
+
+  v8::Local<V8Type> get(v8::Isolate *isolate) const {
+    return persistent.Get(isolate);
+  }
+};
+
+using ObjectHandle = HandleWrapper<v8::Object>;
+using StringHandle = HandleWrapper<v8::String>;
+using SymbolHandle = HandleWrapper<v8::Symbol>;
+using BigIntHandle = HandleWrapper<v8::BigInt>;
+
+/// PreparedJavaScript implementation. Inherits from jsi_prepared_javascript
+/// (not jsi_pointer) — prepared scripts have their own lifecycle and
+/// vtable in the ABI.
+struct PreparedScriptImpl : public jsi_prepared_javascript {
+  static void JSI_CDECL release(jsi_prepared_javascript *self) {
+    delete static_cast<PreparedScriptImpl *>(self);
+  }
+  static constexpr jsi_prepared_javascript_vtable preparedVt{release};
+
+  v8::Persistent<v8::UnboundScript> persistent;
+
+  PreparedScriptImpl(v8::Isolate *iso, v8::Local<v8::UnboundScript> local)
+      : jsi_prepared_javascript{&preparedVt} {
+    persistent.Reset(iso, local);
+  }
+
+  ~PreparedScriptImpl() { persistent.Reset(); }
+
+  v8::Local<v8::UnboundScript> get(v8::Isolate *isolate) const {
+    return persistent.Get(isolate);
+  }
+};
+
+/// Wrapper for property name IDs (can be string or symbol).
+struct PropNameIdHandle : public jsi_pointer {
+  static void JSI_CDECL invalidate(jsi_pointer *self) {
+    delete static_cast<PropNameIdHandle *>(self);
+  }
+  static constexpr jsi_pointer_vtable pointerVt{invalidate};
+
+  v8::Persistent<v8::Value> persistent; // String or Symbol
+
+  PropNameIdHandle(v8::Isolate *iso, v8::Local<v8::Value> local)
+      : jsi_pointer{&pointerVt} {
+    persistent.Reset(iso, local);
+  }
+
+  ~PropNameIdHandle() { persistent.Reset(); }
+
+  v8::Local<v8::Value> get(v8::Isolate *isolate) const {
+    return persistent.Get(isolate);
+  }
+};
+
+/// Wrapper for weak object references.
+struct WeakObjectHandle : public jsi_pointer {
+  static void JSI_CDECL invalidate(jsi_pointer *self) {
+    delete static_cast<WeakObjectHandle *>(self);
+  }
+  static constexpr jsi_pointer_vtable pointerVt{invalidate};
+
+  v8::Persistent<v8::Object> persistent;
+
+  WeakObjectHandle(v8::Isolate *iso, v8::Local<v8::Object> local)
+      : jsi_pointer{&pointerVt} {
+    persistent.Reset(iso, local);
+    persistent.SetWeak();
+  }
+
+  ~WeakObjectHandle() { persistent.Reset(); }
+
+  v8::Local<v8::Object> get(v8::Isolate *isolate) const {
+    return persistent.Get(isolate);
+  }
+};
+
+//==============================================================================
+// Cast Helpers
+//==============================================================================
+
+inline ObjectHandle *toObjectHandle(jsi_object obj) {
+  return static_cast<ObjectHandle *>(obj.pointer);
+}
+inline StringHandle *toStringHandle(jsi_string str) {
+  return static_cast<StringHandle *>(str.pointer);
+}
+inline SymbolHandle *toSymbolHandle(jsi_symbol sym) {
+  return static_cast<SymbolHandle *>(sym.pointer);
+}
+inline BigIntHandle *toBigIntHandle(jsi_bigint bi) {
+  return static_cast<BigIntHandle *>(bi.pointer);
+}
+inline PropNameIdHandle *toPropNameIdHandle(jsi_propnameid name) {
+  return static_cast<PropNameIdHandle *>(name.pointer);
+}
+inline WeakObjectHandle *toWeakObjectHandle(jsi_weak_object weak) {
+  return static_cast<WeakObjectHandle *>(weak.pointer);
+}
+
+//==============================================================================
+// Growable Buffer Helper
+//==============================================================================
+
+/// Write data into a growable buffer.
+void writeToBuf(jsi_growable_buffer *buf, const char *data, size_t len) {
+  if (buf->size < len)
+    buf->vtable->try_grow_to(buf, len);
+  if (buf->size >= len) {
+    std::memcpy(buf->data, data, len);
+    buf->used = len;
+  }
+}
+
+void writeToBuf(jsi_growable_buffer *buf, const std::string &str) {
+  writeToBuf(buf, str.data(), str.size());
+}
+
+//==============================================================================
+// V8 Value <-> jsi_value Conversion
+//==============================================================================
+
+/// Convert a V8 local value to a jsi_value, allocating handles for pointer
+/// types.
+jsi_value createJsiValue(v8::Isolate *isolate, v8::Local<v8::Value> val) {
+  if (val->IsUndefined())
+    return abi::create_undefined_value();
+  if (val->IsNull())
+    return abi::create_null_value();
+  if (val->IsBoolean())
+    return abi::create_bool_value(val->BooleanValue(isolate));
+  if (val->IsNumber())
+    return abi::create_number_value(
+        val->NumberValue(isolate->GetCurrentContext()).FromJust());
+  if (val->IsString())
+    return abi::create_string_value(
+        new StringHandle(isolate, v8::Local<v8::String>::Cast(val)));
+  if (val->IsSymbol())
+    return abi::create_symbol_value(
+        new SymbolHandle(isolate, v8::Local<v8::Symbol>::Cast(val)));
+  if (val->IsBigInt())
+    return abi::create_bigint_value(
+        new BigIntHandle(isolate, v8::Local<v8::BigInt>::Cast(val)));
+  if (val->IsObject())
+    return abi::create_object_value(
+        new ObjectHandle(isolate, v8::Local<v8::Object>::Cast(val)));
+  return abi::create_undefined_value();
+}
+
+/// Convert a jsi_value to a V8 local value.
+v8::Local<v8::Value> toV8Value(v8::Isolate *isolate, const jsi_value *val) {
+  switch (val->kind) {
+  case jsi_valuekind_undefined:
+    return v8::Undefined(isolate);
+  case jsi_valuekind_null:
+    return v8::Null(isolate);
+  case jsi_valuekind_boolean:
+    return v8::Boolean::New(isolate, val->data.boolean);
+  case jsi_valuekind_number:
+    return v8::Number::New(isolate, val->data.number);
+  case jsi_valuekind_string:
+    return static_cast<StringHandle *>(val->data.pointer)->get(isolate);
+  case jsi_valuekind_symbol:
+    return static_cast<SymbolHandle *>(val->data.pointer)->get(isolate);
+  case jsi_valuekind_bigint:
+    return static_cast<BigIntHandle *>(val->data.pointer)->get(isolate);
+  case jsi_valuekind_object:
+    return static_cast<ObjectHandle *>(val->data.pointer)->get(isolate);
+  default:
+    return v8::Undefined(isolate);
+  }
+}
+
+//==============================================================================
+// Internal Runtime State (extends jsi_runtime)
+//==============================================================================
+
+/// Wrapper for native state stored via ABI.
+struct NativeStateWrapper {
+  jsi_native_state *state;
+  v8::Global<v8::Object> weak_ref;
+
+  NativeStateWrapper(v8::Isolate *isolate, v8::Local<v8::Object> obj,
+                     jsi_native_state *s)
+      : state(s) {
+    weak_ref.Reset(isolate, obj);
+    weak_ref.SetWeak(this, weak_callback, v8::WeakCallbackType::kParameter);
+  }
+
+  ~NativeStateWrapper() {
+    if (state) {
+      state->vtable->release(state);
+    }
+    weak_ref.Reset();
+  }
+
+  static void
+  weak_callback(const v8::WeakCallbackInfo<NativeStateWrapper> &info) {
+    delete info.GetParameter();
+  }
+};
+
+/// Internal runtime state that manages V8 isolate and context directly.
+/// Inherits from jsi_runtime so the pointer IS a jsi_runtime*.
+struct JsiRuntimeState : public jsi_runtime {
+  // Reference count. Starts at 1 in create(); incremented by jsi_add_ref;
+  // decremented by jsi_release, which destroys the runtime at zero.
+  std::atomic<uint32_t> refcount{1};
+
+  // ABI version negotiated in v8_create_runtime (the consumer's compiled
+  // JSI_ABI_VERSION). Reserved for future behavioral pinning; get_abi_version
+  // reports the implementation's max, not this value.
+  uint32_t abi_version{JSI_ABI_VERSION};
+
+  v8::Isolate *isolate;
+  v8::Global<v8::Context> context;
+  v8rt::IsolateData *isolateData;
+
+  // True if the consumer requested v8::Locker-protected isolate access.
+  // Read by V8Scope to construct an optional Locker before entering scope.
+  bool enableMultiThread{false};
+
+  // Script cache (W3) — copied from the config in create(). Runtime owns
+  // script_cache_data after handoff: the deleter runs in ~JsiRuntimeState.
+  void *script_cache_data{nullptr};
+  v8_jsi_script_cache_load_cb script_cache_load_cb{nullptr};
+  v8_jsi_script_cache_store_cb script_cache_store_cb{nullptr};
+  jsi_data_delete_cb script_cache_data_delete_cb{nullptr};
+  void *script_cache_deleter_data{nullptr};
+
+  // Error state (v2 pattern)
+  jsi_value pendingJSError{}; // JS exception value (inline tagged union)
+  std::string nativeExceptionMessage;
+
+  // Host object infrastructure
+  v8::Persistent<v8::Function> hostObjectConstructor;
+  bool hostObjectConstructorInitialized{false};
+  std::list<AbiHostObjectProxy *> hostObjectProxies;
+
+  // Host function infrastructure
+  v8::Persistent<v8::Private> hostFunctionKey;
+  std::list<HostFunctionContext *> hostFunctionContexts;
+
+  // W8: unhandled-promise tracking. Migrated from the legacy V8Runtime so the
+  // Node-API path (jsr_has_unhandled_promise_rejection /
+  // jsr_get_and_clear_last_unhandled_promise_rejection) keeps working.
+  // The PromiseRejectCallback finds the runtime via context embedder slot 0.
+  bool ignore_unhandled_promises{false};
+  std::unique_ptr<v8rt::UnhandledPromiseRejection> last_unhandled_promise;
+
+  // W8: optional attached-owner hook. v8_attach_node_api stores the
+  // V8RuntimeEnv pointer and a destroy callback here so the Node-API surface
+  // is torn down before V8 state is disposed in ~JsiRuntimeState.
+  void *attached_owner{nullptr};
+  v8rt_internal::RuntimeAttachedDestroyCb attached_owner_destroy{nullptr};
+
+#if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
+  // W5: per-runtime inspector agent. nullptr when enable_inspector is false.
+  // Held by shared_ptr so multiple JsiRuntimeStates on the same isolate
+  // share one Agent (matches the legacy V8Runtime behavior; see slot 1).
+  std::shared_ptr<inspector::Agent> inspector_agent;
+#endif
+
+  /// Create a new runtime state with its own V8 isolate and context.
+  /// \param config Optional jsi_config (NULL preserves legacy defaults:
+  ///   --expose_gc, MicrotasksPolicy::kExplicit, enable_gc_api=true).
+  static JsiRuntimeState *create(const jsi_config_s *config);
+
+  ~JsiRuntimeState();
+
+  /// Look up the JsiRuntimeState owning a context. Reads context embedder
+  /// slot 0 (set in create()).
+  static JsiRuntimeState *fromContext(v8::Local<v8::Context> context) noexcept {
+    if (context.IsEmpty()) return nullptr;
+    if (context->GetNumberOfEmbedderDataFields() <=
+        v8rt::ContextEmbedderIndex::kContextTag) {
+      return nullptr;
+    }
+    void *tag = context->GetAlignedPointerFromEmbedderData(
+        v8rt::ContextEmbedderIndex::kContextTag);
+    if (tag != v8rt::RuntimeContextTagPtr) return nullptr;
+    return static_cast<JsiRuntimeState *>(
+        context->GetAlignedPointerFromEmbedderData(
+            v8rt::ContextEmbedderIndex::kRuntime));
+  }
+
+  /// V8 PromiseRejectCallback. Finds the runtime via the context embedder
+  /// slot and records the most recent unhandled rejection on it. Adapted
+  /// from V8 d8 / legacy V8Runtime.
+  static void PromiseRejectCallback(v8::PromiseRejectMessage data);
+
+  void SetUnhandledPromise(v8::Local<v8::Promise> promise,
+                            v8::Local<v8::Message> message,
+                            v8::Local<v8::Value> exception);
+  void RemoveUnhandledPromise(v8::Local<v8::Promise> promise);
+
+  v8::Local<v8::Private> getNativeStateKey() {
+    return isolateData->nativeStateKey();
+  }
+
+  v8::Local<v8::Private> getHostObjectKey() {
+    return isolateData->hostObjectKey();
+  }
+
+  v8::Local<v8::Private> getHostFunctionKey() {
+    return hostFunctionKey.Get(isolate);
+  }
+
+  v8::Local<v8::Context> getContextLocal() const {
+    return context.Get(isolate);
+  }
+
+  v8::Local<v8::Function> getHostObjectConstructor();
+
+  void setNativeError(const char *message) {
+    nativeExceptionMessage = message ? message : "";
+  }
+  void setNativeError(std::string message) {
+    nativeExceptionMessage = std::move(message);
+  }
+};
+
+inline JsiRuntimeState *getState(jsi_runtime *rt) {
+  return static_cast<JsiRuntimeState *>(rt);
+}
+
+//==============================================================================
+// TryCatch with Auto-Capture
+//==============================================================================
+
+class TryCatch : public v8::TryCatch {
+public:
+  explicit TryCatch(JsiRuntimeState *state)
+      : v8::TryCatch(state->isolate), state_(state) {}
+
+  ~TryCatch() {
+    if (HasCaught()) {
+      v8::Local<v8::Value> exception = Exception();
+      state_->pendingJSError = createJsiValue(state_->isolate, exception);
+    }
+  }
+
+  TryCatch(const TryCatch &) = delete;
+  TryCatch &operator=(const TryCatch &) = delete;
+
+private:
+  JsiRuntimeState *state_;
+};
+
+//==============================================================================
+// ABI Host Object Proxy
+//==============================================================================
+
+struct AbiHostObjectProxy {
+  jsi_runtime *runtime;
+  jsi_host_object *hostObject;
+  v8::Global<v8::Object> weakRef;
+  std::list<AbiHostObjectProxy *>::iterator listIter;
+  bool registered{false};
+
+  AbiHostObjectProxy(jsi_runtime *rt, jsi_host_object *ho,
+                     v8::Isolate *isolate, v8::Local<v8::Object> obj)
+      : runtime(rt), hostObject(ho) {
+    weakRef.Reset(isolate, obj);
+    weakRef.SetWeak(this, weak_callback, v8::WeakCallbackType::kParameter);
+
+    auto *state = getState(runtime);
+    state->hostObjectProxies.push_back(this);
+    listIter = std::prev(state->hostObjectProxies.end());
+    registered = true;
+  }
+
+  ~AbiHostObjectProxy() {
+    if (hostObject) {
+      hostObject->vtable->release(hostObject);
+    }
+    weakRef.Reset();
+  }
+
+  void unregister() {
+    if (registered) {
+      auto *state = getState(runtime);
+      state->hostObjectProxies.erase(listIter);
+      registered = false;
+    }
+  }
+
+  static void
+  weak_callback(const v8::WeakCallbackInfo<AbiHostObjectProxy> &info) {
+    AbiHostObjectProxy *proxy = info.GetParameter();
+    proxy->unregister();
+    delete proxy;
+  }
+
+  // V8 property interceptor callbacks
+
+  static v8::Intercepted
+  Get(v8::Local<v8::Name> v8PropName,
+      const v8::PropertyCallbackInfo<v8::Value> &info) {
+    AbiHostObjectProxy *proxy = GetProxy(info);
+    if (!proxy || !proxy->hostObject)
+      return v8::Intercepted::kNo;
+
+    v8::Isolate *isolate = info.GetIsolate();
+
+    jsi_propnameid propNameId{new PropNameIdHandle(isolate, v8PropName)};
+
+    jsi_value_or_error result = proxy->hostObject->vtable->get(
+        proxy->hostObject, proxy->runtime, propNameId);
+
+    propNameId.pointer->vtable->invalidate(propNameId.pointer);
+
+    if (abi::is_error(result)) {
+      auto *state = getState(proxy->runtime);
+      if (abi::get_error(result) == jsi_error_js) {
+        jsi_value jsErr = state->pendingJSError;
+        if (abi::is_pointer_value(jsErr)) {
+          isolate->ThrowException(toV8Value(isolate, &jsErr));
+        }
+        state->pendingJSError = abi::create_undefined_value();
+      } else {
+        v8::Local<v8::String> message =
+            v8::String::NewFromUtf8(isolate,
+                                    state->nativeExceptionMessage.c_str())
+                .ToLocalChecked();
+        isolate->ThrowException(v8::Exception::Error(message));
+        state->nativeExceptionMessage.clear();
+      }
+      return v8::Intercepted::kYes;
+    }
+
+    jsi_value val = abi::get_value(result);
+    info.GetReturnValue().Set(toV8Value(isolate, &val));
+    abi::release_value(val);
+    return v8::Intercepted::kYes;
+  }
+
+  static v8::Intercepted
+  Set(v8::Local<v8::Name> v8PropName, v8::Local<v8::Value> value,
+      const v8::PropertyCallbackInfo<void> &info) {
+    AbiHostObjectProxy *proxy = GetProxy(info);
+    if (!proxy || !proxy->hostObject)
+      return v8::Intercepted::kNo;
+
+    v8::Isolate *isolate = info.GetIsolate();
+
+    jsi_propnameid propNameId{new PropNameIdHandle(isolate, v8PropName)};
+    jsi_value jsiValue = createJsiValue(isolate, value);
+
+    jsi_error_code result = proxy->hostObject->vtable->set(
+        proxy->hostObject, proxy->runtime, propNameId, &jsiValue);
+
+    propNameId.pointer->vtable->invalidate(propNameId.pointer);
+    abi::release_value(jsiValue);
+
+    if (abi::is_error(result)) {
+      auto *state = getState(proxy->runtime);
+      if (abi::get_error(result) == jsi_error_js &&
+          abi::is_pointer_value(state->pendingJSError)) {
+        isolate->ThrowException(toV8Value(isolate, &state->pendingJSError));
+        state->pendingJSError = abi::create_undefined_value();
+      } else {
+        v8::Local<v8::String> message =
+            v8::String::NewFromUtf8(isolate,
+                                    state->nativeExceptionMessage.c_str())
+                .ToLocalChecked();
+        isolate->ThrowException(v8::Exception::Error(message));
+        state->nativeExceptionMessage.clear();
+      }
+    }
+
+    return v8::Intercepted::kYes;
+  }
+
+  static v8::Intercepted
+  GetIndexed(uint32_t index,
+             const v8::PropertyCallbackInfo<v8::Value> &info) {
+    v8::Isolate *isolate = info.GetIsolate();
+    v8::Local<v8::String> indexStr =
+        v8::String::NewFromUtf8(isolate, std::to_string(index).c_str())
+            .ToLocalChecked();
+    return Get(indexStr, info);
+  }
+
+  static v8::Intercepted
+  SetIndexed(uint32_t index, v8::Local<v8::Value> value,
+             const v8::PropertyCallbackInfo<void> &info) {
+    v8::Isolate *isolate = info.GetIsolate();
+    v8::Local<v8::String> indexStr =
+        v8::String::NewFromUtf8(isolate, std::to_string(index).c_str())
+            .ToLocalChecked();
+    return Set(indexStr, value, info);
+  }
+
+  static void Enumerator(const v8::PropertyCallbackInfo<v8::Array> &info) {
+    AbiHostObjectProxy *proxy =
+        GetProxyFromThis(info.This(), info.GetIsolate());
+    if (!proxy || !proxy->hostObject) {
+      info.GetReturnValue().Set(v8::Array::New(info.GetIsolate()));
+      return;
+    }
+
+    v8::Isolate *isolate = info.GetIsolate();
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+
+    jsi_propnameid_list_or_error listResult =
+        proxy->hostObject->vtable->get_own_keys(proxy->hostObject,
+                                                 proxy->runtime);
+
+    if (abi::is_error(listResult)) {
+      info.GetReturnValue().Set(v8::Array::New(isolate));
+      return;
+    }
+
+    jsi_propnameid_list *list = abi::get_propnameid_list(listResult);
+    v8::Local<v8::Array> result =
+        v8::Array::New(isolate, static_cast<int>(list->size));
+    for (size_t i = 0; i < list->size; i++) {
+      v8::Local<v8::Value> propValue =
+          toPropNameIdHandle(list->props[i])->get(isolate);
+      result->Set(context, static_cast<uint32_t>(i), propValue)
+          .FromMaybe(false);
+    }
+    list->vtable->release(list);
+
+    info.GetReturnValue().Set(result);
+  }
+
+private:
+  template <typename T>
+  static AbiHostObjectProxy *
+  GetProxy(const v8::PropertyCallbackInfo<T> &info) {
+    return GetProxyFromThis(info.This(), info.GetIsolate());
+  }
+
+  static AbiHostObjectProxy *GetProxyFromThis(v8::Local<v8::Object> obj,
+                                               v8::Isolate * /*isolate*/) {
+    while (obj->InternalFieldCount() != 1) {
+      v8::Local<v8::Value> proto = obj->GetPrototypeV2();
+      if (proto.IsEmpty() || !proto->IsObject())
+        return nullptr;
+      obj = v8::Local<v8::Object>::Cast(proto);
+    }
+
+    v8::Local<v8::Value> externalValue =
+        obj->GetInternalField(0).As<v8::Value>();
+    if (externalValue.IsEmpty() || !externalValue->IsExternal())
+      return nullptr;
+
+    v8::Local<v8::External> data = v8::Local<v8::External>::Cast(externalValue);
+    return reinterpret_cast<AbiHostObjectProxy *>(data->Value());
+  }
+};
+
+//==============================================================================
+// JsiRuntimeState Implementation
+//==============================================================================
+
+JsiRuntimeState *JsiRuntimeState::create(const jsi_config_s *config) {
+  // Legacy default behavior (config==nullptr): match what the ABI runtime
+  // shipped before W1 — --expose_gc, kExplicit microtasks, enable_gc_api=true.
+  // This preserves the existing test corpus (117/117) since JsiAbiRuntime's
+  // C++ constructor passes config=nullptr by default.
+  const bool useDefaults = (config == nullptr);
+
+  // Build the V8 platform-init flag string. V8 only consumes these flags on
+  // first platform init in the process; subsequent runtimes inherit them
+  // (V8 design constraint, not ours).
+  std::string flags;
+  auto appendFlag = [&flags](const char *flag) {
+    if (!flags.empty())
+      flags += ' ';
+    flags += flag;
+  };
+
+  if (useDefaults) {
+    appendFlag("--expose_gc");
+  } else {
+    if (config->enable_gc_api)
+      appendFlag("--expose_gc");
+    if (config->enable_system_instrumentation)
+      appendFlag("--enable-system-instrumentation");
+  }
+
+  const int thread_pool_size = useDefaults ? 0 : config->thread_pool_size;
+
+  // Capture flags by value into the lambda so the string survives to first
+  // init even if the caller frees the config immediately after.
+  v8rt::V8PlatformHolder::initializePlatform(thread_pool_size, [flags]() {
+    if (!flags.empty()) {
+      v8::V8::SetFlagsFromString(flags.c_str());
+    }
+  });
+
+  v8rt::IsolateConfig isolateConfig;
+  if (useDefaults) {
+    isolateConfig.microtasks_policy = v8::MicrotasksPolicy::kExplicit;
+    isolateConfig.enable_gc_api = true;
+  } else {
+    isolateConfig.initial_heap_size = config->initial_heap_size_in_bytes;
+    isolateConfig.maximum_heap_size = config->maximum_heap_size_in_bytes;
+    isolateConfig.microtasks_policy = config->explicit_microtask_policy
+        ? v8::MicrotasksPolicy::kExplicit
+        : v8::MicrotasksPolicy::kAuto;
+    isolateConfig.enable_gc_api = config->enable_gc_api;
+
+    // W4: take ownership of the task runner from the config. The shared_ptr
+    // is handed to IsolateData by createIsolate; once IsolateData is freed in
+    // ~JsiRuntimeState, the shared_ptr drops and the CTaskRunner destructor
+    // runs the consumer's deleter exactly once. We clear the config fields
+    // so ~jsi_config_s does not double-fire the deleter.
+    if (config->task_runner_post_task_cb) {
+      auto *mutableConfig = const_cast<jsi_config_s *>(config);
+      isolateConfig.task_runner = std::make_shared<CTaskRunner>(
+          mutableConfig->task_runner_data,
+          mutableConfig->task_runner_post_task_cb,
+          mutableConfig->task_runner_data_delete_cb,
+          mutableConfig->task_runner_deleter_data);
+      mutableConfig->task_runner_data = nullptr;
+      mutableConfig->task_runner_post_task_cb = nullptr;
+      mutableConfig->task_runner_data_delete_cb = nullptr;
+      mutableConfig->task_runner_deleter_data = nullptr;
+    }
+  }
+
+  v8::Isolate *isolate = v8rt::createIsolate(isolateConfig);
+  if (!isolate)
+    return nullptr;
+
+  v8::Isolate::Scope isolate_scope(isolate);
+  v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::Context> context = v8rt::createContext(isolate);
+
+  // Forward-declare the vtable (defined below)
+  extern const jsi_runtime_vtable g_vtable;
+
+  auto *state = new JsiRuntimeState();
+  state->vt = &g_vtable;
+  state->isolate = isolate;
+  state->context.Reset(isolate, context);
+  state->isolateData = v8rt::IsolateData::fromIsolate(isolate);
+  state->enableMultiThread = !useDefaults && config->enable_multi_thread;
+  state->ignore_unhandled_promises =
+      !useDefaults && config->ignore_unhandled_promises;
+
+  // W8: stamp the context with a back-pointer to this runtime + the v8jsi
+  // marker tag. The PromiseRejectCallback (and any future static V8 callback
+  // that only has a context handle) walks slot 0 to recover the runtime.
+  context->SetAlignedPointerInEmbedderData(
+      v8rt::ContextEmbedderIndex::kRuntime, state);
+  context->SetAlignedPointerInEmbedderData(
+      v8rt::ContextEmbedderIndex::kContextTag, v8rt::RuntimeContextTagPtr);
+
+  // W8: install the unhandled-promise-rejection tracker unless the consumer
+  // explicitly opted out. Mirrors legacy V8Runtime behavior — Node-API's
+  // jsr_has_unhandled_promise_rejection depends on this.
+  if (!state->ignore_unhandled_promises) {
+    isolate->SetPromiseRejectCallback(JsiRuntimeState::PromiseRejectCallback);
+  }
+
+  // W3: take ownership of the script cache from the config. After this
+  // handoff the config no longer owns script_cache_data, so freeing the
+  // config does not invoke the deleter — only ~JsiRuntimeState does.
+  if (!useDefaults) {
+    auto *mutableConfig = const_cast<jsi_config_s *>(config);
+    state->script_cache_data = mutableConfig->script_cache_data;
+    state->script_cache_load_cb = mutableConfig->script_cache_load_cb;
+    state->script_cache_store_cb = mutableConfig->script_cache_store_cb;
+    state->script_cache_data_delete_cb =
+        mutableConfig->script_cache_data_delete_cb;
+    state->script_cache_deleter_data = mutableConfig->script_cache_deleter_data;
+    mutableConfig->script_cache_data = nullptr;
+    mutableConfig->script_cache_load_cb = nullptr;
+    mutableConfig->script_cache_store_cb = nullptr;
+    mutableConfig->script_cache_data_delete_cb = nullptr;
+    mutableConfig->script_cache_deleter_data = nullptr;
+  }
+
+  state->pendingJSError = abi::create_undefined_value();
+  state->hostFunctionKey.Reset(
+      isolate,
+      v8::Private::New(
+          isolate,
+          v8::String::NewFromUtf8Literal(isolate, "v8:jsi:hostFunction")));
+
+#if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
+  if (!useDefaults && config->enable_inspector) {
+    void *existing = isolate->GetData(v8rt::kIsolateInspectorSlot);
+    std::shared_ptr<inspector::Agent> agent;
+    if (existing) {
+      agent = reinterpret_cast<inspector::Agent *>(existing)->getShared();
+    } else {
+      agent = std::make_shared<inspector::Agent>(isolate, config->inspector_port);
+      isolate->SetData(v8rt::kIsolateInspectorSlot, agent.get());
+    }
+    const char *name = config->debugger_runtime_name.empty()
+        ? "JSIRuntime context"
+        : config->debugger_runtime_name.c_str();
+    agent->addContext(context, name);
+    agent->start();
+    if (config->inspector_break_on_start) {
+      agent->waitForDebugger();
+    }
+    state->inspector_agent = std::move(agent);
+  }
+#endif
+
+  return state;
+}
+
+// ~JsiRuntimeState defined after HostFunctionContext and AbiHostObjectProxy
+
+v8::Local<v8::Function> JsiRuntimeState::getHostObjectConstructor() {
+  if (!hostObjectConstructorInitialized) {
+    v8::Local<v8::FunctionTemplate> constructorTemplate =
+        v8::FunctionTemplate::New(isolate);
+    v8::Local<v8::ObjectTemplate> instanceTemplate =
+        constructorTemplate->InstanceTemplate();
+
+    instanceTemplate->SetHandler(v8::NamedPropertyHandlerConfiguration(
+        AbiHostObjectProxy::Get, AbiHostObjectProxy::Set, nullptr, nullptr,
+        AbiHostObjectProxy::Enumerator));
+    instanceTemplate->SetHandler(v8::IndexedPropertyHandlerConfiguration(
+        AbiHostObjectProxy::GetIndexed, AbiHostObjectProxy::SetIndexed));
+
+    instanceTemplate->SetInternalFieldCount(1);
+
+    v8::Local<v8::Context> ctx = getContextLocal();
+    v8::Local<v8::Function> constructor =
+        constructorTemplate->GetFunction(ctx).ToLocalChecked();
+    hostObjectConstructor.Reset(isolate, constructor);
+    hostObjectConstructorInitialized = true;
+  }
+  return hostObjectConstructor.Get(isolate);
+}
+
+//==============================================================================
+// RAII Helper for V8 Scopes
+//==============================================================================
+
+struct V8Scope {
+  // Order matters: Locker must be acquired before any other scope when the
+  // isolate is shared across threads.
+  std::optional<v8::Locker> locker;
+  v8::Isolate::Scope isolate_scope;
+  v8::HandleScope handle_scope;
+  v8::Context::Scope context_scope;
+
+  V8Scope(JsiRuntimeState *state)
+      : locker(makeLocker(state)), isolate_scope(state->isolate),
+        handle_scope(state->isolate),
+        context_scope(state->getContextLocal()) {}
+
+ private:
+  static std::optional<v8::Locker> makeLocker(JsiRuntimeState *state) {
+    if (state->enableMultiThread)
+      return std::make_optional<v8::Locker>(state->isolate);
+    return std::nullopt;
+  }
+};
+
+//==============================================================================
+// Host Function Wrapper
+//==============================================================================
+
+struct HostFunctionContext {
+  jsi_runtime *runtime;
+  jsi_host_function *hostFunction;
+  v8::Global<v8::Function> weakRef;
+  std::list<HostFunctionContext *>::iterator listIter;
+  bool registered{false};
+
+  HostFunctionContext(jsi_runtime *rt, jsi_host_function *hf)
+      : runtime(rt), hostFunction(hf) {}
+
+  /// Set up weak ref tracking after the V8 function has been created.
+  void trackFunction(v8::Isolate *isolate, v8::Local<v8::Function> func) {
+    weakRef.Reset(isolate, func);
+    weakRef.SetWeak(this, weak_callback, v8::WeakCallbackType::kParameter);
+
+    auto *state = getState(runtime);
+    state->hostFunctionContexts.push_back(this);
+    listIter = std::prev(state->hostFunctionContexts.end());
+    registered = true;
+  }
+
+  ~HostFunctionContext() {
+    if (hostFunction) {
+      hostFunction->vtable->release(hostFunction);
+    }
+    weakRef.Reset();
+  }
+
+  void unregister() {
+    if (registered) {
+      auto *state = getState(runtime);
+      state->hostFunctionContexts.erase(listIter);
+      registered = false;
+    }
+  }
+
+  static void
+  weak_callback(const v8::WeakCallbackInfo<HostFunctionContext> &info) {
+    HostFunctionContext *ctx = info.GetParameter();
+    ctx->unregister();
+    delete ctx;
+  }
+};
+
+// Deferred definition — requires HostFunctionContext and AbiHostObjectProxy
+// to be complete types.
+JsiRuntimeState::~JsiRuntimeState() {
+  // W8: tear down the attached Node-API surface (if any) before disposing
+  // V8 state. The destroy callback owns deleting the attached object.
+  if (attached_owner_destroy) {
+    auto cb = attached_owner_destroy;
+    void *attached = attached_owner;
+    attached_owner_destroy = nullptr;
+    attached_owner = nullptr;
+    cb(attached);
+  }
+
+  // Drop the unhandled-promise record (if any) before the isolate goes away;
+  // its v8::Globals must release while the isolate is still live.
+  last_unhandled_promise.reset();
+
+  for (HostFunctionContext *ctx : hostFunctionContexts) {
+    ctx->registered = false;
+    delete ctx;
+  }
+  hostFunctionContexts.clear();
+
+  for (AbiHostObjectProxy *proxy : hostObjectProxies) {
+    proxy->registered = false;
+    delete proxy;
+  }
+  hostObjectProxies.clear();
+
+  abi::release_value(pendingJSError);
+
+#if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
+  // Tear down the inspector before the context is reset — the Agent's
+  // removeContext takes a v8::Local<v8::Context>.
+  if (inspector_agent) {
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+    inspector_agent->removeContext(getContextLocal());
+    inspector_agent.reset();
+  }
+#endif
+
+  hostObjectConstructor.Reset();
+  hostFunctionKey.Reset();
+  context.Reset();
+
+  if (isolate) {
+    delete isolateData;
+    isolate->Dispose();
+  }
+
+  // W3: release the consumer-supplied script cache after the isolate is gone
+  // (no more cache calls can be in flight). Runs in the consumer's CRT
+  // because the consumer also supplied the deleter callback.
+  if (script_cache_data_delete_cb) {
+    script_cache_data_delete_cb(script_cache_data, script_cache_deleter_data);
+  }
+}
+
+// Adapted from V8 d8 utility code (was V8Runtime::PromiseRejectCallback).
+void JsiRuntimeState::PromiseRejectCallback(v8::PromiseRejectMessage data) {
+  if (data.GetEvent() == v8::kPromiseRejectAfterResolved ||
+      data.GetEvent() == v8::kPromiseResolveAfterResolved) {
+    return;
+  }
+  v8::Local<v8::Promise> promise = data.GetPromise();
+  v8::Isolate *isolate = v8::Isolate::GetCurrent();
+  v8::MaybeLocal<v8::Context> maybeContext = promise->GetCreationContext(isolate);
+  if (maybeContext.IsEmpty()) return;
+  JsiRuntimeState *runtime = JsiRuntimeState::fromContext(
+      maybeContext.ToLocalChecked());
+  if (!runtime) return;
+
+  if (data.GetEvent() == v8::kPromiseHandlerAddedAfterReject) {
+    runtime->RemoveUnhandledPromise(promise);
+    return;
+  }
+
+  isolate->SetCaptureStackTraceForUncaughtExceptions(true);
+  v8::Local<v8::Value> exception = data.GetValue();
+  v8::Local<v8::Message> message;
+  if (exception->IsObject()) {
+    message = v8::Exception::CreateMessage(isolate, exception);
+  }
+  if (!exception->IsNativeError() &&
+      (message.IsEmpty() || message->GetStackTrace().IsEmpty())) {
+    v8::TryCatch try_catch(isolate);
+    try_catch.SetVerbose(true);
+    isolate->ThrowException(v8::Exception::Error(
+        v8::String::NewFromUtf8Literal(isolate, "Unhandled Promise.")));
+    message = try_catch.Message();
+    exception = try_catch.Exception();
+  }
+
+  runtime->SetUnhandledPromise(promise, message, exception);
+}
+
+void JsiRuntimeState::SetUnhandledPromise(v8::Local<v8::Promise> promise,
+                                           v8::Local<v8::Message> message,
+                                           v8::Local<v8::Value> exception) {
+  if (ignore_unhandled_promises) return;
+  last_unhandled_promise =
+      std::make_unique<v8rt::UnhandledPromiseRejection>(
+          v8rt::UnhandledPromiseRejection{
+              v8::Global<v8::Promise>(isolate, promise),
+              v8::Global<v8::Message>(isolate, message),
+              v8::Global<v8::Value>(isolate, exception)});
+}
+
+void JsiRuntimeState::RemoveUnhandledPromise(v8::Local<v8::Promise> promise) {
+  if (ignore_unhandled_promises) return;
+  if (last_unhandled_promise &&
+      last_unhandled_promise->promise.Get(isolate) == promise) {
+    last_unhandled_promise.reset();
+  }
+}
+
+void JSI_CDECL HostFunctionCallbackTrampoline(
+    const v8::FunctionCallbackInfo<v8::Value> &info) {
+  v8::Isolate *isolate = info.GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+
+  v8::Local<v8::External> data = v8::Local<v8::External>::Cast(info.Data());
+  auto *ctx = static_cast<HostFunctionContext *>(data->Value());
+
+  std::vector<jsi_value> args;
+  args.reserve(info.Length());
+  for (int i = 0; i < info.Length(); ++i)
+    args.push_back(createJsiValue(isolate, info[i]));
+
+  jsi_value thisVal = createJsiValue(isolate, info.This());
+
+  jsi_value_or_error result = ctx->hostFunction->vtable->call(
+      ctx->hostFunction, ctx->runtime, &thisVal, args.data(), args.size());
+
+  for (auto &arg : args)
+    abi::release_value(arg);
+  abi::release_value(thisVal);
+
+  if (abi::is_error(result)) {
+    auto *state = getState(ctx->runtime);
+    jsi_error_code err = abi::get_error(result);
+    if (err == jsi_error_js && abi::is_pointer_value(state->pendingJSError)) {
+      isolate->ThrowException(toV8Value(isolate, &state->pendingJSError));
+      abi::release_value(state->pendingJSError);
+      state->pendingJSError = abi::create_undefined_value();
+    } else {
+      std::string errMessage = "Exception in HostFunction: " +
+                                state->nativeExceptionMessage;
+      v8::Local<v8::String> message =
+          v8::String::NewFromUtf8(isolate, errMessage.c_str())
+              .ToLocalChecked();
+      isolate->ThrowException(v8::Exception::Error(message));
+      state->nativeExceptionMessage.clear();
+    }
+    return;
+  }
+
+  jsi_value val = abi::get_value(result);
+  info.GetReturnValue().Set(toV8Value(isolate, &val));
+  abi::release_value(val);
+}
+
+//==============================================================================
+// Helper to get NativeStateWrapper from an object
+//==============================================================================
+
+NativeStateWrapper *getNativeStateWrapper(JsiRuntimeState *state,
+                                          v8::Local<v8::Context> context,
+                                          v8::Local<v8::Object> obj) {
+  v8::Local<v8::Private> key = state->getNativeStateKey();
+  v8::MaybeLocal<v8::Value> maybeVal = obj->GetPrivate(context, key);
+  if (maybeVal.IsEmpty())
+    return nullptr;
+  v8::Local<v8::Value> val = maybeVal.ToLocalChecked();
+  if (!val->IsExternal())
+    return nullptr;
+  return static_cast<NativeStateWrapper *>(val.As<v8::External>()->Value());
+}
+
+//==============================================================================
+// VTable Function Implementations
+//==============================================================================
+
+//------------------------------------------------------------------------------
+// QueryInterface
+//------------------------------------------------------------------------------
+
+jsi_error_code JSI_CDECL jsi_query_interface(
+    jsi_runtime *rt, const jsi_interface_id * /*iid*/,
+    const void ** /*vtable_out*/, void ** /*instance_out*/) {
+  // No optional interfaces are currently supported. query_interface is
+  // retained as the COM-style extension seam for future engine-specific
+  // interfaces; callers must handle the not-supported result.
+  getState(rt)->setNativeError("Interface not supported");
+  return jsi_error_native;
+}
+
+//------------------------------------------------------------------------------
+// ABI version
+//------------------------------------------------------------------------------
+
+// Report the implementation's max supported ABI version (Node-API
+// napi_get_version analog). The create-time negotiation in v8_create_runtime is
+// what actually gates; this is a feature-probe.
+uint32_t JSI_CDECL jsi_get_abi_version(jsi_runtime * /*rt*/) {
+  return JSI_ABI_VERSION;
+}
+
+//------------------------------------------------------------------------------
+// Lifecycle
+//------------------------------------------------------------------------------
+
+void JSI_CDECL jsi_add_ref(jsi_runtime *rt) {
+  getState(rt)->refcount.fetch_add(1, std::memory_order_relaxed);
+}
+
+void JSI_CDECL jsi_release(jsi_runtime *rt) {
+  auto *state = getState(rt);
+  // acq_rel ensures the destructor sees all writes from threads that held
+  // a ref; relaxed isn't enough across thread boundaries.
+  if (state->refcount.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+    delete state;
+  }
+}
+
+//------------------------------------------------------------------------------
+// Error Handling
+//------------------------------------------------------------------------------
+
+jsi_value JSI_CDECL jsi_get_and_clear_js_error_value(jsi_runtime *rt) {
+  auto *state = getState(rt);
+  jsi_value result = state->pendingJSError;
+  state->pendingJSError = abi::create_undefined_value();
+  return result;
+}
+
+void JSI_CDECL jsi_get_and_clear_native_exception_message(
+    jsi_runtime *rt, jsi_growable_buffer *buf) {
+  auto *state = getState(rt);
+  writeToBuf(buf, state->nativeExceptionMessage);
+  state->nativeExceptionMessage.clear();
+  state->nativeExceptionMessage.shrink_to_fit();
+}
+
+void JSI_CDECL jsi_set_js_error_value(jsi_runtime *rt,
+                                       const jsi_value *error_value) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  abi::release_value(state->pendingJSError);
+  if (abi::is_pointer_value(*error_value)) {
+    v8::Local<v8::Value> v8val = toV8Value(state->isolate, error_value);
+    state->pendingJSError = createJsiValue(state->isolate, v8val);
+  } else {
+    state->pendingJSError = *error_value;
+  }
+}
+
+void JSI_CDECL jsi_set_native_exception_message(jsi_runtime *rt,
+                                                  const uint8_t *utf8,
+                                                  size_t length) {
+  getState(rt)->nativeExceptionMessage.assign(
+      reinterpret_cast<const char *>(utf8), length);
+}
+
+//------------------------------------------------------------------------------
+// Clone Operations
+//------------------------------------------------------------------------------
+
+jsi_propnameid JSI_CDECL jsi_clone_propnameid(jsi_runtime *rt,
+                                               jsi_propnameid name) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Value> v8val = toPropNameIdHandle(name)->get(state->isolate);
+  return {new PropNameIdHandle(state->isolate, v8val)};
+}
+
+jsi_string JSI_CDECL jsi_clone_string(jsi_runtime *rt, jsi_string str) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::String> v8str = toStringHandle(str)->get(state->isolate);
+  return {new StringHandle(state->isolate, v8str)};
+}
+
+jsi_symbol JSI_CDECL jsi_clone_symbol(jsi_runtime *rt, jsi_symbol sym) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Symbol> v8sym = toSymbolHandle(sym)->get(state->isolate);
+  return {new SymbolHandle(state->isolate, v8sym)};
+}
+
+jsi_object JSI_CDECL jsi_clone_object(jsi_runtime *rt, jsi_object obj) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  return {new ObjectHandle(state->isolate, v8obj)};
+}
+
+jsi_bigint JSI_CDECL jsi_clone_bigint(jsi_runtime *rt, jsi_bigint bigint) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::BigInt> v8bi = toBigIntHandle(bigint)->get(state->isolate);
+  return {new BigIntHandle(state->isolate, v8bi)};
+}
+
+//------------------------------------------------------------------------------
+// Description & Capabilities
+//------------------------------------------------------------------------------
+
+void JSI_CDECL jsi_get_description(jsi_runtime * /*rt*/,
+                                    jsi_growable_buffer *buf) {
+  const char *v8_version = v8::V8::GetVersion();
+  std::string desc = std::string("V8Runtime [") + v8_version + "]";
+  writeToBuf(buf, desc);
+}
+
+bool JSI_CDECL jsi_is_inspectable(jsi_runtime * /*rt*/) { return false; }
+
+//------------------------------------------------------------------------------
+// Handle Scopes
+//------------------------------------------------------------------------------
+
+jsi_error_code JSI_CDECL jsi_push_scope(jsi_runtime * /*rt*/,
+                                            void **scope) {
+  if (scope)
+    *scope = reinterpret_cast<void *>(1);
+  return jsi_no_error;
+}
+
+jsi_error_code JSI_CDECL jsi_pop_scope(jsi_runtime * /*rt*/,
+                                           void * /*scope*/) {
+  return jsi_no_error;
+}
+
+//------------------------------------------------------------------------------
+// Script Evaluation
+//------------------------------------------------------------------------------
+
+jsi_value_or_error JSI_CDECL jsi_evaluate_javascript_source(
+    jsi_runtime *rt, jsi_buffer *buf, const char *source_url,
+    size_t source_url_len) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Isolate *isolate = state->isolate;
+  TryCatch try_catch(state);
+
+  v8::Local<v8::String> sourceStr;
+  if (!v8::String::NewFromUtf8(isolate,
+                                reinterpret_cast<const char *>(buf->data),
+                                v8::NewStringType::kNormal,
+                                static_cast<int>(buf->size))
+           .ToLocal(&sourceStr)) {
+    if (buf->vtable && buf->vtable->release)
+      buf->vtable->release(buf);
+    state->setNativeError("Failed to create source string");
+    return abi::create_value_or_error(jsi_error_native);
+  }
+
+  v8::Local<v8::String> urlV8Str;
+  if (!v8::String::NewFromUtf8(isolate, source_url, v8::NewStringType::kNormal,
+                                static_cast<int>(source_url_len))
+           .ToLocal(&urlV8Str)) {
+    if (buf->vtable && buf->vtable->release)
+      buf->vtable->release(buf);
+    state->setNativeError("Failed to create source URL string");
+    return abi::create_value_or_error(jsi_error_native);
+  }
+
+  if (buf->vtable && buf->vtable->release)
+    buf->vtable->release(buf);
+
+  v8::ScriptOrigin origin(urlV8Str);
+
+  v8::Local<v8::Script> compiled;
+  if (!v8::Script::Compile(state->getContextLocal(), sourceStr, &origin)
+           .ToLocal(&compiled))
+    return abi::create_value_or_error(jsi_error_js);
+
+  v8::Local<v8::Value> resultValue;
+  if (!compiled->Run(state->getContextLocal()).ToLocal(&resultValue))
+    return abi::create_value_or_error(jsi_error_js);
+
+  return abi::create_value_or_error(createJsiValue(isolate, resultValue));
+}
+
+jsi_prepared_javascript_or_error JSI_CDECL jsi_prepare_javascript(
+    jsi_runtime *rt, jsi_buffer *buf, const char *source_url,
+    size_t source_url_len) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Isolate *isolate = state->isolate;
+  TryCatch try_catch(state);
+
+  // W3: compute MurmurHash3 over the source bytes for the cache key. Must
+  // happen before buf->release() since the buffer pointer becomes invalid.
+  uint64_t source_hash = 0;
+  if (state->script_cache_load_cb || state->script_cache_store_cb) {
+    murmurhash(buf->data, buf->size, source_hash);
+  }
+
+  v8::Local<v8::String> sourceStr;
+  if (!v8::String::NewFromUtf8(isolate,
+                                reinterpret_cast<const char *>(buf->data),
+                                v8::NewStringType::kNormal,
+                                static_cast<int>(buf->size))
+           .ToLocal(&sourceStr)) {
+    if (buf->vtable && buf->vtable->release)
+      buf->vtable->release(buf);
+    state->setNativeError("Failed to create source string");
+    return abi::create_prepared_javascript_or_error(jsi_error_native);
+  }
+
+  v8::Local<v8::String> urlV8Str;
+  if (!v8::String::NewFromUtf8(isolate, source_url, v8::NewStringType::kNormal,
+                                static_cast<int>(source_url_len))
+           .ToLocal(&urlV8Str)) {
+    if (buf->vtable && buf->vtable->release)
+      buf->vtable->release(buf);
+    state->setNativeError("Failed to create source URL string");
+    return abi::create_prepared_javascript_or_error(jsi_error_native);
+  }
+
+  if (buf->vtable && buf->vtable->release)
+    buf->vtable->release(buf);
+
+  v8::ScriptOrigin origin(urlV8Str);
+
+  // W3: cache_tag = "perf" matches the legacy V8Runtime convention.
+  // runtime_name = "V8" likewise — preserves cache keys for deployed
+  // consumers whose stores already contain entries under that name.
+  static constexpr const char *kCacheTag = "perf";
+  static constexpr const char *kRuntimeName = "V8";
+  const uint64_t runtime_version = v8::ScriptCompiler::CachedDataVersionTag();
+
+  // W3: try cache load.
+  v8::ScriptCompiler::CompileOptions options =
+      v8::ScriptCompiler::CompileOptions::kNoCompileOptions;
+  v8::ScriptCompiler::CachedData *cached_data = nullptr;
+  const uint8_t *cache_buffer = nullptr;
+  size_t cache_buffer_size = 0;
+  jsi_data_delete_cb cache_buffer_delete_cb = nullptr;
+  void *cache_buffer_deleter_data = nullptr;
+
+  if (state->script_cache_load_cb) {
+    state->script_cache_load_cb(
+        state->script_cache_data,
+        source_url,
+        source_hash,
+        kRuntimeName,
+        runtime_version,
+        kCacheTag,
+        &cache_buffer,
+        &cache_buffer_size,
+        &cache_buffer_delete_cb,
+        &cache_buffer_deleter_data);
+    if (cache_buffer && cache_buffer_size > 0) {
+      // BufferNotOwned: V8 does not free `cache_buffer`; we own it and
+      // release via cache_buffer_delete_cb after Compile returns.
+      cached_data = new v8::ScriptCompiler::CachedData(
+          cache_buffer, static_cast<int>(cache_buffer_size));
+      options = v8::ScriptCompiler::CompileOptions::kConsumeCodeCache;
+    }
+  }
+
+  v8::ScriptCompiler::Source script_source(sourceStr, origin, cached_data);
+
+  v8::Local<v8::Script> compiled;
+  bool compile_ok =
+      v8::ScriptCompiler::Compile(state->getContextLocal(), &script_source,
+                                  options)
+          .ToLocal(&compiled);
+
+  // Release the consumer's cache buffer (if any) now that V8 is done with it.
+  // Compile is synchronous, so the bytes are no longer needed past this point.
+  if (cache_buffer_delete_cb) {
+    cache_buffer_delete_cb(const_cast<uint8_t *>(cache_buffer),
+                            cache_buffer_deleter_data);
+  }
+
+  if (!compile_ok)
+    return abi::create_prepared_javascript_or_error(jsi_error_js);
+
+  v8::Local<v8::UnboundScript> unbound = compiled->GetUnboundScript();
+
+  // W3: cache miss → produce code cache and hand it to the consumer.
+  if (state->script_cache_store_cb &&
+      options != v8::ScriptCompiler::CompileOptions::kConsumeCodeCache) {
+    v8::ScriptCompiler::CachedData *codeCache =
+        v8::ScriptCompiler::CreateCodeCache(unbound);
+    if (codeCache) {
+      // The consumer reads codeCache->data and then calls our delete_cb,
+      // which deletes the V8 CachedData object (and its owned buffer) in the
+      // DLL's CRT — the same CRT that allocated it.
+      auto delete_cb = [](void * /*data*/, void *deleter_data) {
+        delete static_cast<v8::ScriptCompiler::CachedData *>(deleter_data);
+      };
+      state->script_cache_store_cb(
+          state->script_cache_data,
+          source_url,
+          source_hash,
+          kRuntimeName,
+          runtime_version,
+          kCacheTag,
+          codeCache->data,
+          static_cast<size_t>(codeCache->length),
+          delete_cb,
+          codeCache);
+    }
+  }
+
+  return abi::create_prepared_javascript_or_error(
+      new PreparedScriptImpl(isolate, unbound));
+}
+
+jsi_value_or_error JSI_CDECL
+jsi_evaluate_prepared_javascript(jsi_runtime *rt,
+                                  jsi_prepared_javascript *prepared) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Isolate *isolate = state->isolate;
+  TryCatch try_catch(state);
+
+  auto *impl = static_cast<PreparedScriptImpl *>(prepared);
+  v8::Local<v8::UnboundScript> unbound = impl->get(state->isolate);
+  v8::Local<v8::Script> script = unbound->BindToCurrentContext();
+
+  v8::Local<v8::Value> resultValue;
+  if (!script->Run(state->getContextLocal()).ToLocal(&resultValue))
+    return abi::create_value_or_error(jsi_error_js);
+
+  return abi::create_value_or_error(createJsiValue(isolate, resultValue));
+}
+
+//------------------------------------------------------------------------------
+// Microtasks
+//------------------------------------------------------------------------------
+
+jsi_bool_or_error JSI_CDECL jsi_drain_microtasks(jsi_runtime *rt,
+                                                   int32_t /*max_hint*/) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+
+  if (state->isolate->GetMicrotasksPolicy() == v8::MicrotasksPolicy::kExplicit)
+    state->isolate->PerformMicrotaskCheckpoint();
+
+  return abi::create_bool_or_error(false);
+}
+
+jsi_error_code JSI_CDECL jsi_queue_microtask(jsi_runtime *rt,
+                                                  jsi_function callback) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+
+  v8::Local<v8::Object> obj = toObjectHandle({callback.pointer})->get(state->isolate);
+  if (!obj->IsFunction()) {
+    state->setNativeError("callback must be a function");
+    return jsi_error_native;
+  }
+
+  state->isolate->EnqueueMicrotask(v8::Local<v8::Function>::Cast(obj));
+  return jsi_no_error;
+}
+
+//------------------------------------------------------------------------------
+// Global Object
+//------------------------------------------------------------------------------
+
+jsi_object JSI_CDECL jsi_get_global_object(jsi_runtime *rt) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Object> global = state->getContextLocal()->Global();
+  return {new ObjectHandle(state->isolate, global)};
+}
+
+//------------------------------------------------------------------------------
+// String Operations
+//------------------------------------------------------------------------------
+
+jsi_string_or_error JSI_CDECL jsi_create_string_from_utf8(jsi_runtime *rt,
+                                                           const uint8_t *utf8,
+                                                           size_t len) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::String> v8str;
+  if (!v8::String::NewFromUtf8(state->isolate,
+                                reinterpret_cast<const char *>(utf8),
+                                v8::NewStringType::kNormal,
+                                static_cast<int>(len))
+           .ToLocal(&v8str)) {
+    state->setNativeError("Failed to create string");
+    return abi::create_string_or_error(jsi_error_native);
+  }
+  return abi::create_string_or_error(
+      static_cast<jsi_pointer *>(new StringHandle(state->isolate, v8str)));
+}
+
+jsi_string_or_error JSI_CDECL jsi_create_string_from_utf16(
+    jsi_runtime *rt, const uint16_t *utf16, size_t len) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::String> v8str;
+  if (!v8::String::NewFromTwoByte(state->isolate, utf16,
+                                   v8::NewStringType::kNormal,
+                                   static_cast<int>(len))
+           .ToLocal(&v8str)) {
+    state->setNativeError("Failed to create string");
+    return abi::create_string_or_error(jsi_error_native);
+  }
+  return abi::create_string_or_error(
+      static_cast<jsi_pointer *>(new StringHandle(state->isolate, v8str)));
+}
+
+void JSI_CDECL jsi_get_utf8_from_string(jsi_runtime *rt, jsi_string str,
+                                         jsi_growable_buffer *buf) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Isolate *isolate = state->isolate;
+  v8::Local<v8::String> v8str = toStringHandle(str)->get(state->isolate);
+
+  size_t utf8_len = v8str->Utf8LengthV2(isolate);
+  if (buf->size < utf8_len)
+    buf->vtable->try_grow_to(buf, utf8_len);
+  if (buf->size >= utf8_len) {
+    v8str->WriteUtf8V2(isolate, reinterpret_cast<char *>(buf->data),
+                        static_cast<int>(utf8_len));
+    buf->used = utf8_len;
+  }
+}
+
+void JSI_CDECL jsi_get_utf16_from_string(jsi_runtime *rt, jsi_string str,
+                                          jsi_growable_buffer *buf) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Isolate *isolate = state->isolate;
+  v8::Local<v8::String> v8str = toStringHandle(str)->get(state->isolate);
+
+  int len = v8str->Length();
+  size_t bytes = static_cast<size_t>(len) * sizeof(uint16_t);
+  if (buf->size < bytes)
+    buf->vtable->try_grow_to(buf, bytes);
+  if (buf->size >= bytes) {
+    v8str->WriteV2(isolate, 0, len,
+                    reinterpret_cast<uint16_t *>(buf->data));
+    buf->used = bytes;
+  }
+}
+
+//------------------------------------------------------------------------------
+// Symbol Operations
+//------------------------------------------------------------------------------
+
+void JSI_CDECL jsi_get_utf8_from_symbol(jsi_runtime *rt, jsi_symbol sym,
+                                         jsi_growable_buffer *buf) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Isolate *isolate = state->isolate;
+
+  v8::Local<v8::Symbol> v8sym = toSymbolHandle(sym)->get(state->isolate);
+  v8::Local<v8::Value> descVal = v8sym->Description(isolate);
+
+  std::string result_str = "Symbol(";
+  if (descVal->IsString()) {
+    v8::Local<v8::String> descStr = v8::Local<v8::String>::Cast(descVal);
+    size_t len = descStr->Utf8LengthV2(isolate);
+    std::string desc(len, '\0');
+    descStr->WriteUtf8V2(isolate, &desc[0], static_cast<int>(len));
+    result_str += desc;
+  }
+  result_str += ")";
+  writeToBuf(buf, result_str);
+}
+
+//------------------------------------------------------------------------------
+// PropNameID Operations
+//------------------------------------------------------------------------------
+
+jsi_propnameid_or_error JSI_CDECL jsi_create_propnameid_from_utf8(
+    jsi_runtime *rt, const uint8_t *utf8, size_t len) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::String> v8str;
+  if (!v8::String::NewFromUtf8(state->isolate,
+                                reinterpret_cast<const char *>(utf8),
+                                v8::NewStringType::kInternalized,
+                                static_cast<int>(len))
+           .ToLocal(&v8str)) {
+    state->setNativeError("Failed to create property name");
+    return abi::create_propnameid_or_error(jsi_error_native);
+  }
+  return abi::create_propnameid_or_error(
+      static_cast<jsi_pointer *>(new PropNameIdHandle(state->isolate, v8str)));
+}
+
+jsi_propnameid_or_error JSI_CDECL
+jsi_create_propnameid_from_string(jsi_runtime *rt, jsi_string str) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::String> v8str = toStringHandle(str)->get(state->isolate);
+  return abi::create_propnameid_or_error(
+      static_cast<jsi_pointer *>(new PropNameIdHandle(state->isolate, v8str)));
+}
+
+jsi_propnameid_or_error JSI_CDECL
+jsi_create_propnameid_from_symbol(jsi_runtime *rt, jsi_symbol sym) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Symbol> v8sym = toSymbolHandle(sym)->get(state->isolate);
+  return abi::create_propnameid_or_error(
+      static_cast<jsi_pointer *>(new PropNameIdHandle(state->isolate, v8sym)));
+}
+
+bool JSI_CDECL jsi_prop_name_id_equals(jsi_runtime *rt, jsi_propnameid a,
+                                        jsi_propnameid b) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Value> va = toPropNameIdHandle(a)->get(state->isolate);
+  v8::Local<v8::Value> vb = toPropNameIdHandle(b)->get(state->isolate);
+  return va->StrictEquals(vb);
+}
+
+void JSI_CDECL jsi_get_utf8_from_propnameid(jsi_runtime *rt,
+                                             jsi_propnameid name,
+                                             jsi_growable_buffer *buf) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Isolate *isolate = state->isolate;
+
+  v8::Local<v8::Value> v8val = toPropNameIdHandle(name)->get(state->isolate);
+  v8::Local<v8::String> v8str;
+
+  if (v8val->IsString()) {
+    v8str = v8::Local<v8::String>::Cast(v8val);
+  } else if (v8val->IsSymbol()) {
+    v8::Local<v8::Symbol> sym = v8::Local<v8::Symbol>::Cast(v8val);
+    v8::Local<v8::Value> desc = sym->Description(isolate);
+    if (desc->IsString())
+      v8str = v8::Local<v8::String>::Cast(desc);
+  }
+
+  if (v8str.IsEmpty()) {
+    buf->used = 0;
+    return;
+  }
+
+  size_t utf8_len = v8str->Utf8LengthV2(isolate);
+  if (buf->size < utf8_len)
+    buf->vtable->try_grow_to(buf, utf8_len);
+  if (buf->size >= utf8_len) {
+    v8str->WriteUtf8V2(isolate, reinterpret_cast<char *>(buf->data),
+                        static_cast<int>(utf8_len));
+    buf->used = utf8_len;
+  }
+}
+
+//------------------------------------------------------------------------------
+// Object Operations
+//------------------------------------------------------------------------------
+
+jsi_object_or_error JSI_CDECL jsi_create_object(jsi_runtime *rt) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Object> obj = v8::Object::New(state->isolate);
+  return abi::create_object_or_error(
+      static_cast<jsi_pointer *>(new ObjectHandle(state->isolate, obj)));
+}
+
+jsi_object_or_error JSI_CDECL
+jsi_create_object_with_prototype(jsi_runtime *rt,
+                                  const jsi_value *prototype) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Isolate *isolate = state->isolate;
+
+  v8::Local<v8::Value> proto =
+      (prototype && !abi::is_undefined_value(*prototype) &&
+       !abi::is_null_value(*prototype))
+          ? toV8Value(isolate, prototype)
+          : v8::Null(isolate).As<v8::Value>();
+
+  v8::Local<v8::Object> obj =
+      v8::Object::New(isolate, proto, nullptr, nullptr, 0);
+  return abi::create_object_or_error(
+      static_cast<jsi_pointer *>(new ObjectHandle(isolate, obj)));
+}
+
+jsi_value_or_error JSI_CDECL jsi_get_prototype_of(jsi_runtime *rt,
+                                                    jsi_object obj) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Value> proto = v8obj->GetPrototypeV2();
+  return abi::create_value_or_error(createJsiValue(state->isolate, proto));
+}
+
+jsi_error_code JSI_CDECL jsi_set_prototype_of(jsi_runtime *rt,
+                                                   jsi_object obj,
+                                                   const jsi_value *prototype) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+  v8::Isolate *isolate = state->isolate;
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Value> proto = prototype
+                                    ? toV8Value(isolate, prototype)
+                                    : v8::Null(isolate).As<v8::Value>();
+
+  v8::Maybe<bool> success =
+      v8obj->SetPrototypeV2(state->getContextLocal(), proto);
+  if (success.IsNothing())
+    return jsi_error_js;
+  if (!success.FromJust()) {
+    state->setNativeError("Failed to set prototype");
+    return jsi_error_native;
+  }
+  return jsi_no_error;
+}
+
+jsi_bool_or_error JSI_CDECL jsi_has_object_property_from_propnameid(
+    jsi_runtime *rt, jsi_object obj, jsi_propnameid name) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Value> v8name = toPropNameIdHandle(name)->get(state->isolate);
+
+  v8::Maybe<bool> has = v8obj->Has(state->getContextLocal(), v8name);
+  if (has.IsNothing())
+    return abi::create_bool_or_error(jsi_error_js);
+  return abi::create_bool_or_error(has.FromJust());
+}
+
+jsi_value_or_error JSI_CDECL jsi_get_object_property_from_propnameid(
+    jsi_runtime *rt, jsi_object obj, jsi_propnameid name) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Value> v8name = toPropNameIdHandle(name)->get(state->isolate);
+
+  v8::Local<v8::Value> val;
+  if (!v8obj->Get(state->getContextLocal(), v8name).ToLocal(&val))
+    return abi::create_value_or_error(jsi_error_js);
+
+  return abi::create_value_or_error(createJsiValue(state->isolate, val));
+}
+
+jsi_error_code JSI_CDECL jsi_set_object_property_from_propnameid(
+    jsi_runtime *rt, jsi_object obj, jsi_propnameid name,
+    const jsi_value *value) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Value> v8name = toPropNameIdHandle(name)->get(state->isolate);
+  v8::Local<v8::Value> v8val = toV8Value(state->isolate, value);
+
+  v8::Maybe<bool> success =
+      v8obj->Set(state->getContextLocal(), v8name, v8val);
+  if (success.IsNothing())
+    return jsi_error_js;
+  return jsi_no_error;
+}
+
+jsi_error_code JSI_CDECL jsi_delete_property_from_propnameid(
+    jsi_runtime *rt, jsi_object obj, jsi_propnameid name) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Value> v8name = toPropNameIdHandle(name)->get(state->isolate);
+
+  v8::Maybe<bool> deleted = v8obj->Delete(state->getContextLocal(), v8name);
+  if (deleted.IsNothing())
+    return jsi_error_js;
+  return jsi_no_error;
+}
+
+jsi_bool_or_error JSI_CDECL jsi_has_object_property_from_value(
+    jsi_runtime *rt, jsi_object obj, const jsi_value *key) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Value> v8key = toV8Value(state->isolate, key);
+
+  v8::Maybe<bool> has = v8obj->Has(state->getContextLocal(), v8key);
+  if (has.IsNothing())
+    return abi::create_bool_or_error(jsi_error_js);
+  return abi::create_bool_or_error(has.FromJust());
+}
+
+jsi_value_or_error JSI_CDECL jsi_get_object_property_from_value(
+    jsi_runtime *rt, jsi_object obj, const jsi_value *key) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Value> v8key = toV8Value(state->isolate, key);
+
+  v8::Local<v8::Value> val;
+  if (!v8obj->Get(state->getContextLocal(), v8key).ToLocal(&val))
+    return abi::create_value_or_error(jsi_error_js);
+
+  return abi::create_value_or_error(createJsiValue(state->isolate, val));
+}
+
+jsi_error_code JSI_CDECL jsi_set_object_property_from_value(
+    jsi_runtime *rt, jsi_object obj, const jsi_value *key,
+    const jsi_value *value) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Value> v8key = toV8Value(state->isolate, key);
+  v8::Local<v8::Value> v8val = toV8Value(state->isolate, value);
+
+  v8::Maybe<bool> success =
+      v8obj->Set(state->getContextLocal(), v8key, v8val);
+  if (success.IsNothing())
+    return jsi_error_js;
+  return jsi_no_error;
+}
+
+jsi_error_code JSI_CDECL jsi_delete_property_from_value(
+    jsi_runtime *rt, jsi_object obj, const jsi_value *key) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Value> v8key = toV8Value(state->isolate, key);
+
+  v8::Maybe<bool> deleted = v8obj->Delete(state->getContextLocal(), v8key);
+  if (deleted.IsNothing())
+    return jsi_error_js;
+  return jsi_no_error;
+}
+
+jsi_array_or_error JSI_CDECL jsi_get_object_property_names(jsi_runtime *rt,
+                                                            jsi_object obj) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Array> names;
+  if (!v8obj
+           ->GetPropertyNames(
+               state->getContextLocal(),
+               v8::KeyCollectionMode::kIncludePrototypes,
+               static_cast<v8::PropertyFilter>(v8::ONLY_ENUMERABLE |
+                                               v8::SKIP_SYMBOLS),
+               v8::IndexFilter::kIncludeIndices,
+               v8::KeyConversionMode::kConvertToString)
+           .ToLocal(&names))
+    return abi::create_array_or_error(jsi_error_js);
+
+  return abi::create_array_or_error(
+      static_cast<jsi_pointer *>(new ObjectHandle(state->isolate, names)));
+}
+
+jsi_error_code JSI_CDECL jsi_set_object_external_memory_pressure(
+    jsi_runtime *rt, jsi_object /*obj*/, size_t amount) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  state->isolate->AdjustAmountOfExternalAllocatedMemory(
+      static_cast<int64_t>(amount));
+  return jsi_no_error;
+}
+
+jsi_object_or_error JSI_CDECL jsi_create_error(jsi_runtime *rt,
+                                                const uint8_t *utf8_msg,
+                                                size_t len) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Isolate *isolate = state->isolate;
+
+  v8::Local<v8::String> msgStr;
+  if (utf8_msg && len > 0) {
+    if (!v8::String::NewFromUtf8(isolate,
+                                  reinterpret_cast<const char *>(utf8_msg),
+                                  v8::NewStringType::kNormal,
+                                  static_cast<int>(len))
+             .ToLocal(&msgStr)) {
+      state->setNativeError("Failed to create message string");
+      return abi::create_object_or_error(jsi_error_native);
+    }
+  } else {
+    msgStr = v8::String::Empty(isolate);
+  }
+
+  v8::Local<v8::Value> error = v8::Exception::Error(msgStr);
+  return abi::create_object_or_error(static_cast<jsi_pointer *>(
+      new ObjectHandle(isolate, v8::Local<v8::Object>::Cast(error))));
+}
+
+//------------------------------------------------------------------------------
+// Array Operations
+//------------------------------------------------------------------------------
+
+jsi_array_or_error JSI_CDECL jsi_create_array(jsi_runtime *rt, size_t length) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Array> arr =
+      v8::Array::New(state->isolate, static_cast<int>(length));
+  return abi::create_array_or_error(
+      static_cast<jsi_pointer *>(new ObjectHandle(state->isolate, arr)));
+}
+
+size_t JSI_CDECL jsi_get_array_length(jsi_runtime *rt, jsi_array arr) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Object> v8obj = toObjectHandle({arr.pointer})->get(state->isolate);
+  if (!v8obj->IsArray())
+    return 0;
+  return v8::Local<v8::Array>::Cast(v8obj)->Length();
+}
+
+jsi_value_or_error JSI_CDECL jsi_get_array_element(jsi_runtime *rt,
+                                                    jsi_object arr,
+                                                    size_t index) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(arr)->get(state->isolate);
+  v8::Local<v8::Value> val;
+  if (!v8obj->Get(state->getContextLocal(), static_cast<uint32_t>(index))
+           .ToLocal(&val))
+    return abi::create_value_or_error(jsi_error_js);
+
+  return abi::create_value_or_error(createJsiValue(state->isolate, val));
+}
+
+jsi_error_code JSI_CDECL jsi_set_array_element(jsi_runtime *rt,
+                                                    jsi_object arr,
+                                                    size_t index,
+                                                    const jsi_value *value) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(arr)->get(state->isolate);
+  v8::Local<v8::Value> v8val = toV8Value(state->isolate, value);
+
+  v8::Maybe<bool> success =
+      v8obj->Set(state->getContextLocal(), static_cast<uint32_t>(index), v8val);
+  if (success.IsNothing())
+    return jsi_error_js;
+  return jsi_no_error;
+}
+
+//------------------------------------------------------------------------------
+// ArrayBuffer Operations
+//------------------------------------------------------------------------------
+
+jsi_arraybuffer_or_error JSI_CDECL jsi_create_arraybuffer(jsi_runtime *rt,
+                                                           size_t byte_length) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::ArrayBuffer> ab =
+      v8::ArrayBuffer::New(state->isolate, byte_length);
+  return abi::create_arraybuffer_or_error(
+      static_cast<jsi_pointer *>(new ObjectHandle(state->isolate, ab)));
+}
+
+jsi_arraybuffer_or_error JSI_CDECL jsi_create_arraybuffer_from_external_data(
+    jsi_runtime *rt, jsi_mutable_buffer *buf) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Isolate *isolate = state->isolate;
+
+  struct BufRef {
+    jsi_mutable_buffer *buf;
+  };
+  auto *ref = new BufRef{buf};
+
+  std::unique_ptr<v8::BackingStore> backing_store =
+      v8::ArrayBuffer::NewBackingStore(
+          buf->data, buf->size,
+          [](void * /*data*/, size_t /*length*/, void *deleter_data) {
+            auto *r = static_cast<BufRef *>(deleter_data);
+            if (r->buf->vtable && r->buf->vtable->release)
+              r->buf->vtable->release(r->buf);
+            delete r;
+          },
+          ref);
+
+  v8::Local<v8::ArrayBuffer> ab =
+      v8::ArrayBuffer::New(isolate, std::move(backing_store));
+  return abi::create_arraybuffer_or_error(
+      static_cast<jsi_pointer *>(new ObjectHandle(isolate, ab)));
+}
+
+jsi_uint8_ptr_or_error JSI_CDECL jsi_get_arraybuffer_data(jsi_runtime *rt,
+                                                           jsi_arraybuffer ab) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle({ab.pointer})->get(state->isolate);
+  if (!v8obj->IsArrayBuffer()) {
+    state->setNativeError("Object is not an ArrayBuffer");
+    return abi::create_uint8_ptr_or_error(jsi_error_native);
+  }
+
+  v8::Local<v8::ArrayBuffer> v8ab = v8::Local<v8::ArrayBuffer>::Cast(v8obj);
+  return abi::create_uint8_ptr_or_error(
+      static_cast<uint8_t *>(v8ab->GetBackingStore()->Data()));
+}
+
+jsi_size_or_error JSI_CDECL jsi_get_arraybuffer_size(jsi_runtime *rt,
+                                                      jsi_arraybuffer ab) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle({ab.pointer})->get(state->isolate);
+  if (!v8obj->IsArrayBuffer()) {
+    state->setNativeError("Object is not an ArrayBuffer");
+    return abi::create_size_or_error(jsi_error_native);
+  }
+
+  v8::Local<v8::ArrayBuffer> v8ab = v8::Local<v8::ArrayBuffer>::Cast(v8obj);
+  return abi::create_size_or_error(v8ab->ByteLength());
+}
+
+//------------------------------------------------------------------------------
+// Function Operations
+//------------------------------------------------------------------------------
+
+jsi_value_or_error JSI_CDECL jsi_call(jsi_runtime *rt, jsi_function fn,
+                                       const jsi_value *js_this,
+                                       const jsi_value *args,
+                                       size_t arg_count) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+  v8::Isolate *isolate = state->isolate;
+
+  v8::Local<v8::Object> v8obj = toObjectHandle({fn.pointer})->get(state->isolate);
+  if (!v8obj->IsFunction()) {
+    state->setNativeError("Object is not a function");
+    return abi::create_value_or_error(jsi_error_native);
+  }
+  v8::Local<v8::Function> v8func = v8::Local<v8::Function>::Cast(v8obj);
+
+  v8::Local<v8::Value> v8this =
+      js_this ? toV8Value(isolate, js_this)
+              : v8::Undefined(isolate).As<v8::Value>();
+
+  std::vector<v8::Local<v8::Value>> v8args;
+  v8args.reserve(arg_count);
+  for (size_t i = 0; i < arg_count; ++i)
+    v8args.push_back(toV8Value(isolate, &args[i]));
+
+  v8::Local<v8::Value> callResult;
+  if (!v8func
+           ->Call(state->getContextLocal(), v8this,
+                  static_cast<int>(arg_count), v8args.data())
+           .ToLocal(&callResult))
+    return abi::create_value_or_error(jsi_error_js);
+
+  return abi::create_value_or_error(createJsiValue(isolate, callResult));
+}
+
+jsi_value_or_error JSI_CDECL jsi_call_as_constructor(jsi_runtime *rt,
+                                                      jsi_function fn,
+                                                      const jsi_value *args,
+                                                      size_t arg_count) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+  v8::Isolate *isolate = state->isolate;
+
+  v8::Local<v8::Object> v8obj = toObjectHandle({fn.pointer})->get(state->isolate);
+  if (!v8obj->IsFunction()) {
+    state->setNativeError("Object is not a function");
+    return abi::create_value_or_error(jsi_error_native);
+  }
+  v8::Local<v8::Function> v8func = v8::Local<v8::Function>::Cast(v8obj);
+
+  std::vector<v8::Local<v8::Value>> v8args;
+  v8args.reserve(arg_count);
+  for (size_t i = 0; i < arg_count; ++i)
+    v8args.push_back(toV8Value(isolate, &args[i]));
+
+  v8::Local<v8::Object> constructed;
+  if (!v8func
+           ->NewInstance(state->getContextLocal(),
+                         static_cast<int>(arg_count), v8args.data())
+           .ToLocal(&constructed))
+    return abi::create_value_or_error(jsi_error_js);
+
+  return abi::create_value_or_error(
+      abi::create_object_value(new ObjectHandle(isolate, constructed)));
+}
+
+jsi_function_or_error JSI_CDECL jsi_create_function_from_host_function(
+    jsi_runtime *rt, jsi_propnameid name, uint32_t param_count,
+    jsi_host_function *hf) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+  v8::Isolate *isolate = state->isolate;
+
+  auto *ctx = new HostFunctionContext(rt, hf);
+  v8::Local<v8::External> data = v8::External::New(isolate, ctx);
+
+  v8::Local<v8::Function> func;
+  if (!v8::Function::New(state->getContextLocal(),
+                          HostFunctionCallbackTrampoline, data, param_count)
+           .ToLocal(&func)) {
+    ctx->hostFunction = nullptr; // caller still owns hf
+    delete ctx;
+    return abi::create_function_or_error(jsi_error_js);
+  }
+
+  // Set up weak ref so ctx + hf are released when V8 GCs the function
+  ctx->trackFunction(isolate, func);
+
+  // Tag as host function so get_host_function can retrieve it
+  func->SetPrivate(state->getContextLocal(), state->getHostFunctionKey(), data)
+      .Check();
+
+  if (name.pointer) {
+    v8::Local<v8::Value> v8name = toPropNameIdHandle(name)->get(state->isolate);
+    if (v8name->IsString())
+      func->SetName(v8::Local<v8::String>::Cast(v8name));
+  }
+
+  return abi::create_function_or_error(
+      static_cast<jsi_pointer *>(new ObjectHandle(isolate, func)));
+}
+
+jsi_host_function *JSI_CDECL jsi_get_host_function(jsi_runtime *rt,
+                                                    jsi_function fn) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle({fn.pointer})->get(state->isolate);
+  v8::Local<v8::Value> privateVal;
+  if (v8obj->GetPrivate(state->getContextLocal(), state->getHostFunctionKey())
+          .ToLocal(&privateVal) &&
+      privateVal->IsExternal()) {
+    auto *ctx = static_cast<HostFunctionContext *>(
+        v8::Local<v8::External>::Cast(privateVal)->Value());
+    return ctx->hostFunction;
+  }
+  return nullptr;
+}
+
+//------------------------------------------------------------------------------
+// Host Object Operations
+//------------------------------------------------------------------------------
+
+jsi_object_or_error JSI_CDECL
+jsi_create_object_from_host_object(jsi_runtime *rt, jsi_host_object *ho) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+  v8::Isolate *isolate = state->isolate;
+  v8::Local<v8::Context> context = state->getContextLocal();
+
+  v8::Local<v8::Function> constructor = state->getHostObjectConstructor();
+
+  v8::Local<v8::Object> newObject;
+  if (!constructor->NewInstance(context).ToLocal(&newObject))
+    return abi::create_object_or_error(jsi_error_js);
+
+  auto *proxy = new AbiHostObjectProxy(rt, ho, isolate, newObject);
+  newObject->SetInternalField(0, v8::External::New(isolate, proxy));
+
+  v8::Local<v8::Private> hostObjectKey = state->getHostObjectKey();
+  newObject->SetPrivate(context, hostObjectKey,
+                        v8::External::New(isolate, proxy));
+
+  return abi::create_object_or_error(
+      static_cast<jsi_pointer *>(new ObjectHandle(isolate, newObject)));
+}
+
+jsi_host_object *JSI_CDECL jsi_get_host_object(jsi_runtime *rt,
+                                                jsi_object obj) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Context> context = state->getContextLocal();
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Private> hostObjectKey = state->getHostObjectKey();
+
+  v8::Local<v8::Value> privateValue;
+  if (v8obj->GetPrivate(context, hostObjectKey).ToLocal(&privateValue) &&
+      privateValue->IsExternal()) {
+    auto *proxy = reinterpret_cast<AbiHostObjectProxy *>(
+        v8::Local<v8::External>::Cast(privateValue)->Value());
+    return proxy ? proxy->hostObject : nullptr;
+  }
+  return nullptr;
+}
+
+//------------------------------------------------------------------------------
+// Native State
+//------------------------------------------------------------------------------
+
+bool JSI_CDECL jsi_has_native_state(jsi_runtime *rt, jsi_object obj) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Context> context = state->getContextLocal();
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+
+  v8::Local<v8::Private> key = state->getNativeStateKey();
+  v8::Maybe<bool> hasPrivate = v8obj->HasPrivate(context, key);
+  return hasPrivate.FromMaybe(false);
+}
+
+jsi_native_state *JSI_CDECL jsi_get_native_state(jsi_runtime *rt,
+                                                   jsi_object obj) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Context> context = state->getContextLocal();
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+
+  NativeStateWrapper *wrapper = getNativeStateWrapper(state, context, v8obj);
+  return wrapper ? wrapper->state : nullptr;
+}
+
+jsi_error_code JSI_CDECL jsi_set_native_state(jsi_runtime *rt,
+                                                   jsi_object obj,
+                                                   jsi_native_state *ns) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Isolate *isolate = state->isolate;
+  v8::Local<v8::Context> context = state->getContextLocal();
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Private> key = state->getNativeStateKey();
+
+  NativeStateWrapper *existing = getNativeStateWrapper(state, context, v8obj);
+  if (existing) {
+    if (existing->state)
+      existing->state->vtable->release(existing->state);
+    existing->state = ns;
+  } else {
+    auto *wrapper = new NativeStateWrapper(isolate, v8obj, ns);
+    v8::Local<v8::External> external = v8::External::New(isolate, wrapper);
+    v8obj->SetPrivate(context, key, external).Check();
+  }
+  return jsi_no_error;
+}
+
+//------------------------------------------------------------------------------
+// Type Checks
+//------------------------------------------------------------------------------
+
+bool JSI_CDECL jsi_object_is_array(jsi_runtime *rt, jsi_object obj) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  return toObjectHandle(obj)->get(state->isolate)->IsArray();
+}
+
+bool JSI_CDECL jsi_object_is_arraybuffer(jsi_runtime *rt, jsi_object obj) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  return toObjectHandle(obj)->get(state->isolate)->IsArrayBuffer();
+}
+
+bool JSI_CDECL jsi_object_is_function(jsi_runtime *rt, jsi_object obj) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  return toObjectHandle(obj)->get(state->isolate)->IsFunction();
+}
+
+//------------------------------------------------------------------------------
+// Weak References
+//------------------------------------------------------------------------------
+
+jsi_weak_object_or_error JSI_CDECL jsi_create_weak_object(jsi_runtime *rt,
+                                                           jsi_object obj) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  return abi::create_weak_object_or_error(
+      static_cast<jsi_pointer *>(new WeakObjectHandle(state->isolate, v8obj)));
+}
+
+jsi_value JSI_CDECL jsi_lock_weak_object(jsi_runtime *rt,
+                                          jsi_weak_object wo) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::Object> v8obj = toWeakObjectHandle(wo)->get(state->isolate);
+  if (v8obj.IsEmpty())
+    return abi::create_undefined_value();
+  return abi::create_object_value(new ObjectHandle(state->isolate, v8obj));
+}
+
+//------------------------------------------------------------------------------
+// Comparison
+//------------------------------------------------------------------------------
+
+jsi_bool_or_error JSI_CDECL jsi_instance_of(jsi_runtime *rt, jsi_object obj,
+                                             jsi_function ctor) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+
+  v8::Local<v8::Object> v8obj = toObjectHandle(obj)->get(state->isolate);
+  v8::Local<v8::Object> v8ctor = toObjectHandle({ctor.pointer})->get(state->isolate);
+
+  v8::Maybe<bool> result =
+      v8obj->InstanceOf(state->getContextLocal(), v8ctor);
+  if (result.IsNothing())
+    return abi::create_bool_or_error(jsi_error_js);
+  return abi::create_bool_or_error(result.FromJust());
+}
+
+bool JSI_CDECL jsi_strict_equals_symbol(jsi_runtime *rt, jsi_symbol a,
+                                         jsi_symbol b) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  return toSymbolHandle(a)->get(state->isolate)->StrictEquals(toSymbolHandle(b)->get(state->isolate));
+}
+
+bool JSI_CDECL jsi_strict_equals_bigint(jsi_runtime *rt, jsi_bigint a,
+                                         jsi_bigint b) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  return toBigIntHandle(a)->get(state->isolate)->StrictEquals(toBigIntHandle(b)->get(state->isolate));
+}
+
+bool JSI_CDECL jsi_strict_equals_string(jsi_runtime *rt, jsi_string a,
+                                         jsi_string b) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  return toStringHandle(a)->get(state->isolate)->StrictEquals(toStringHandle(b)->get(state->isolate));
+}
+
+bool JSI_CDECL jsi_strict_equals_object(jsi_runtime *rt, jsi_object a,
+                                         jsi_object b) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  return toObjectHandle(a)->get(state->isolate)->StrictEquals(toObjectHandle(b)->get(state->isolate));
+}
+
+//------------------------------------------------------------------------------
+// BigInt Operations
+//------------------------------------------------------------------------------
+
+jsi_bigint_or_error JSI_CDECL jsi_create_bigint_from_int64(jsi_runtime *rt,
+                                                            int64_t value) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::BigInt> bi = v8::BigInt::New(state->isolate, value);
+  return abi::create_bigint_or_error(
+      static_cast<jsi_pointer *>(new BigIntHandle(state->isolate, bi)));
+}
+
+jsi_bigint_or_error JSI_CDECL jsi_create_bigint_from_uint64(jsi_runtime *rt,
+                                                             uint64_t value) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  v8::Local<v8::BigInt> bi =
+      v8::BigInt::NewFromUnsigned(state->isolate, value);
+  return abi::create_bigint_or_error(
+      static_cast<jsi_pointer *>(new BigIntHandle(state->isolate, bi)));
+}
+
+bool JSI_CDECL jsi_bigint_is_int64(jsi_runtime *rt, jsi_bigint bigint) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  bool lossless = true;
+  toBigIntHandle(bigint)->get(state->isolate)->Int64Value(&lossless);
+  return lossless;
+}
+
+bool JSI_CDECL jsi_bigint_is_uint64(jsi_runtime *rt, jsi_bigint bigint) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  bool lossless = true;
+  toBigIntHandle(bigint)->get(state->isolate)->Uint64Value(&lossless);
+  return lossless;
+}
+
+uint64_t JSI_CDECL jsi_bigint_truncate_to_uint64(jsi_runtime *rt,
+                                                   jsi_bigint bigint) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  bool lossless = false;
+  return toBigIntHandle(bigint)->get(state->isolate)->Uint64Value(&lossless);
+}
+
+int64_t JSI_CDECL jsi_bigint_to_int64(jsi_runtime *rt, jsi_bigint bigint,
+                                       bool *lossless) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  bool is_lossless = true;
+  int64_t result = toBigIntHandle(bigint)->get(state->isolate)->Int64Value(&is_lossless);
+  if (lossless)
+    *lossless = is_lossless;
+  return result;
+}
+
+uint64_t JSI_CDECL jsi_bigint_to_uint64(jsi_runtime *rt, jsi_bigint bigint,
+                                         bool *lossless) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  bool is_lossless = true;
+  uint64_t result = toBigIntHandle(bigint)->get(state->isolate)->Uint64Value(&is_lossless);
+  if (lossless)
+    *lossless = is_lossless;
+  return result;
+}
+
+jsi_string_or_error JSI_CDECL jsi_bigint_to_string(jsi_runtime *rt,
+                                                    jsi_bigint bigint,
+                                                    uint32_t radix) {
+  auto *state = getState(rt);
+  V8Scope scope(state);
+  TryCatch try_catch(state);
+  v8::Isolate *isolate = state->isolate;
+  v8::Local<v8::Context> context = state->getContextLocal();
+
+  v8::Local<v8::BigInt> bi = toBigIntHandle(bigint)->get(state->isolate);
+
+  v8::Local<v8::Object> bigintProto;
+  if (!bi->ToObject(context).ToLocal(&bigintProto))
+    return abi::create_string_or_error(jsi_error_js);
+
+  v8::Local<v8::String> toStringName =
+      v8::String::NewFromUtf8Literal(isolate, "toString");
+  v8::Local<v8::Value> toStringFn;
+  if (!bigintProto->Get(context, toStringName).ToLocal(&toStringFn) ||
+      !toStringFn->IsFunction()) {
+    state->setNativeError("BigInt.prototype.toString not found");
+    return abi::create_string_or_error(jsi_error_native);
+  }
+
+  v8::Local<v8::Value> radixArg =
+      v8::Integer::New(isolate, static_cast<int32_t>(radix));
+  v8::Local<v8::Value> resultValue;
+  if (!v8::Local<v8::Function>::Cast(toStringFn)
+           ->Call(context, bi, 1, &radixArg)
+           .ToLocal(&resultValue))
+    return abi::create_string_or_error(jsi_error_js);
+
+  if (!resultValue->IsString()) {
+    state->setNativeError("BigInt.toString did not return a string");
+    return abi::create_string_or_error(jsi_error_native);
+  }
+
+  return abi::create_string_or_error(static_cast<jsi_pointer *>(
+      new StringHandle(isolate, v8::Local<v8::String>::Cast(resultValue))));
+}
+
+//==============================================================================
+// Runtime VTable Definition
+//==============================================================================
+
+const jsi_runtime_vtable g_vtable = {
+    /* query_interface */ jsi_query_interface,
+    /* get_abi_version */ jsi_get_abi_version,
+    /* add_ref */ jsi_add_ref,
+    /* release */ jsi_release,
+
+    /* get_and_clear_js_error_value */ jsi_get_and_clear_js_error_value,
+    /* get_and_clear_native_exception_message */
+    jsi_get_and_clear_native_exception_message,
+    /* set_js_error_value */ jsi_set_js_error_value,
+    /* set_native_exception_message */ jsi_set_native_exception_message,
+
+    /* clone_propnameid */ jsi_clone_propnameid,
+    /* clone_string */ jsi_clone_string,
+    /* clone_symbol */ jsi_clone_symbol,
+    /* clone_object */ jsi_clone_object,
+    /* clone_bigint */ jsi_clone_bigint,
+
+    /* get_description */ jsi_get_description,
+    /* is_inspectable */ jsi_is_inspectable,
+
+    /* push_scope */ jsi_push_scope,
+    /* pop_scope */ jsi_pop_scope,
+
+    /* evaluate_javascript_source */ jsi_evaluate_javascript_source,
+    /* prepare_javascript */ jsi_prepare_javascript,
+    /* evaluate_prepared_javascript */ jsi_evaluate_prepared_javascript,
+
+    /* drain_microtasks */ jsi_drain_microtasks,
+    /* queue_microtask */ jsi_queue_microtask,
+
+    /* get_global_object */ jsi_get_global_object,
+
+    /* create_string_from_utf8 */ jsi_create_string_from_utf8,
+    /* create_string_from_utf16 */ jsi_create_string_from_utf16,
+    /* get_utf8_from_string */ jsi_get_utf8_from_string,
+    /* get_utf16_from_string */ jsi_get_utf16_from_string,
+
+    /* get_utf8_from_symbol */ jsi_get_utf8_from_symbol,
+
+    /* create_propnameid_from_utf8 */ jsi_create_propnameid_from_utf8,
+    /* create_propnameid_from_string */ jsi_create_propnameid_from_string,
+    /* create_propnameid_from_symbol */ jsi_create_propnameid_from_symbol,
+    /* prop_name_id_equals */ jsi_prop_name_id_equals,
+    /* get_utf8_from_propnameid */ jsi_get_utf8_from_propnameid,
+
+    /* create_object */ jsi_create_object,
+    /* create_object_with_prototype */ jsi_create_object_with_prototype,
+    /* get_prototype_of */ jsi_get_prototype_of,
+    /* set_prototype_of */ jsi_set_prototype_of,
+
+    /* has_object_property_from_propnameid */
+    jsi_has_object_property_from_propnameid,
+    /* get_object_property_from_propnameid */
+    jsi_get_object_property_from_propnameid,
+    /* set_object_property_from_propnameid */
+    jsi_set_object_property_from_propnameid,
+    /* delete_property_from_propnameid */ jsi_delete_property_from_propnameid,
+
+    /* has_object_property_from_value */ jsi_has_object_property_from_value,
+    /* get_object_property_from_value */ jsi_get_object_property_from_value,
+    /* set_object_property_from_value */ jsi_set_object_property_from_value,
+    /* delete_property_from_value */ jsi_delete_property_from_value,
+
+    /* get_object_property_names */ jsi_get_object_property_names,
+    /* set_object_external_memory_pressure */
+    jsi_set_object_external_memory_pressure,
+    /* create_error */ jsi_create_error,
+
+    /* create_array */ jsi_create_array,
+    /* get_array_length */ jsi_get_array_length,
+    /* get_array_element */ jsi_get_array_element,
+    /* set_array_element */ jsi_set_array_element,
+
+    /* create_arraybuffer */ jsi_create_arraybuffer,
+    /* create_arraybuffer_from_external_data */
+    jsi_create_arraybuffer_from_external_data,
+    /* get_arraybuffer_data */ jsi_get_arraybuffer_data,
+    /* get_arraybuffer_size */ jsi_get_arraybuffer_size,
+
+    /* call */ jsi_call,
+    /* call_as_constructor */ jsi_call_as_constructor,
+    /* create_function_from_host_function */
+    jsi_create_function_from_host_function,
+    /* get_host_function */ jsi_get_host_function,
+
+    /* create_object_from_host_object */ jsi_create_object_from_host_object,
+    /* get_host_object */ jsi_get_host_object,
+
+    /* has_native_state */ jsi_has_native_state,
+    /* get_native_state */ jsi_get_native_state,
+    /* set_native_state */ jsi_set_native_state,
+
+    /* object_is_array */ jsi_object_is_array,
+    /* object_is_arraybuffer */ jsi_object_is_arraybuffer,
+    /* object_is_function */ jsi_object_is_function,
+
+    /* create_weak_object */ jsi_create_weak_object,
+    /* lock_weak_object */ jsi_lock_weak_object,
+
+    /* instance_of */ jsi_instance_of,
+    /* strict_equals_symbol */ jsi_strict_equals_symbol,
+    /* strict_equals_bigint */ jsi_strict_equals_bigint,
+    /* strict_equals_string */ jsi_strict_equals_string,
+    /* strict_equals_object */ jsi_strict_equals_object,
+
+    /* create_bigint_from_int64 */ jsi_create_bigint_from_int64,
+    /* create_bigint_from_uint64 */ jsi_create_bigint_from_uint64,
+    /* bigint_is_int64 */ jsi_bigint_is_int64,
+    /* bigint_is_uint64 */ jsi_bigint_is_uint64,
+    /* bigint_truncate_to_uint64 */ jsi_bigint_truncate_to_uint64,
+    /* bigint_to_int64 */ jsi_bigint_to_int64,
+    /* bigint_to_uint64 */ jsi_bigint_to_uint64,
+    /* bigint_to_string */ jsi_bigint_to_string,
+};
+
+} // anonymous namespace
+
+//==============================================================================
+// Internal Accessors (jsi_abi_v8_internal.h)
+//==============================================================================
+//
+// These are internal-coupling accessors exposed to other TUs compiled into
+// v8jsi.dll (currently node-api/v8_api_abi.cpp). They reach into the
+// anonymous-namespaced JsiRuntimeState without leaking its layout.
+
+namespace v8rt_internal {
+
+namespace {
+inline JsiRuntimeState *toState(jsi_runtime *runtime) noexcept {
+  return static_cast<JsiRuntimeState *>(runtime);
+}
+}  // namespace
+
+v8::Isolate *getIsolate(jsi_runtime *runtime) noexcept {
+  return toState(runtime)->isolate;
+}
+
+v8::Global<v8::Context> &getContext(jsi_runtime *runtime) noexcept {
+  return toState(runtime)->context;
+}
+
+v8::Local<v8::Context> getContextLocal(jsi_runtime *runtime) noexcept {
+  return toState(runtime)->getContextLocal();
+}
+
+bool getEnableMultiThread(jsi_runtime *runtime) noexcept {
+  return toState(runtime)->enableMultiThread;
+}
+
+bool hasUnhandledPromiseRejection(jsi_runtime *runtime) noexcept {
+  return !!toState(runtime)->last_unhandled_promise;
+}
+
+std::unique_ptr<v8rt::UnhandledPromiseRejection>
+takeLastUnhandledPromiseRejection(jsi_runtime *runtime) noexcept {
+  return std::exchange(toState(runtime)->last_unhandled_promise, nullptr);
+}
+
+ScriptCacheCallbacks getScriptCacheCallbacks(jsi_runtime *runtime) noexcept {
+  auto *state = toState(runtime);
+  return ScriptCacheCallbacks{
+      state->script_cache_data,
+      state->script_cache_load_cb,
+      state->script_cache_store_cb};
+}
+
+void setAttachedOwner(jsi_runtime *runtime,
+                      void *attached,
+                      RuntimeAttachedDestroyCb destroy_cb) noexcept {
+  auto *state = toState(runtime);
+  state->attached_owner = attached;
+  state->attached_owner_destroy = destroy_cb;
+}
+
+void clearAttachedOwner(jsi_runtime *runtime) noexcept {
+  auto *state = toState(runtime);
+  state->attached_owner = nullptr;
+  state->attached_owner_destroy = nullptr;
+}
+
+}  // namespace v8rt_internal
+
+//==============================================================================
+// Entry Point
+//==============================================================================
+
+extern "C" {
+
+// Flat runtime-creation export (replaces the dropped jsi_vtable factory).
+// requested_abi_version is the consumer's compiled JSI_ABI_VERSION; configure
+// (may be NULL) populates a factory-owned jsi_config via the v8_jsi_config_set_*
+// setters. Returns NULL on version mismatch or configure failure.
+JSI_API jsi_runtime *JSI_CDECL v8_create_runtime(
+    uint32_t requested_abi_version,
+    jsi_configure_runtime_cb configure,
+    void *configure_data) {
+  // Model B version negotiation: refuse a version newer than we implement.
+  if (requested_abi_version > JSI_ABI_VERSION)
+    return nullptr;
+
+  jsi_runtime *rt = nullptr;
+  if (configure) {
+    // Factory owns the config: allocate it, let the consumer populate it via
+    // the setters, consume it, then let it destruct. The handle never escapes
+    // the callback. JsiRuntimeState::create clears the cache/task-runner
+    // pointers it takes over, so ~jsi_config_s does not double-fire; on a
+    // configure abort, ~jsi_config_s fires any registered deleters exactly once.
+    jsi_config_s config;
+    if (configure(configure_data, &config) != jsi_no_error)
+      return nullptr;
+    rt = JsiRuntimeState::create(&config);
+  } else {
+    // No configure callback → engine defaults. Passing nullptr selects the
+    // historical default-init path (distinct from a zero-initialized config).
+    rt = JsiRuntimeState::create(nullptr);
+  }
+
+  if (rt) {
+    // Pin the runtime to the negotiated version (reserved for future
+    // behavioral branching; get_abi_version reports the impl max).
+    static_cast<JsiRuntimeState *>(rt)->abi_version = requested_abi_version;
+  }
+  return rt;
+}
+
+// Process-global V8 engine flags. Raw CLI-style pass-through to V8 — these are
+// process-global and consumed only on the first platform init, so they are NOT
+// per-runtime config. Must be called before the first v8_create_runtime.
+JSI_API void JSI_CDECL v8_jsi_set_v8_flags(
+    size_t *argc, char **argv, bool remove_flags) {
+  if (!argc || !argv)
+    return;
+  int n = static_cast<int>(*argc);
+  v8::V8::SetFlagsFromCommandLine(&n, argv, remove_flags);
+  *argc = n < 0 ? 0u : static_cast<size_t>(n);
+}
+
+// W5 inspector entry point. Pure-C replacement for the legacy
+// openInspector(jsi::Runtime &) and openInspectors_toberemoved() exports.
+// Starts a previously-quiet Agent (e.g. when enable_inspector was set on the
+// config but inspector_break_on_start was false). Safe to call multiple times.
+JSI_API void JSI_CDECL v8_open_inspector(jsi_runtime *runtime) {
+#if defined(_WIN32) && defined(V8JSI_ENABLE_INSPECTOR)
+  if (!runtime) return;
+  auto *state = static_cast<JsiRuntimeState *>(runtime);
+  if (state->inspector_agent) {
+    state->inspector_agent->start();
+  }
+#else
+  (void)runtime;
+#endif
+}
+
+// W4 test-only hook: post a synthetic task to the runtime's foreground task
+// runner. Gated behind JSI_TESTING_ONLY (gyp variable v8jsi_test_hooks) so
+// release builds can drop it. Not declared in any public header; the test
+// forward-declares it inline.
+#ifdef JSI_TESTING_ONLY
+JSI_API void JSI_CDECL v8_jsi_test_post_foreground_task(
+    jsi_runtime *runtime,
+    void (JSI_CDECL *task_run_cb)(void *),
+    void *task_data) {
+  if (!runtime || !task_run_cb)
+    return;
+  auto *state = static_cast<JsiRuntimeState *>(runtime);
+  auto runner = v8rt::IsolateData::fromIsolate(state->isolate)->taskRunner();
+  if (!runner)
+    return;
+  struct InlineTask final : public v8rt::TaskRunner::Task {
+    void (JSI_CDECL *cb)(void *);
+    void *data;
+    void run() override { cb(data); }
+  };
+  auto task = std::make_unique<InlineTask>();
+  task->cb = task_run_cb;
+  task->data = task_data;
+  runner->postTask(std::move(task));
+}
+#endif  // JSI_TESTING_ONLY
+
+//==============================================================================
+// V8 jsi_config — public C API
+//==============================================================================
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_initial_heap_size(jsi_config config, size_t bytes) {
+  if (config) config->initial_heap_size_in_bytes = bytes;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_maximum_heap_size(jsi_config config, size_t bytes) {
+  if (config) config->maximum_heap_size_in_bytes = bytes;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_thread_pool_size(jsi_config config, uint8_t size) {
+  if (config) config->thread_pool_size = size;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_debugger_runtime_name(jsi_config config, const char *name) {
+  if (config) config->debugger_runtime_name = (name ? name : "");
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_inspector(jsi_config config, bool value) {
+  if (config) config->enable_inspector = value;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_inspector_port(jsi_config config, uint16_t port) {
+  if (config) config->inspector_port = port;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_inspector_break_on_start(jsi_config config, bool value) {
+  if (config) config->inspector_break_on_start = value;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_explicit_microtask_policy(jsi_config config, bool value) {
+  if (config) config->explicit_microtask_policy = value;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_ignore_unhandled_promises(jsi_config config, bool value) {
+  if (config) config->ignore_unhandled_promises = value;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_gc_api(jsi_config config, bool value) {
+  if (config) config->enable_gc_api = value;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_multi_thread(jsi_config config, bool value) {
+  if (config) config->enable_multi_thread = value;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_jit_tracing(jsi_config config, bool value) {
+  if (config) config->enable_jit_tracing = value;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_message_tracing(jsi_config config, bool value) {
+  if (config) config->enable_message_tracing = value;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_gc_tracing(jsi_config config, bool value) {
+  if (config) config->enable_gc_tracing = value;
+}
+
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_system_instrumentation(jsi_config config, bool value) {
+  if (config) config->enable_system_instrumentation = value;
+}
+
+JSI_API void JSI_CDECL v8_jsi_config_set_script_cache(
+    jsi_config config,
+    void *script_cache_data,
+    v8_jsi_script_cache_load_cb load_cb,
+    v8_jsi_script_cache_store_cb store_cb,
+    jsi_data_delete_cb script_cache_data_delete_cb,
+    void *deleter_data) {
+  if (!config) {
+    // Nothing owns script_cache_data; release it immediately.
+    if (script_cache_data_delete_cb)
+      script_cache_data_delete_cb(script_cache_data, deleter_data);
+    return;
+  }
+  // Release any previously-set cache before overwriting.
+  if (config->script_cache_data_delete_cb) {
+    config->script_cache_data_delete_cb(
+        config->script_cache_data, config->script_cache_deleter_data);
+  }
+  config->script_cache_data = script_cache_data;
+  config->script_cache_load_cb = load_cb;
+  config->script_cache_store_cb = store_cb;
+  config->script_cache_data_delete_cb = script_cache_data_delete_cb;
+  config->script_cache_deleter_data = deleter_data;
+}
+
+JSI_API void JSI_CDECL v8_jsi_config_set_task_runner(
+    jsi_config config,
+    void *task_runner_data,
+    v8_jsi_task_runner_post_task_cb post_task_cb,
+    jsi_data_delete_cb task_runner_data_delete_cb,
+    void *deleter_data) {
+  if (!config) {
+    // Nothing owns task_runner_data; release it immediately.
+    if (task_runner_data_delete_cb)
+      task_runner_data_delete_cb(task_runner_data, deleter_data);
+    return;
+  }
+  // Release any previously-set task runner before overwriting.
+  if (config->task_runner_data_delete_cb) {
+    config->task_runner_data_delete_cb(
+        config->task_runner_data, config->task_runner_deleter_data);
+  }
+  config->task_runner_data = task_runner_data;
+  config->task_runner_post_task_cb = post_task_cb;
+  config->task_runner_data_delete_cb = task_runner_data_delete_cb;
+  config->task_runner_deleter_data = deleter_data;
+}
+
+} // extern "C"

--- a/src/jsi_abi/jsi_abi_v8_internal.h
+++ b/src/jsi_abi/jsi_abi_v8_internal.h
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// Internal accessor functions for JsiRuntimeState. Used only by code
+// compiled into v8jsi.dll (currently jsi_abi_v8.cpp + node-api/v8_api_abi.cpp).
+// JsiRuntimeState's full layout is anonymous-namespaced inside
+// jsi_abi_v8.cpp; these free functions expose the bits the Node-API surface
+// needs without leaking the struct shape (host-object proxies, host-function
+// contexts, ABI handle types, etc.) into other TUs.
+//
+// Do NOT include this from a public header.
+
+#pragma once
+
+#include "jsi_abi/jsi_abi.h"
+#include "jsi_abi/v8_jsi_config.h"
+#include "../v8_core.h"
+#include "v8.h"
+
+#include <memory>
+
+namespace v8rt_internal {
+
+/// Direct V8 isolate accessor for the runtime.
+v8::Isolate *getIsolate(jsi_runtime *runtime) noexcept;
+
+/// Direct V8 context accessor (persistent global).
+v8::Global<v8::Context> &getContext(jsi_runtime *runtime) noexcept;
+
+/// Direct V8 context accessor (handle-scoped local).
+v8::Local<v8::Context> getContextLocal(jsi_runtime *runtime) noexcept;
+
+/// Whether the runtime was constructed with multi-threaded isolate access.
+/// Used to decide whether v8::Locker should be acquired around scoped work.
+bool getEnableMultiThread(jsi_runtime *runtime) noexcept;
+
+/// True if a previous unhandled promise rejection has been recorded and
+/// not yet cleared.
+bool hasUnhandledPromiseRejection(jsi_runtime *runtime) noexcept;
+
+/// Take ownership of the most recent unhandled-promise-rejection record.
+/// Subsequent calls return null until a new rejection is recorded.
+std::unique_ptr<v8rt::UnhandledPromiseRejection>
+takeLastUnhandledPromiseRejection(jsi_runtime *runtime) noexcept;
+
+/// Snapshot of the consumer-supplied script-cache C callbacks. Held inside
+/// JsiRuntimeState; Node-API's prepareScript/runPreparedScript path uses
+/// these to honor the same cache the JSI side honors.
+struct ScriptCacheCallbacks {
+  void *data;
+  v8_jsi_script_cache_load_cb load_cb;
+  v8_jsi_script_cache_store_cb store_cb;
+};
+ScriptCacheCallbacks getScriptCacheCallbacks(jsi_runtime *runtime) noexcept;
+
+/// Type for the attached-Node-API teardown callback. Called from
+/// ~JsiRuntimeState before any V8 state is freed.
+typedef void (*RuntimeAttachedDestroyCb)(void *attached);
+
+/// Register an attached-owner cleanup hook on the runtime. Used by
+/// v8_attach_node_api so ~JsiRuntimeState tears down the napi surface before
+/// disposing the V8 isolate. Only one attachment is supported per runtime;
+/// re-attaching while a previous attachment is live is a programming error.
+void setAttachedOwner(jsi_runtime *runtime,
+                      void *attached,
+                      RuntimeAttachedDestroyCb destroy_cb) noexcept;
+
+/// Clear the attached-owner hook without invoking it. Called from the
+/// attached-owner's own destructor when it is being destroyed manually
+/// (e.g. via RuntimeWrapper teardown ordering) so ~JsiRuntimeState does not
+/// double-fire the destroy callback.
+void clearAttachedOwner(jsi_runtime *runtime) noexcept;
+
+}  // namespace v8rt_internal

--- a/src/jsi_abi/v8_jsi_config.h
+++ b/src/jsi_abi/v8_jsi_config.h
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * V8-specific configuration for the JSI ABI factory.
+ *
+ * Mirrors the established jsr_config / v8_api split next door (see
+ * src/node-api/js_runtime_api.h and src/node-api/v8_api.h):
+ *   - jsi_config (declared in jsi_abi.h) is the engine-agnostic opaque type.
+ *   - v8_create_runtime + the v8_jsi_config_set_* functions in this header are
+ *     V8-specific. A future Hermes ABI port can add hermes_create_runtime and
+ *     hermes_jsi_config_set_* setters against the same opaque jsi_config type.
+ *
+ * The DLL owns the config layout AND its lifetime: v8_create_runtime allocates
+ * the jsi_config, hands it to the consumer's jsi_configure_runtime_cb to be
+ * populated via the setters, then frees it. Consumers never create or destroy a
+ * config; they only see the opaque handle inside the callback. Adding a new V8
+ * flag in the future is a new setter — no struct version to bump, no field-order
+ * contract to preserve.
+ *
+ * Pure C header. Safe to include from C or C++.
+ */
+
+/* ===========================================================================
+ * EXPERIMENTAL API - NOT YET ABI-STABLE
+ *
+ * This API is experimental and subject to change. Although it is C-based, it is
+ * NOT ABI-safe yet: function signatures, vtable layouts, struct fields, enum
+ * values, and error codes may change without notice while the API remains in
+ * experimental mode. Do not depend on binary compatibility across builds. Once
+ * the API leaves experimental mode it will become ABI-stable and this notice
+ * will be removed.
+ * =========================================================================== */
+
+#ifndef V8_JSI_CONFIG_H
+#define V8_JSI_CONFIG_H
+
+#include "jsi_abi/jsi_abi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*============================================================================
+ * Runtime creation
+ *============================================================================*/
+
+/* Create a V8-backed jsi_runtime.
+ *
+ * requested_abi_version: the JSI_ABI_VERSION the consumer compiled against.
+ *   Returns NULL if it exceeds the implementation's max (Model B pin-or-fail).
+ * configure: invoked with a factory-owned jsi_config so the consumer can set
+ *   fields via the v8_jsi_config_set_* setters below. May be NULL (defaults).
+ *   The config handle is valid only for the duration of that callback. If
+ *   configure returns a non-zero jsi_error_code, creation aborts and this
+ *   returns NULL.
+ * configure_data: opaque context passed straight through to configure.
+ *
+ * The returned runtime has refcount 1 (release via the runtime vtable). */
+JSI_API jsi_runtime *JSI_CDECL v8_create_runtime(
+    uint32_t requested_abi_version,
+    jsi_configure_runtime_cb configure,
+    void *configure_data);
+
+/*============================================================================
+ * Heap / threading
+ *============================================================================*/
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_initial_heap_size(jsi_config config, size_t bytes);
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_maximum_heap_size(jsi_config config, size_t bytes);
+
+/* Cap the V8 worker thread pool. 0 means default
+ * (V8 picks min(num_cores - 1, 16)). */
+JSI_API void JSI_CDECL
+v8_jsi_config_set_thread_pool_size(jsi_config config, uint8_t size);
+
+/*============================================================================
+ * Inspector / debugger
+ *============================================================================*/
+
+/* Name shown in the inspector UI to distinguish parallel runtimes. */
+JSI_API void JSI_CDECL
+v8_jsi_config_set_debugger_runtime_name(jsi_config config, const char *name);
+
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_inspector(jsi_config config, bool value);
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_inspector_port(jsi_config config, uint16_t port);
+
+JSI_API void JSI_CDECL
+v8_jsi_config_set_inspector_break_on_start(jsi_config config, bool value);
+
+/*============================================================================
+ * Microtasks / promises
+ *============================================================================*/
+
+/* If true, the runtime uses MicrotasksPolicy::kExplicit and the host must
+ * drain microtasks itself. Default is false (V8 default policy). */
+JSI_API void JSI_CDECL
+v8_jsi_config_set_explicit_microtask_policy(jsi_config config, bool value);
+
+/* If true, the PromiseRejectCallback that tracks unhandled rejections is
+ * NOT installed. Default is false (track rejections). */
+JSI_API void JSI_CDECL
+v8_jsi_config_set_ignore_unhandled_promises(jsi_config config, bool value);
+
+/*============================================================================
+ * GC
+ *============================================================================*/
+
+/* Expose the global gc() function (passes --expose_gc to V8). */
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_gc_api(jsi_config config, bool value);
+
+/*============================================================================
+ * Concurrency
+ *============================================================================*/
+
+/* Wrap isolate access in v8::Locker for multi-threaded use. */
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_multi_thread(jsi_config config, bool value);
+
+/*============================================================================
+ * Tracing
+ *============================================================================*/
+
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_jit_tracing(jsi_config config, bool value);
+
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_message_tracing(jsi_config config, bool value);
+
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_gc_tracing(jsi_config config, bool value);
+
+/* V8 ETW provider GUID 57277741-3638-4A4B-BDBA-0AC6E45DA56C
+ * (passes --enable-system-instrumentation to V8). */
+JSI_API void JSI_CDECL
+v8_jsi_config_enable_system_instrumentation(jsi_config config, bool value);
+
+/*============================================================================
+ * Process-global V8 engine flags
+ *
+ * V8 command-line flags are PROCESS-GLOBAL and consumed only during the first
+ * platform initialization (the first v8_create_runtime). They are exposed raw,
+ * CLI-style, NOT as per-runtime config setters — a per-runtime field for a
+ * process-global value would be silently ignored after the first runtime.
+ *
+ * Call this BEFORE the first v8_create_runtime. argv uses V8 CLI flag syntax
+ * (e.g. "--sparkplug", "--jitless", "--optimize_for_size",
+ * "--max-old-space-size=512"). Forwarded to V8::SetFlagsFromCommandLine.
+ *
+ * remove_flags=true: V8 removes the flags it recognized from argv, compacts the
+ * remaining (unrecognized) entries to the front, and updates *argc to that
+ * count — letting the caller report leftover/unknown flags (the Node trick).
+ *============================================================================*/
+
+JSI_API void JSI_CDECL
+v8_jsi_set_v8_flags(size_t *argc, char **argv, bool remove_flags);
+
+/*============================================================================
+ * Script cache (prepared-script storage)
+ *
+ * Mirrors jsr_config_set_script_cache in src/node-api/js_runtime_api.h
+ * byte-for-byte. Consumers register a pair of C callbacks that load and store
+ * compiled bytecode on behalf of jsi_prepare_javascript. NULL callbacks mean
+ * "no cache" — prepare always falls back to fresh V8 compilation.
+ *
+ * Lifetime: when the setter is called the config takes ownership of
+ * script_cache_data; on runtime construction the runtime takes over (the
+ * config's pointer is cleared so it isn't deleted twice). When the runtime
+ * is destroyed it invokes script_cache_data_delete_cb(script_cache_data,
+ * deleter_data) exactly once. The config shell itself is owned by the factory:
+ * v8_create_runtime frees it after the configure callback returns (the runtime
+ * having already taken over the data); if configure aborts before the runtime
+ * is built, the config's destructor fires the deleter so nothing leaks.
+ *============================================================================*/
+
+typedef void (JSI_CDECL *v8_jsi_script_cache_load_cb)(
+    void *script_cache_data,
+    const char *source_url,
+    uint64_t source_hash,
+    const char *runtime_name,
+    uint64_t runtime_version,
+    const char *cache_tag,
+    const uint8_t **buffer,                /* out */
+    size_t *buffer_size,                   /* out */
+    jsi_data_delete_cb *buffer_delete_cb,  /* out */
+    void **deleter_data);                  /* out */
+
+typedef void (JSI_CDECL *v8_jsi_script_cache_store_cb)(
+    void *script_cache_data,
+    const char *source_url,
+    uint64_t source_hash,
+    const char *runtime_name,
+    uint64_t runtime_version,
+    const char *cache_tag,
+    const uint8_t *buffer,
+    size_t buffer_size,
+    jsi_data_delete_cb buffer_delete_cb,
+    void *deleter_data);
+
+JSI_API void JSI_CDECL v8_jsi_config_set_script_cache(
+    jsi_config config,
+    void *script_cache_data,
+    v8_jsi_script_cache_load_cb load_cb,
+    v8_jsi_script_cache_store_cb store_cb,
+    jsi_data_delete_cb script_cache_data_delete_cb,
+    void *deleter_data);
+
+/*============================================================================
+ * Task runner (foreground-thread dispatch)
+ *
+ * Mirrors jsr_config_set_task_runner in src/node-api/js_runtime_api.h
+ * byte-for-byte. The foreground task runner is how the inspector dispatches
+ * incoming debugger messages onto the JS thread (see inspector_agent.cpp).
+ * NULL post_task_cb means "no task runner" — V8 falls back to its default
+ * platform runner.
+ *
+ * Lifetime: when the setter is called the config takes ownership of
+ * task_runner_data; on runtime construction the runtime takes over (the
+ * config's pointer is cleared so it isn't deleted twice). The runtime holds
+ * the task runner inside the V8 IsolateData via a shared_ptr; when the
+ * runtime is destroyed the shared_ptr drops, the internal adapter destructs,
+ * and task_runner_data_delete_cb(task_runner_data, deleter_data) runs
+ * exactly once. The config shell itself is owned by the factory:
+ * v8_create_runtime frees it after the configure callback returns; if configure
+ * aborts before the runtime is built, the config's destructor fires the deleter
+ * so nothing leaks.
+ *============================================================================*/
+
+typedef void (JSI_CDECL *v8_jsi_task_run_cb)(void *task_data);
+
+typedef void (JSI_CDECL *v8_jsi_task_runner_post_task_cb)(
+    void *task_runner_data,
+    void *task_data,
+    v8_jsi_task_run_cb task_run_cb,
+    jsi_data_delete_cb task_data_delete_cb,
+    void *deleter_data);
+
+JSI_API void JSI_CDECL v8_jsi_config_set_task_runner(
+    jsi_config config,
+    void *task_runner_data,
+    v8_jsi_task_runner_post_task_cb post_task_cb,
+    jsi_data_delete_cb task_runner_data_delete_cb,
+    void *deleter_data);
+
+/*============================================================================
+ * Inspector control
+ *
+ * The inspector is wired into v8_create_runtime when enable_inspector is true
+ * on the config (see v8_jsi_config_enable_inspector). v8_open_inspector starts
+ * a previously-quiet inspector on a runtime that was created with the flag
+ * set. Mirrors the legacy openInspector(jsi::Runtime &) entry point but takes
+ * an opaque jsi_runtime so it does not depend on a JSI Runtime layout (no CRT
+ * boundary leaks).
+ *
+ * Pure C export — does not go through query_interface.
+ *============================================================================*/
+
+JSI_API void JSI_CDECL v8_open_inspector(jsi_runtime *runtime);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* V8_JSI_CONFIG_H */
+
+/*============================================================================
+ * Note: v8_attach_node_api lives in src/jsi_abi/v8_node_api_attach.h. It is
+ * kept out of this header so consumers of the v8 jsi config do not have to
+ * pull in the Node-API headers (napi_env / napi_status types).
+ *============================================================================*/

--- a/src/jsi_abi/v8_node_api_attach.h
+++ b/src/jsi_abi/v8_node_api_attach.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * v8_attach_node_api — attach a Node-API surface (napi_env) onto an existing
+ * jsi_runtime that was created via v8_create_runtime. This is the seam that
+ * preserves the dual-API contract after W8: a consumer can hold one V8
+ * isolate exposed simultaneously through JSI (jsi_runtime / JsiAbiRuntime)
+ * and Node-API (napi_env). Internally jsr_create_runtime is now a thin
+ * wrapper that calls v8_create_runtime + v8_attach_node_api.
+ *
+ * Lifetime: the jsi_runtime is the primary owner. Releasing the jsi_runtime
+ * (via the ABI vtable's release hook, or implicitly via JsiAbiRuntime's
+ * destructor) tears down the napi_env first. The consumer should not call
+ * Unref on the napi_env unless they also called Ref on it explicitly.
+ *
+ * This header lives separate from v8_jsi_config.h so consumers of the JSI
+ * ABI config surface do not have to pull in Node-API headers.
+ */
+
+/* ===========================================================================
+ * EXPERIMENTAL API - NOT YET ABI-STABLE
+ *
+ * This API is experimental and subject to change. Although it is C-based, it is
+ * NOT ABI-safe yet: function signatures, vtable layouts, struct fields, enum
+ * values, and error codes may change without notice while the API remains in
+ * experimental mode. Do not depend on binary compatibility across builds. Once
+ * the API leaves experimental mode it will become ABI-stable and this notice
+ * will be removed.
+ * =========================================================================== */
+
+#ifndef V8_NODE_API_ATTACH_H
+#define V8_NODE_API_ATTACH_H
+
+#include "jsi_abi/jsi_abi.h"
+#include "node-api/js_runtime_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Build a Node-API surface (napi_env) over an existing jsi_runtime. The new
+ * env shares the runtime's V8 isolate and context. */
+JSI_API napi_status JSI_CDECL v8_attach_node_api(struct jsi_runtime *runtime,
+                                                  int32_t api_version,
+                                                  napi_env *env_out);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* V8_NODE_API_ATTACH_H */

--- a/src/jsitests_main.cpp
+++ b/src/jsitests_main.cpp
@@ -1,0 +1,546 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// JSI tests main file - uses V8JsiRuntime without Node-API
+
+#include <gtest/gtest.h>
+#include <jsi/jsi.h>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+#include "jsi/test/testlib.h"
+#include "public/ScriptStore.h"
+#include "public/V8JsiRuntime.h"
+#include "jsi_abi/JsiAbiRuntime.h"
+#include "jsi_abi/jsi_abi_helpers.h"
+#include "jsi_abi/v8_jsi_config.h"
+#include "js_runtime_api.h"
+
+// W4 test-only hook (declared in jsi_abi_v8.cpp). Posts a task to the
+// runtime's foreground task runner — used by JsiAbiTaskRunner.LifecycleAndPostTask
+// to exercise the post-task trampoline without an inspector session.
+extern "C" JSI_API void JSI_CDECL v8_jsi_test_post_foreground_task(
+    jsi_runtime *runtime,
+    void (JSI_CDECL *task_run_cb)(void *),
+    void *task_data);
+
+namespace facebook::jsi {
+
+// Runtime index constants for identifying which runtime is being tested
+constexpr size_t kDirectRuntimeIndex = 0;
+constexpr size_t kAbiRuntimeIndex = 1;
+
+std::vector<facebook::jsi::RuntimeFactory> runtimeGenerators() {
+  return std::vector<facebook::jsi::RuntimeFactory>{
+      // Index 0: Direct V8JsiRuntime (C++ interface)
+      []() -> std::shared_ptr<facebook::jsi::Runtime> {
+        v8runtime::V8RuntimeArgs args;
+        args.flags.explicitMicrotaskPolicy = true;
+        args.flags.enableGCApi = true;
+        return v8runtime::makeV8Runtime(std::move(args));
+      },
+      // Index 1: V8JsiRuntime via ABI-stable C interface
+      []() -> std::shared_ptr<facebook::jsi::Runtime> {
+        return ::jsi::abi::makeJsiAbiRuntime(&v8_create_runtime);
+      },
+  };
+}
+
+// Helper to check if current test parameter is the ABI runtime
+// Use in tests: if (isAbiRuntime()) GTEST_SKIP() << "Not yet supported in ABI runtime";
+bool isAbiRuntime() {
+  auto* testInfo = ::testing::UnitTest::GetInstance()->current_test_info();
+  if (!testInfo) return false;
+
+  // Parameter index is in the test name suffix: TestName/0 or TestName/1
+  std::string name = testInfo->name();
+  size_t slashPos = name.rfind('/');
+  if (slashPos != std::string::npos && slashPos + 1 < name.size()) {
+    return name.substr(slashPos + 1) == std::to_string(kAbiRuntimeIndex);
+  }
+  return false;
+}
+
+} // namespace facebook::jsi
+
+using namespace facebook::jsi;
+
+TEST(Basic, CreateOneRuntimes) {
+  v8runtime::V8RuntimeArgs args;
+  args.flags.enableInspector = false;  // Inspector disabled for now
+  args.flags.enableGCApi = true;
+  auto runtime = v8runtime::makeV8Runtime(std::move(args));
+
+  runtime->evaluateJavaScript(std::make_unique<facebook::jsi::StringBuffer>("x = 1"), "");
+  EXPECT_EQ(runtime->global().getProperty(*runtime, "x").getNumber(), 1);
+}
+
+TEST(Basic, CreateManyRuntimes) {
+  for (size_t i = 0; i < 100; i++) {
+    v8runtime::V8RuntimeArgs args;
+    args.flags.enableInspector = false;
+    auto runtime = v8runtime::makeV8Runtime(std::move(args));
+
+    runtime->evaluateJavaScript(std::make_unique<facebook::jsi::StringBuffer>("x = 1"), "");
+    EXPECT_EQ(runtime->global().getProperty(*runtime, "x").getNumber(), 1);
+  }
+}
+
+TEST(Basic, MultiThreadIsolate) {
+  v8runtime::V8RuntimeArgs args;
+  args.flags.enableMultiThread = true;
+  auto runtime = v8runtime::makeV8Runtime(std::move(args));
+
+  runtime->evaluateJavaScript(
+      std::make_unique<facebook::jsi::StringBuffer>("x = {1:2, '3':4, 5:'six', 'seven':['eight', 'nine']}"), "");
+
+  Runtime &rt = *runtime;
+
+  Object x = rt.global().getPropertyAsObject(rt, "x");
+  EXPECT_EQ(x.getProperty(rt, "1").getNumber(), 2);
+
+  std::vector<std::thread> vec_thr;
+  for (size_t i = 0; i < 10; ++i) {
+    vec_thr.push_back(std::thread([&]() {
+      EXPECT_EQ(x.getProperty(rt, PropNameID::forAscii(rt, "1")).getNumber(), 2);
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      EXPECT_EQ(x.getProperty(rt, "3").getNumber(), 4);
+    }));
+  }
+
+  for (size_t i = 0; i < vec_thr.size(); ++i) {
+    vec_thr.at(i).join();
+  }
+}
+
+// W1 smoke test: end-to-end exercise of the v8_jsi_config plumbing.
+// Populates a factory-owned config via the public C setters inside the
+// configure callback, and confirms a basic eval works. Does not (and cannot)
+// verify that V8 actually applied the requested flags — V8 platform-flag state
+// is process-global and first-init-only, and these tests share a process.
+TEST(JsiAbiConfig, RuntimeFromConfigEvaluates) {
+  // The factory owns the jsi_config; we populate it inside the configure
+  // callback (pull model). Touch a representative subset of every field group
+  // to confirm linkage.
+  jsi_configure_runtime_cb configure = [](void * /*cb_data*/,
+                                          jsi_config cfg) -> jsi_error_code {
+    v8_jsi_config_set_initial_heap_size(cfg, 0);
+    v8_jsi_config_set_maximum_heap_size(cfg, 0);
+    v8_jsi_config_set_thread_pool_size(cfg, 0);
+    v8_jsi_config_set_debugger_runtime_name(cfg, "w1-smoke");
+    v8_jsi_config_enable_inspector(cfg, false);
+    v8_jsi_config_set_inspector_port(cfg, 9223);
+    v8_jsi_config_set_inspector_break_on_start(cfg, false);
+    v8_jsi_config_set_explicit_microtask_policy(cfg, true);
+    v8_jsi_config_set_ignore_unhandled_promises(cfg, false);
+    v8_jsi_config_enable_gc_api(cfg, true);
+    v8_jsi_config_enable_multi_thread(cfg, false);
+    v8_jsi_config_enable_jit_tracing(cfg, false);
+    v8_jsi_config_enable_message_tracing(cfg, false);
+    v8_jsi_config_enable_gc_tracing(cfg, false);
+    v8_jsi_config_enable_system_instrumentation(cfg, false);
+    return jsi_no_error;
+  };
+
+  std::shared_ptr<facebook::jsi::Runtime> runtime =
+      ::jsi::abi::makeJsiAbiRuntime(&v8_create_runtime, configure);
+
+  facebook::jsi::Value result = runtime->evaluateJavaScript(
+      std::make_shared<facebook::jsi::StringBuffer>("1 + 2"), "w1-smoke.js");
+  EXPECT_TRUE(result.isNumber());
+  EXPECT_EQ(result.getNumber(), 3.0);
+}
+
+// W3 round-trip test: stub PreparedScriptStore wired through V8RuntimeArgs.
+// Confirms the full chain — consumer's PreparedScriptStore → V8ScriptCache
+// adapter → C callbacks → DLL → V8 code cache → C callbacks → adapter →
+// consumer's persistPreparedScript / tryGetPreparedScript.
+namespace {
+
+class StubPreparedScript final : public facebook::jsi::Buffer {
+ public:
+  explicit StubPreparedScript(std::vector<uint8_t> bytes)
+      : bytes_(std::move(bytes)) {}
+  const uint8_t *data() const override { return bytes_.data(); }
+  size_t size() const override { return bytes_.size(); }
+
+ private:
+  std::vector<uint8_t> bytes_;
+};
+
+class StubPreparedScriptStore final
+    : public facebook::jsi::PreparedScriptStore {
+ public:
+  std::shared_ptr<const facebook::jsi::Buffer> tryGetPreparedScript(
+      const facebook::jsi::ScriptSignature &scriptSignature,
+      const facebook::jsi::JSRuntimeSignature & /*runtimeSignature*/,
+      const char * /*prepareTag*/) noexcept override {
+    ++loadCount;
+    auto it = entries.find(makeKey(scriptSignature));
+    if (it == entries.end())
+      return nullptr;
+    return std::make_shared<StubPreparedScript>(it->second);
+  }
+
+  void persistPreparedScript(
+      std::shared_ptr<const facebook::jsi::Buffer> preparedScript,
+      const facebook::jsi::ScriptSignature &scriptMetadata,
+      const facebook::jsi::JSRuntimeSignature & /*runtimeMetadata*/,
+      const char * /*prepareTag*/) noexcept override {
+    ++storeCount;
+    std::vector<uint8_t> copy(
+        preparedScript->data(),
+        preparedScript->data() + preparedScript->size());
+    lastPersistedSize = copy.size();
+    entries[makeKey(scriptMetadata)] = std::move(copy);
+  }
+
+  int loadCount{0};
+  int storeCount{0};
+  size_t lastPersistedSize{0};
+
+ private:
+  static std::string makeKey(
+      const facebook::jsi::ScriptSignature &sig) {
+    return sig.url + "#" + std::to_string(sig.version);
+  }
+
+  std::unordered_map<std::string, std::vector<uint8_t>> entries;
+};
+
+} // namespace
+
+TEST(JsiAbiScriptCache, LoadStoreRoundtrip) {
+  auto store = std::make_shared<StubPreparedScriptStore>();
+
+  const std::string source = "var roundtripResult = 40 + 2; roundtripResult";
+  const std::string url = "w3-roundtrip.js";
+
+  // First run: cache miss → V8 compiles, stores cached data via the adapter.
+  {
+    v8runtime::V8RuntimeArgs args;
+    args.flags.explicitMicrotaskPolicy = true;
+    args.flags.enableGCApi = true;
+    args.preparedScriptStore = store;
+    auto runtime = v8runtime::makeV8Runtime(std::move(args));
+
+    auto prepared = runtime->prepareJavaScript(
+        std::make_shared<facebook::jsi::StringBuffer>(source), url);
+    auto result = runtime->evaluatePreparedJavaScript(prepared);
+    EXPECT_TRUE(result.isNumber());
+    EXPECT_EQ(result.getNumber(), 42.0);
+  }
+
+  EXPECT_EQ(store->loadCount, 1)
+      << "tryGetPreparedScript should be called exactly once on first run";
+  EXPECT_EQ(store->storeCount, 1)
+      << "persistPreparedScript should be called once after compile-from-source";
+  EXPECT_GT(store->lastPersistedSize, 0u)
+      << "stored cache should be non-empty";
+
+  // Second run: cache hit → V8 consumes cached data, no new persist call.
+  {
+    v8runtime::V8RuntimeArgs args;
+    args.flags.explicitMicrotaskPolicy = true;
+    args.flags.enableGCApi = true;
+    args.preparedScriptStore = store;
+    auto runtime = v8runtime::makeV8Runtime(std::move(args));
+
+    auto prepared = runtime->prepareJavaScript(
+        std::make_shared<facebook::jsi::StringBuffer>(source), url);
+    auto result = runtime->evaluatePreparedJavaScript(prepared);
+    EXPECT_TRUE(result.isNumber());
+    EXPECT_EQ(result.getNumber(), 42.0);
+  }
+
+  EXPECT_EQ(store->loadCount, 2)
+      << "tryGetPreparedScript should be queried again on second run";
+  EXPECT_EQ(store->storeCount, 1)
+      << "persistPreparedScript must NOT be called on a cache hit";
+}
+
+// W4 lifecycle + post-task test. Confirms:
+//   1. A foreground_task_runner supplied via V8RuntimeArgs reaches the runtime.
+//   2. Posting a task through the foreground runner round-trips through both
+//      the consumer-side V8TaskRunner adapter and the DLL-side CTaskRunner
+//      adapter, and the supplied callback fires.
+//   3. The deleter chain runs exactly once on runtime destruction (the
+//      consumer-side adapter is freed, which drops the shared_ptr to the
+//      stub task runner, which destroys the stub).
+namespace {
+
+class StubTaskRunner final : public v8runtime::JSITaskRunner {
+ public:
+  std::atomic<int> postTaskCount{0};
+
+  void postTask(std::unique_ptr<v8runtime::JSITask> task) override {
+    ++postTaskCount;
+    task->run();
+    // unique_ptr destruction fires the C task_data_delete_cb via ~CTask.
+  }
+};
+
+} // namespace
+
+TEST(JsiAbiTaskRunner, LifecycleAndPostTask) {
+  auto stub = std::make_shared<StubTaskRunner>();
+  std::weak_ptr<StubTaskRunner> weakStub = stub;
+
+  int taskFiredCount = 0;
+
+  {
+    v8runtime::V8RuntimeArgs args;
+    args.flags.explicitMicrotaskPolicy = true;
+    args.flags.enableGCApi = true;
+    args.foreground_task_runner = stub;
+    auto runtime = v8runtime::makeV8Runtime(std::move(args));
+
+    // Sanity: runtime evaluates JS — confirms construction succeeded with
+    // the task runner wired in.
+    auto evalResult = runtime->evaluateJavaScript(
+        std::make_shared<facebook::jsi::StringBuffer>("1 + 2"),
+        "w4-construct.js");
+    EXPECT_TRUE(evalResult.isNumber());
+    EXPECT_EQ(evalResult.getNumber(), 3.0);
+
+    jsi_runtime *abiRuntime = ::jsi::abi::getAbiRuntime(*runtime);
+
+    // Post a task: runtime → DLL CTaskRunner → consumer V8TaskRunner →
+    // stub::postTask → CTask::run → DLL trampoline → user callback.
+    v8_jsi_test_post_foreground_task(
+        abiRuntime,
+        [](void *data) { ++(*static_cast<int *>(data)); },
+        &taskFiredCount);
+
+    EXPECT_EQ(taskFiredCount, 1)
+        << "user callback must fire exactly once via the post-task chain";
+    EXPECT_EQ(stub->postTaskCount.load(), 1)
+        << "stub task runner must observe the postTask call";
+
+    // Drop our local strong ref. Only the runtime should be holding the
+    // stub alive at this point — verify that with the weak_ptr.
+    stub.reset();
+    EXPECT_FALSE(weakStub.expired())
+        << "runtime must keep the task runner alive while it lives";
+  }
+
+  // Runtime is destroyed; consumer's Delete callback freed the V8TaskRunner
+  // adapter, which dropped its shared_ptr<JSITaskRunner>, which destroyed
+  // the stub — verify the deleter fired exactly once via weak_ptr expiry.
+  EXPECT_TRUE(weakStub.expired())
+      << "runtime destruction must release the task runner exactly once";
+}
+
+// W5 inspector lifecycle smoke test. Builds a runtime with
+// enable_inspector=true, calls v8_open_inspector, evaluates JS, and tears
+// down — all without standing up a real debugger client. The point is to
+// verify the inspector::Agent is created/started/torn down without crashing,
+// not to exercise the protocol. Mark skipped on inspector-disabled builds so
+// the test corpus stays portable during transitional rebuilds.
+extern "C" JSI_API void JSI_CDECL v8_open_inspector(jsi_runtime *runtime);
+
+TEST(JsiAbiInspector, LifecycleAndOpen) {
+#if !defined(_WIN32) || !defined(V8JSI_ENABLE_INSPECTOR)
+  GTEST_SKIP() << "Inspector not enabled in this build";
+#else
+  // Stub task runner — inspector dispatch posts onto the foreground runner.
+  // Run-immediately to keep the test synchronous.
+  auto stub = std::make_shared<StubTaskRunner>();
+
+  v8runtime::V8RuntimeArgs args;
+  args.flags.explicitMicrotaskPolicy = true;
+  args.flags.enableGCApi = true;
+  args.flags.enableInspector = true;
+  args.flags.waitForDebugger = false;  // Don't block waiting on a client.
+  // Use a non-default port to avoid collisions with anything else listening.
+  args.inspectorPort = 19223;
+  args.debuggerRuntimeName = "w5-smoke";
+  args.foreground_task_runner = stub;
+
+  auto runtime = v8runtime::makeV8Runtime(std::move(args));
+
+  // Trivial evaluation must succeed with the inspector wired in.
+  auto result = runtime->evaluateJavaScript(
+      std::make_shared<facebook::jsi::StringBuffer>("40 + 2"),
+      "w5-smoke.js");
+  EXPECT_TRUE(result.isNumber());
+  EXPECT_EQ(result.getNumber(), 42.0);
+
+  // Calling v8_open_inspector again on an already-started agent must be safe.
+  v8_open_inspector(::jsi::abi::getAbiRuntime(*runtime));
+
+  // Tear down — Agent::removeContext + Agent::stop run inside the runtime
+  // destructor; the test passes if nothing crashes.
+#endif
+}
+
+// W6 Node-API revival smoke test. Confirms that the napi_*/jsr_* surface
+// compiled into v8jsi.dll works end-to-end:
+//   1. Build a jsr_config and create a jsr_runtime.
+//   2. Obtain the napi_env and open an env scope.
+//   3. Run a trivial JS script via napi_run_script and read back a number.
+//   4. Tear down env scope and runtime.
+// The point is to prove the path is wired, not to exhaustively cover Node-API.
+// Full N-API conformance comes back in W7.
+TEST(NodeApiSmoke, CreateRuntimeAndRunScript) {
+  jsr_config config{};
+  ASSERT_EQ(jsr_create_config(&config), napi_ok);
+  ASSERT_NE(config, nullptr);
+  jsr_config_enable_gc_api(config, true);
+
+  jsr_runtime runtime{};
+  ASSERT_EQ(jsr_create_runtime(config, &runtime), napi_ok);
+  ASSERT_NE(runtime, nullptr);
+  // jsr_create_runtime takes ownership of config-owned state; safe to free now.
+  ASSERT_EQ(jsr_delete_config(config), napi_ok);
+
+  napi_env env{};
+  ASSERT_EQ(jsr_runtime_get_node_api_env(runtime, &env), napi_ok);
+  ASSERT_NE(env, nullptr);
+
+  jsr_napi_env_scope envScope{};
+  ASSERT_EQ(jsr_open_napi_env_scope(env, &envScope), napi_ok);
+
+  {
+    napi_handle_scope handleScope{};
+    ASSERT_EQ(napi_open_handle_scope(env, &handleScope), napi_ok);
+
+    napi_value source{};
+    ASSERT_EQ(
+        napi_create_string_utf8(env, "40 + 2", NAPI_AUTO_LENGTH, &source),
+        napi_ok);
+
+    napi_value result{};
+    ASSERT_EQ(jsr_run_script(env, source, "w6-smoke.js", &result), napi_ok);
+
+    double value{};
+    ASSERT_EQ(napi_get_value_double(env, result, &value), napi_ok);
+    EXPECT_EQ(value, 42.0);
+
+    ASSERT_EQ(napi_close_handle_scope(env, handleScope), napi_ok);
+  }
+
+  ASSERT_EQ(jsr_close_napi_env_scope(env, envScope), napi_ok);
+  ASSERT_EQ(jsr_delete_runtime(runtime), napi_ok);
+}
+
+// W8 dual-API smoke test. The original reason `V8RuntimeEnv : public V8Runtime`
+// existed was so a consumer could create a runtime via Node-API (jsr_*) and
+// also reach into the same V8 isolate through the JSI APIs. After W8 the
+// inheritance is gone, but the contract is preserved through:
+//   1. v8_create_runtime + v8_attach_node_api as the underlying primitives.
+//   2. jsr_create_runtime as the same convenience entry point, internally
+//      calling those two.
+//   3. jsr_runtime_get_jsi_runtime as the accessor that lets a napi-created
+//      runtime hand back a jsi_runtime * a JsiAbiRuntime can wrap.
+// The test sets a global property from the napi side and reads it back from
+// the JSI side over the same V8 isolate — the smallest possible exercise of
+// the dual-API contract.
+TEST(DualApi, NodeApiAndJsiShareIsolate) {
+  jsr_config config{};
+  ASSERT_EQ(jsr_create_config(&config), napi_ok);
+  jsr_config_enable_gc_api(config, true);
+
+  jsr_runtime runtime{};
+  ASSERT_EQ(jsr_create_runtime(config, &runtime), napi_ok);
+  ASSERT_EQ(jsr_delete_config(config), napi_ok);
+
+  // Node-API side: set globalThis.W8DualValue = 42.
+  napi_env env{};
+  ASSERT_EQ(jsr_runtime_get_node_api_env(runtime, &env), napi_ok);
+
+  jsr_napi_env_scope envScope{};
+  ASSERT_EQ(jsr_open_napi_env_scope(env, &envScope), napi_ok);
+  {
+    napi_handle_scope handleScope{};
+    ASSERT_EQ(napi_open_handle_scope(env, &handleScope), napi_ok);
+
+    napi_value source{};
+    ASSERT_EQ(
+        napi_create_string_utf8(env,
+                                 "globalThis.W8DualValue = 42;",
+                                 NAPI_AUTO_LENGTH,
+                                 &source),
+        napi_ok);
+    napi_value result{};
+    ASSERT_EQ(jsr_run_script(env, source, "w8-dual-set.js", &result), napi_ok);
+
+    ASSERT_EQ(napi_close_handle_scope(env, handleScope), napi_ok);
+  }
+  ASSERT_EQ(jsr_close_napi_env_scope(env, envScope), napi_ok);
+
+  // JSI side: pull the underlying jsi_runtime out and wrap it as a
+  // JsiAbiRuntime. Read back the property; assert it matches.
+  jsi_runtime *abiRuntime{};
+  ASSERT_EQ(jsr_runtime_get_jsi_runtime(runtime, &abiRuntime), napi_ok);
+  ASSERT_NE(abiRuntime, nullptr);
+
+  // Wrap the ABI runtime as a jsi::Runtime. wrapJsiRuntime adds its own ref,
+  // independent of the one held by the jsr_runtime — both sides can release
+  // in any order; the runtime is destroyed when the last ref drops.
+  auto wrapper = ::jsi::abi::wrapJsiRuntime(abiRuntime);
+  facebook::jsi::Runtime &jsiRt = *wrapper;
+  facebook::jsi::Value v =
+      jsiRt.global().getProperty(jsiRt, "W8DualValue");
+  ASSERT_TRUE(v.isNumber());
+  EXPECT_EQ(v.getNumber(), 42.0);
+
+  ASSERT_EQ(jsr_delete_runtime(runtime), napi_ok);
+}
+
+// W9 query_interface negative-path test. The ABI currently supports no
+// optional interfaces, so query_interface always reports not-supported.
+// Confirms it returns jsi_error_native and surfaces "Interface not supported"
+// via the native-exception-message slot. Exercises the only path through which
+// a non-JS error message flows back to the consumer.
+TEST(JsiAbiQueryInterface, UnknownIidReturnsError) {
+  jsi_runtime *rt = v8_create_runtime(JSI_ABI_VERSION, nullptr, nullptr);
+  ASSERT_NE(rt, nullptr);
+
+  // Bogus IID — reserved-bit-pattern that will never collide with any
+  // well-known IID a future engine-specific interface might use.
+  static constexpr jsi_interface_id kBogusIid = {
+      0xDEADBEEFCAFEBABEull, 0x0123456789ABCDEFull};
+
+  const void *vtableOut = nullptr;
+  void *instanceOut = nullptr;
+  jsi_error_code result =
+      rt->vt->query_interface(rt, &kBogusIid, &vtableOut, &instanceOut);
+
+  ASSERT_TRUE(::jsi::abi::is_error(result));
+  EXPECT_EQ(::jsi::abi::get_error(result), jsi_error_native);
+
+  // Read back the native exception message — must mention "Interface not
+  // supported".
+  struct LocalBuf : public jsi_growable_buffer {
+    std::string buf{std::string(64, '\0')};
+    LocalBuf() {
+      static const jsi_growable_buffer_vtable bufVt{&tryGrowTo};
+      vtable = const_cast<jsi_growable_buffer_vtable *>(&bufVt);
+      data = reinterpret_cast<uint8_t *>(buf.data());
+      size = buf.size();
+      used = 0;
+    }
+    static void JSI_CDECL tryGrowTo(jsi_growable_buffer *b, size_t sz) {
+      auto *self = static_cast<LocalBuf *>(b);
+      if (sz > self->buf.size()) {
+        self->buf.resize(sz);
+        b->data = reinterpret_cast<uint8_t *>(self->buf.data());
+        b->size = self->buf.size();
+      }
+    }
+  } gb;
+
+  rt->vt->get_and_clear_native_exception_message(rt, &gb);
+  std::string msg(reinterpret_cast<const char *>(gb.data), gb.used);
+  EXPECT_NE(msg.find("Interface not supported"), std::string::npos)
+      << "expected 'Interface not supported' in message; got: " << msg;
+
+  rt->vt->release(rt);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/node-api/js_native_api_v8.h
+++ b/src/node-api/js_native_api_v8.h
@@ -2,7 +2,14 @@
 #define SRC_JS_NATIVE_API_V8_H_
 
 #include "js_native_api_types.h"
+
+#ifdef JSI_ABI_BUILDING
+// New v8jsi.dll build (no legacy V8Runtime class). PR 3 collapses the fork by
+// deleting js_native_api_v8_internals.h and renaming the _abi.h file in.
+#include "js_native_api_v8_internals_abi.h"
+#else
 #include "js_native_api_v8_internals.h"
+#endif
 
 inline napi_status napi_clear_last_error(node_api_nogc_env env);
 

--- a/src/node-api/js_native_api_v8_internals_abi.h
+++ b/src/node-api/js_native_api_v8_internals_abi.h
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ----------------------------------------------------------------------------
+// This file is referenced from js_native_api_v8.cc when compiled into the
+// new v8jsi.dll (JSI_ABI_BUILDING). It replaces V8Runtime-based private-key
+// lookup with the per-isolate IsolateData lookup the W8 architecture
+// exposes. The legacy js_native_api_v8_internals.h (master state) stays
+// unchanged through PR 1+2; the rename-on-delete collapse happens in PR 3.
+// ----------------------------------------------------------------------------
+// Original Node.js copyright:
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+#ifndef SRC_JS_NATIVE_API_V8_INTERNALS_ABI_H_
+#define SRC_JS_NATIVE_API_V8_INTERNALS_ABI_H_
+
+#define NODE_API_DEFAULT_MODULE_API_VERSION 8
+#define NODE_API_SUPPORTED_VERSION_MAX 9
+#define NODE_API_SUPPORTED_VERSION_MIN 1
+
+// The V8 implementation of N-API, including `js_native_api_v8.h` uses certain
+// idioms which require definition here. For example, it uses a variant of
+// persistent references which need not be reset in the constructor. It is the
+// responsibility of this file to define these idioms. Optionally, this file
+// may also define `NAPI_VERSION` and set it to the version of N-API to be
+// exposed.
+
+// In the case of the Node.js implementation of N-API some of the idioms are
+// imported directly from Node.js by including `node_internals.h` below. Others
+// are bridged to remove references to the `node` namespace. `node_version.h`,
+// included below, defines `NAPI_VERSION`.
+
+#include "v8_core.h"
+#include "js_native_api.h"
+#include "util-inl.h"
+#include "v8.h"
+
+#define NAPI_ARRAYSIZE(array) node::arraysize((array))
+
+// W8: napi_type_tag/napi_wrapper private keys live on v8rt::IsolateData
+// (set up by createIsolate via v8_core). The legacy lookup through
+// V8Runtime::GetCurrent(context) is gone — the keys are per-isolate, not
+// per-context, so we read them from the shared struct directly.
+#define NAPI_PRIVATE_KEY(context, suffix)                                      \
+  (v8rt::IsolateData::fromIsolate((context)->GetIsolate())->napi_##suffix())
+
+namespace v8impl {
+
+template <typename T>
+using Persistent = v8::Global<T>;
+
+[[noreturn]] inline void OnFatalError(const char* location,
+                                      const char* message) {
+  if (location) {
+    fprintf(stderr, "FATAL ERROR: %s %s\n", location, message);
+  } else {
+    fprintf(stderr, "FATAL ERROR: %s\n", message);
+  }
+
+  fflush(stderr);
+  _exit(static_cast<int>(node::ExitCode::kAbort));
+}
+
+// Convert a v8::PersistentBase, e.g. v8::Global, to a Local, with an extra
+// optimization for strong persistent handles.
+class PersistentToLocal {
+ public:
+  // If persistent.IsWeak() == false, then do not call persistent.Reset()
+  // while the returned Local<T> is still in scope, it will destroy the
+  // reference to the object.
+  template <class TypeName>
+  static inline v8::Local<TypeName> Default(
+      v8::Isolate* isolate, const v8::PersistentBase<TypeName>& persistent) {
+    if (persistent.IsWeak()) {
+      return PersistentToLocal::Weak(isolate, persistent);
+    } else {
+      return PersistentToLocal::Strong(persistent);
+    }
+  }
+
+  // Unchecked conversion from a non-weak Persistent<T> to Local<T>,
+  // use with care!
+  //
+  // Do not call persistent.Reset() while the returned Local<T> is still in
+  // scope, it will destroy the reference to the object.
+  template <class TypeName>
+  static inline v8::Local<TypeName> Strong(
+      const v8::PersistentBase<TypeName>& persistent) {
+    return *reinterpret_cast<v8::Local<TypeName>*>(
+        const_cast<v8::PersistentBase<TypeName>*>(&persistent));
+  }
+
+  template <class TypeName>
+  static inline v8::Local<TypeName> Weak(
+      v8::Isolate* isolate, const v8::PersistentBase<TypeName>& persistent) {
+    return v8::Local<TypeName>::New(isolate, persistent);
+  }
+};
+
+}  // end of namespace v8impl
+
+// It is called from the napi_create_external_arraybuffer implementation
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_external_buffer(napi_env env,
+                            size_t length,
+                            void* data,
+                            node_api_nogc_finalize finalize_cb,
+                            void* finalize_hint,
+                            napi_value* result);
+
+#endif  // SRC_JS_NATIVE_API_V8_INTERNALS_ABI_H_

--- a/src/node-api/js_runtime_api.h
+++ b/src/node-api/js_runtime_api.h
@@ -6,13 +6,22 @@
 
 #include "js_native_api.h"
 
+// W8: jsi_runtime forward declaration for jsr_runtime_get_jsi_runtime.
+// The full opaque type is declared in jsi_abi/jsi_abi.h; forward-declared
+// here so consumers do not need to pull in the JSI ABI header just to use
+// jsr_runtime_get_jsi_runtime.
+struct jsi_runtime;
+
 //
 // Node-API extensions required for JavaScript engine hosting.
 //
-// It is a very early version of the APIs which we consider to be experimental.
-// These APIs are not stable yet and are subject to change while we continue
-// their development. After some time we will stabilize the APIs and make them
-// "officially stable".
+// EXPERIMENTAL - NOT YET ABI-STABLE.
+// This is a very early version of the APIs, which we consider experimental.
+// They are not stable yet and are subject to change while we continue their
+// development. Although they are C-based, they are NOT ABI-safe yet:
+// signatures, struct fields, and enum values may change without notice. Do not
+// depend on binary compatibility across builds. After some time we will
+// stabilize the APIs, make them ABI-stable, and mark them "officially stable".
 //
 
 #define JSR_API NAPI_EXTERN napi_status NAPI_CDECL
@@ -33,6 +42,13 @@ typedef void(NAPI_CDECL* jsr_data_delete_cb)(void* data, void* deleter_data);
 JSR_API jsr_create_runtime(jsr_config config, jsr_runtime* runtime);
 JSR_API jsr_delete_runtime(jsr_runtime runtime);
 JSR_API jsr_runtime_get_node_api_env(jsr_runtime runtime, napi_env* env);
+
+// W8: dual-API accessor. Returns the underlying jsi_runtime so a consumer
+// that started with jsr_create_runtime can also build a jsi::Runtime over
+// the same V8 isolate (via JsiAbiRuntime). Output borrows from the
+// jsr_runtime; do not call jsi_release on it.
+JSR_API jsr_runtime_get_jsi_runtime(jsr_runtime runtime,
+                                     struct jsi_runtime** abi_runtime);
 
 //=============================================================================
 // jsr_config

--- a/src/node-api/test/node_api_tests.gyp
+++ b/src/node-api/test/node_api_tests.gyp
@@ -1,0 +1,720 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#
+# node_api_tests.gyp - Build configuration for the Node-API conformance test rig.
+#
+# Ports the BUILD.gn-era test rig (src/node-api/test/BUILD.gn) to GYP:
+#   - 34 loadable_module test addons under js-native-api/<name>/
+#   - node_lite.exe — JS-runner that LoadLibrary()'s addons and runs JS tests
+#   - node_api_tests.exe — GoogleTest harness that spawns node_lite per .js file
+#   - copy_node_api_test_js_files — populates out/<conf>/test-js-files/
+#
+# This file is included from src/v8jsi.gyp; relative paths follow the same
+# convention as v8jsi.gyp — anchored to the v8-jsi repo root via v8jsi_root.
+{
+  'variables': {
+    # Path to v8-jsi repo root relative to the outer gyp (deps/nodejs/node.gyp).
+    # Set as '%=' so an outer scope can override (e.g. when v8jsi.gyp has
+    # already declared it).
+    'v8jsi_root%': '../..',
+
+    # Common addon settings so each loadable_module target stays terse.
+    'test_addon_include_dirs': [
+      '<(v8jsi_root)/src/node-api',
+      '<(v8jsi_root)/src/node-api/test/js-native-api',
+    ],
+    # BUILDING_NODE_EXTENSION flips NAPI_EXTERN to __declspec(dllimport) in
+    # the test-side js-native-api/node_api.h so napi_* resolve via v8jsi.lib.
+    'test_addon_defines': [
+      'BUILDING_NODE_EXTENSION',
+    ],
+  },
+
+  'targets': [
+    #
+    # JS test files copy.
+    #
+    # Copies the .js test files from src/node-api/test/ into
+    # <PRODUCT_DIR>/test-js-files/<rel-path>, preserving the directory
+    # structure so RegisterNodeApiTests' recursive scan finds them next to
+    # node_api_tests.exe / node_lite.exe.
+    #
+    {
+      'target_name': 'copy_node_api_test_js_files',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'copy_test_js_files',
+          'inputs': [
+            '<(v8jsi_root)/src/copy_test_js_files.ts',
+          ],
+          # Use a stamp file as the GYP output marker since gyp wants outputs.
+          'outputs': [
+            '<(PRODUCT_DIR)/test-js-files/.copied.stamp',
+          ],
+          'action': [
+            'node',
+            '<(v8jsi_root)/src/copy_test_js_files.ts',
+            '--source-base', '<(v8jsi_root)/src/node-api/test',
+            # Pass the destination root explicitly (rather than PRODUCT_DIR)
+            # so the path doesn't end in MSVS's trailing backslash, which
+            # would escape the closing quote in the generated MSBuild
+            # custom-build action.
+            '--dest-root', '<(PRODUCT_DIR)/test-js-files',
+            '--stamp', '<(PRODUCT_DIR)/test-js-files/.copied.stamp',
+          ],
+          'msvs_cygwin_shell': 0,
+        },
+      ],
+    },
+
+    #
+    # node_lite.exe — JS-runner used as a child process by node_api_tests.exe.
+    # Initializes a jsr_runtime, evaluates a single .js file, and dynamically
+    # loads addon DLLs through JSRequire().
+    #
+    {
+      'target_name': 'node_lite',
+      'type': 'executable',
+      'dependencies': [
+        'v8jsi',
+      ],
+      'include_dirs': [
+        '<(v8jsi_root)/src/node-api',
+        '<(v8jsi_root)/src/node-api/test',
+        '<(v8jsi_root)/src/node-api/test/js-native-api',
+        '<(v8jsi_root)/src/public',
+      ],
+      'defines': [
+        'NAPI_EXPERIMENTAL',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/child_process.cpp',
+        '<(v8jsi_root)/src/node-api/test/child_process.h',
+        '<(v8jsi_root)/src/node-api/test/node_api_test.cpp',
+        '<(v8jsi_root)/src/node-api/test/node_api_test.h',
+        '<(v8jsi_root)/src/node-api/test/node_api_test_v8.cpp',
+      ],
+      'conditions': [
+        ['OS=="win"', {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'ExceptionHandling': 1,  # /EHsc
+              'RuntimeTypeInfo': 'true',
+            },
+            'VCLinkerTool': {
+              'AdditionalDependencies': [
+                'dbghelp.lib',
+                'winmm.lib',
+              ],
+            },
+          },
+          'configurations': {
+            'Release': {
+              'msvs_settings': {
+                'VCCLCompilerTool': {
+                  'ExceptionHandling': 1,
+                  'RuntimeTypeInfo': 'true',
+                },
+              },
+            },
+            'Debug': {
+              'msvs_settings': {
+                'VCCLCompilerTool': {
+                  'ExceptionHandling': 1,
+                  'RuntimeTypeInfo': 'true',
+                },
+              },
+            },
+          },
+        }],
+      ],
+    },
+
+    #
+    # Test addon DLLs — each is a small native module loaded into node_lite
+    # via LoadLibraryA. Registered with napi_register_module_v1.
+    # Mirrors the ":test_module" config + per-target settings from BUILD.gn.
+    #
+
+    {
+      'target_name': '2_function_arguments',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=2_function_arguments',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/2_function_arguments/2_function_arguments.c',
+      ],
+    },
+
+    {
+      'target_name': '3_callbacks',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=3_callbacks',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/3_callbacks/3_callbacks.c',
+      ],
+    },
+
+    {
+      'target_name': '4_object_factory',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=4_object_factory',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/4_object_factory/4_object_factory.c',
+      ],
+    },
+
+    {
+      'target_name': '5_function_factory',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=5_function_factory',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/5_function_factory/5_function_factory.c',
+      ],
+    },
+
+    {
+      'target_name': '6_object_wrap',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=6_object_wrap',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/6_object_wrap/6_object_wrap.cc',
+      ],
+    },
+
+    {
+      'target_name': '7_factory_wrap',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=7_factory_wrap',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/7_factory_wrap/7_factory_wrap.cc',
+        '<(v8jsi_root)/src/node-api/test/js-native-api/7_factory_wrap/myobject.cc',
+      ],
+    },
+
+    {
+      'target_name': '8_passing_wrapped',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=8_passing_wrapped',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/8_passing_wrapped/8_passing_wrapped.cc',
+        '<(v8jsi_root)/src/node-api/test/js-native-api/8_passing_wrapped/myobject.cc',
+      ],
+    },
+
+    {
+      'target_name': 'test_array',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_array',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_array/test_array.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_bigint',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_bigint',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_bigint/test_bigint.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_cannot_run_js',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NAPI_EXPERIMENTAL',
+        'NODE_GYP_MODULE_NAME=test_cannot_run_js',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_cannot_run_js/test_cannot_run_js.c',
+      ],
+    },
+
+    # test_pending_exception: same source as test_cannot_run_js but pinned to
+    # NAPI v8 to exercise the legacy non-experimental code path.
+    {
+      'target_name': 'test_pending_exception',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NAPI_VERSION=8',
+        'NODE_GYP_MODULE_NAME=test_pending_exception',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_cannot_run_js/test_cannot_run_js.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_constructor',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_constructor',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_constructor/test_constructor.c',
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_constructor/test_null.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_conversions',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_conversions',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_conversions/test_conversions.c',
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_conversions/test_null.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_dataview',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_dataview',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_dataview/test_dataview.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_date',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_date',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_date/test_date.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_error',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_error',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_error/test_error.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_exception',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_exception',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_exception/test_exception.c',
+      ],
+    },
+
+    # test_exceptions: lives under js-native-api/test_object/.
+    {
+      'target_name': 'test_exceptions',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_exceptions',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_object/test_exceptions.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_finalizer',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NAPI_EXPERIMENTAL',
+        'NODE_GYP_MODULE_NAME=test_finalizer',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_finalizer/test_finalizer.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_function',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_function',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_function/test_function.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_general',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_general',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_general/test_general.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_handle_scope',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_handle_scope',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_handle_scope/test_handle_scope.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_instance_data',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_instance_data',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_instance_data/test_instance_data.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_new_target',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_new_target',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_new_target/test_new_target.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_number',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_number',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_number/test_null.c',
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_number/test_number.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_object',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_object',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_object/test_null.c',
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_object/test_object.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_promise',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_promise',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_promise/test_promise.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_properties',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_properties',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_properties/test_properties.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_reference',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_reference',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_reference/test_reference.c',
+      ],
+    },
+
+    # test_ref_finalizer: source is test_reference/test_finalizer.c.
+    {
+      'target_name': 'test_ref_finalizer',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_ref_finalizer',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_reference/test_finalizer.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_reference_double_free',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_reference_double_free',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_reference_double_free/test_reference_double_free.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_string',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NAPI_EXPERIMENTAL',
+        'NODE_GYP_MODULE_NAME=test_string',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_string/test_null.c',
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_string/test_string.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_symbol',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_symbol',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_symbol/test_symbol.c',
+      ],
+    },
+
+    {
+      'target_name': 'test_typedarray',
+      'type': 'loadable_module',
+      'dependencies': ['v8jsi'],
+      'include_dirs': ['<@(test_addon_include_dirs)'],
+      'defines': [
+        '<@(test_addon_defines)',
+        'NODE_GYP_MODULE_NAME=test_typedarray',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/js-native-api/test_typedarray/test_typedarray.c',
+      ],
+    },
+
+    #
+    # node_api_tests.exe — GoogleTest harness. Walks <PRODUCT_DIR>/test-js-files/
+    # at runtime and registers one GTest per .js file. Each test spawns
+    # node_lite.exe as a child process. Does NOT link against v8jsi.dll —
+    # the harness is a pure black-box runner over the addon DLLs + node_lite.
+    #
+    {
+      'target_name': 'node_api_tests',
+      'type': 'executable',
+      'dependencies': [
+        'node_lite',
+        'copy_node_api_test_js_files',
+        'deps/googletest/googletest.gyp:gtest',
+        # 34 addon DLLs — declared as deps so they all build before the
+        # harness runs. node_api_tests.exe does not link against them; the
+        # dependency is purely a runtime/spawn relationship.
+        '2_function_arguments',
+        '3_callbacks',
+        '4_object_factory',
+        '5_function_factory',
+        '6_object_wrap',
+        '7_factory_wrap',
+        '8_passing_wrapped',
+        'test_array',
+        'test_bigint',
+        'test_cannot_run_js',
+        'test_constructor',
+        'test_conversions',
+        'test_dataview',
+        'test_date',
+        'test_error',
+        'test_exception',
+        'test_exceptions',
+        'test_finalizer',
+        'test_function',
+        'test_general',
+        'test_handle_scope',
+        'test_instance_data',
+        'test_new_target',
+        'test_number',
+        'test_object',
+        'test_pending_exception',
+        'test_promise',
+        'test_properties',
+        'test_ref_finalizer',
+        'test_reference',
+        'test_reference_double_free',
+        'test_string',
+        'test_symbol',
+        'test_typedarray',
+      ],
+      'include_dirs': [
+        '<(v8jsi_root)/src/node-api/test',
+      ],
+      'sources': [
+        '<(v8jsi_root)/src/node-api/test/child_process.cpp',
+        '<(v8jsi_root)/src/node-api/test/child_process.h',
+        '<(v8jsi_root)/src/node-api/test/testmain.cpp',
+      ],
+      'conditions': [
+        ['OS=="win"', {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'ExceptionHandling': 1,
+              'RuntimeTypeInfo': 'true',
+            },
+          },
+          'configurations': {
+            'Release': {
+              'msvs_settings': {
+                'VCCLCompilerTool': {
+                  'ExceptionHandling': 1,
+                  'RuntimeTypeInfo': 'true',
+                },
+              },
+            },
+            'Debug': {
+              'msvs_settings': {
+                'VCCLCompilerTool': {
+                  'ExceptionHandling': 1,
+                  'RuntimeTypeInfo': 'true',
+                },
+              },
+            },
+          },
+        }],
+      ],
+    },
+  ],
+}

--- a/src/node-api/util-inl.h
+++ b/src/node-api/util-inl.h
@@ -204,7 +204,7 @@ struct OnScopeLeaveImpl {
 //   // ... run some code ...
 // });
 template <typename Fn>
-inline MUST_USE_RESULT OnScopeLeaveImpl<Fn> OnScopeLeave(Fn&& fn) {
+[[nodiscard]] inline OnScopeLeaveImpl<Fn> OnScopeLeave(Fn&& fn) {
   return OnScopeLeaveImpl<Fn>{std::move(fn)};
 }
 

--- a/src/node-api/v8_api_abi.cpp
+++ b/src/node-api/v8_api_abi.cpp
@@ -1,0 +1,1301 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ----------------------------------------------------------------------------
+// Some code is copied from Node.js project to compile V8 NAPI code
+// without major changes.
+// ----------------------------------------------------------------------------
+// Original Node.js copyright:
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#define NAPI_EXPERIMENTAL
+#include "env-inl.h"
+
+// Include the public Node-API headers first so NAPI_EXTERN, NAPI_VERSION_*,
+// napi_key_*, napi_type_tag etc. are defined before js_native_api_v8.h pulls
+// in js_native_api_v8_internals.h.
+#include "js_native_api.h"
+#include "js_runtime_api.h"
+#include "public/v8_api.h"
+
+#include "js_native_api_v8.h"
+
+#include "MurmurHash.h"
+#include "V8Instrumentation.h"
+#include "jsi_abi/jsi_abi_v8_internal.h"
+#include "jsi_abi/v8_jsi_config.h"
+#include "jsi_abi/v8_node_api_attach.h"
+#include "v8_core.h"
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#define CHECKED_ENV(env)                                                       \
+  ((env) == nullptr)                                                           \
+      ? napi_invalid_arg                                                       \
+      : static_cast<v8impl::NodeApiEnv*>(reinterpret_cast<napi_env>(env))
+
+#define CHECKED_RUNTIME(runtime)                                               \
+  ((runtime) == nullptr) ? napi_generic_failure                                \
+                         : reinterpret_cast<v8impl::RuntimeWrapper*>(runtime)
+
+#define CHECKED_CONFIG(config)                                                 \
+  ((config) == nullptr) ? napi_generic_failure                                 \
+                        : reinterpret_cast<v8impl::ConfigWrapper*>(config)
+
+#define V8_CHECK_ARG(arg)                                                      \
+  if ((arg) == nullptr) {                                                      \
+    return napi_generic_failure;                                               \
+  }
+
+namespace v8impl {
+
+class NodeApiEnv;
+
+//============================================================================
+// V8RuntimeEnv ΓÇö Node-API surface attached to a jsi_runtime.
+//
+// W8: replaces the legacy `class V8RuntimeEnv : public v8runtime::V8Runtime`.
+// Composition over a jsi_runtime *. All V8-state accessors (isolate,
+// context, script cache, unhandled-promise tracking) reach into the
+// underlying JsiRuntimeState via the v8rt_internal:: free functions.
+//
+// One V8RuntimeEnv per attached napi surface. Owns a list of NodeApiEnvs
+// (one root + zero or more module envs created via createNodeApi). Lifetime:
+// the V8RuntimeEnv is destroyed before V8 state via the attached-owner hook
+// on JsiRuntimeState; on destruction it Unrefs every env it owns.
+//============================================================================
+class V8RuntimeEnv {
+ public:
+  explicit V8RuntimeEnv(jsi_runtime *abiRuntime)
+      : abiRuntime_(abiRuntime),
+        instrumentation_(std::make_unique<v8runtime::V8Instrumentation>(
+            v8rt_internal::getIsolate(abiRuntime))) {
+    // Create the root env after the runtime fields are initialized.
+    rootEnv_ = createNodeApi(NAPI_VERSION_EXPERIMENTAL);
+  }
+
+  ~V8RuntimeEnv() {
+    // Drive the root env's refcount to 0. Its DeleteMe ΓåÆ unlinks itself
+    // from moduleEnvList_ and frees the env. Iterate any remaining module
+    // envs and Unref them too ΓÇö typical case is none, but a misbehaving
+    // consumer might have leaked one.
+    NodeApiEnv *root = rootEnv_;
+    rootEnv_ = nullptr;
+    if (root) {
+      Unref(root);
+    }
+    // Module envs that survived (unusual). Take a snapshot since Unref ΓåÆ
+    // DeleteMe mutates the list.
+    std::vector<NodeApiEnv*> remaining = std::move(moduleEnvList_);
+    for (NodeApiEnv *env : remaining) {
+      Unref(env);
+    }
+  }
+
+  V8RuntimeEnv(const V8RuntimeEnv &) = delete;
+  V8RuntimeEnv &operator=(const V8RuntimeEnv &) = delete;
+
+  jsi_runtime *abiRuntime() const noexcept { return abiRuntime_; }
+
+  v8::Isolate *GetIsolate() const noexcept {
+    return v8rt_internal::getIsolate(abiRuntime_);
+  }
+
+  v8::Global<v8::Context> &GetContext() noexcept {
+    return v8rt_internal::getContext(abiRuntime_);
+  }
+
+  v8::Local<v8::Context> GetContextLocal() const noexcept {
+    return v8rt_internal::getContextLocal(abiRuntime_);
+  }
+
+  bool getEnableMultiThread() const noexcept {
+    return v8rt_internal::getEnableMultiThread(abiRuntime_);
+  }
+
+  bool isInspectable() const noexcept { return true; }
+
+  bool HasUnhandledPromiseRejection() noexcept {
+    return v8rt_internal::hasUnhandledPromiseRejection(abiRuntime_);
+  }
+
+  std::unique_ptr<v8rt::UnhandledPromiseRejection>
+  GetAndClearLastUnhandledPromiseRejection() noexcept {
+    return v8rt_internal::takeLastUnhandledPromiseRejection(abiRuntime_);
+  }
+
+  facebook::jsi::Instrumentation &instrumentation() noexcept {
+    return *instrumentation_;
+  }
+
+  napi_status getRootNodeApi(napi_env *env);
+  NodeApiEnv *createNodeApi(int32_t apiVersion);
+  void removeModuleEnv(NodeApiEnv *env);
+
+  void SetImmediate(std::function<void()> callback) {
+    auto runner = v8rt::IsolateData::fromIsolate(GetIsolate())->taskRunner();
+    if (!runner) return;
+    runner->postTask(std::make_unique<ImmediateTask>(std::move(callback)));
+  }
+
+  class ImmediateTask : public v8rt::TaskRunner::Task {
+   public:
+    explicit ImmediateTask(std::function<void()> task)
+        : task_(std::move(task)) {}
+    void run() override { task_(); }
+
+   private:
+    std::function<void()> task_;
+  };
+
+  // RAII Locker for Node-API operations. Extends v8rt::IsolateLocker with
+  // TLS-current tracking + AddRef/Release semantics for nested env-scope
+  // opens on the same thread.
+  class NodeApiIsolateLocker : public v8rt::IsolateLocker {
+   public:
+    explicit NodeApiIsolateLocker(V8RuntimeEnv *env)
+        : v8rt::IsolateLocker(env->GetIsolate(),
+                               env->GetContext(),
+                               env->getEnableMultiThread()),
+          env_(env),
+          previous_(tls_current_) {
+      tls_current_ = this;
+    }
+
+    static NodeApiIsolateLocker *Current() noexcept { return tls_current_; }
+
+    static bool HasCurrentEnv(const V8RuntimeEnv *env) noexcept {
+      return tls_current_ != nullptr && tls_current_->env_ == env;
+    }
+
+    void AddRef() noexcept { ++refCount_; }
+
+    void Release() {
+      if (--refCount_ == 0) delete this;
+    }
+
+   private:
+    ~NodeApiIsolateLocker() { tls_current_ = previous_; }
+
+    const V8RuntimeEnv *env_;
+    std::atomic<int32_t> refCount_{1};
+    NodeApiIsolateLocker *previous_;
+    static inline thread_local NodeApiIsolateLocker *tls_current_{};
+  };
+
+  // Internal Unref helper that does not assume NodeApiEnv layout.
+  static void Unref(NodeApiEnv *env);
+
+ private:
+  jsi_runtime *abiRuntime_;
+  std::unique_ptr<v8runtime::V8Instrumentation> instrumentation_;
+  std::vector<NodeApiEnv*> moduleEnvList_;
+  NodeApiEnv *rootEnv_{nullptr};
+};
+
+//============================================================================
+// NodeApiPreparedScript ΓÇö Node-API's opaque jsr_prepared_script payload.
+//
+// W8: was a heap-allocated shared_ptr<facebook::jsi::PreparedJavaScript> in
+// the legacy code (because V8Runtime::prepareJavaScript2 returned that
+// type). Now the script-cache plumbing happens directly in V8RuntimeEnv;
+// the prepared-script payload is just a v8::Global<v8::UnboundScript> the
+// consumer holds onto for later runs.
+//============================================================================
+struct NodeApiPreparedScript {
+  v8::Global<v8::UnboundScript> unbound;
+};
+
+//============================================================================
+// NodeApiEnv ΓÇö concrete napi_env implementation backed by V8RuntimeEnv.
+//
+// W8: composition over V8RuntimeEnv (no V8Runtime inheritance). The
+// destruction flow is owned by V8RuntimeEnv: its destructor Unrefs the
+// root env which cascades through any module envs. NodeApiEnv::DeleteMe
+// no longer deletes the runtime ΓÇö V8RuntimeEnv lifetime is managed by the
+// JsiRuntimeState attached-owner hook.
+//============================================================================
+class NodeApiEnv : public napi_env__ {
+ public:
+  NodeApiEnv(V8RuntimeEnv *runtime, int32_t apiVersion)
+      : napi_env__(runtime->GetIsolate(),
+                    runtime->GetContext(),
+                    apiVersion),
+        m_runtime(runtime) {}
+
+  ~NodeApiEnv() override {}
+
+  V8RuntimeEnv *runtime() const noexcept { return m_runtime; }
+
+  void DetachFromRuntime() noexcept { m_runtime = nullptr; }
+
+  void DeleteMe() override {
+    m_isDestructing = true;
+    if (m_runtime) {
+      m_runtime->removeModuleEnv(this);
+      m_runtime = nullptr;
+    }
+    DrainFinalizerQueue();
+    napi_env__::DeleteMe();
+  }
+
+  void EnqueueFinalizer(v8impl::RefTracker* finalizer) override {
+    napi_env__::EnqueueFinalizer(finalizer);
+    // Schedule a second pass only when it has not been scheduled, and not
+    // destructing the env.
+    if (!m_isFinalizationScheduled && !m_isDestructing && m_runtime) {
+      m_isFinalizationScheduled = true;
+      Ref();
+      m_runtime->SetImmediate([this]() {
+        m_isFinalizationScheduled = false;
+        Unref();
+        DrainFinalizerQueue();
+      });
+    }
+  }
+
+  void DrainFinalizerQueue() {
+    while (!pending_finalizers.empty()) {
+      v8impl::RefTracker* ref_tracker = *pending_finalizers.begin();
+      pending_finalizers.erase(ref_tracker);
+      ref_tracker->Finalize();
+    }
+  }
+
+  bool can_call_into_js() const override { return !m_isDestructing; }
+
+  void CallFinalizer(napi_finalize cb, void* data, void* hint) override {
+    if (in_gc_finalizer) {
+      cb(env, data, hint);
+      return;
+    }
+    // Finalizers may run during runtime teardown (after the isolate has been
+    // left by higher-level scopes). Context::Enter calls GetIsolate() which
+    // DCHECKs heap->isolate() == Isolate::TryGetCurrent() — fires (then hangs
+    // V8_Fatal's stderr writer) if no Isolate::Scope is active here.
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+    v8::Context::Scope context_scope(context());
+    CallIntoModule([&](napi_env env) { cb(env, data, hint); },
+                   [](napi_env env, v8::Local<v8::Value> local_err) {
+                     NodeApiEnv* runtimeEnv = static_cast<NodeApiEnv*>(env);
+                     if (env->terminatedOrTerminating()) {
+                       return;
+                     }
+                     runtimeEnv->TriggerFatalException(local_err);
+                   });
+  }
+
+  static void PrintToStderrAndFlush(const std::string& str) {
+    fprintf(stderr, "%s\n", str.c_str());
+    fflush(stderr);
+  }
+
+  void TriggerFatalException(v8::Local<v8::Value> err) {
+    v8::String::Utf8Value reason(
+        isolate,
+        err->ToDetailString(context()).FromMaybe(v8::Local<v8::String>()));
+    std::string reason_str(*reason, reason.length());
+    PrintToStderrAndFlush(reason_str + "\n");
+    _exit(static_cast<int>(node::ExitCode::kAbort));
+  }
+
+  napi_status collectGarbage() {
+    isolate->RequestGarbageCollectionForTesting(
+        v8::Isolate::kFullGarbageCollection);
+    return napi_status::napi_ok;
+  }
+
+  napi_status hasUnhandledPromiseRejection(bool* result) {
+    CHECK_ARG(env, result);
+    *result = m_runtime->HasUnhandledPromiseRejection();
+    return napi_ok;
+  }
+
+  napi_status getDescription(const char** result) noexcept {
+    CHECK_ARG(env, result);
+    *result = "V8";
+    return napi_ok;
+  }
+
+  napi_status drainMicrotasks(int32_t /*maxCountHint*/, bool* result) {
+    if (result) {
+      *result = true;
+    }
+    return napi_ok;
+  }
+
+  napi_status isInspectable(bool* result) noexcept {
+    CHECK_ARG(env, result);
+    *result = m_runtime->isInspectable();
+    return napi_ok;
+  }
+
+  napi_status openEnvScope(jsr_napi_env_scope* scope) {
+    CHECK_ARG(env, scope);
+    if (V8RuntimeEnv::NodeApiIsolateLocker::HasCurrentEnv(m_runtime)) {
+      V8RuntimeEnv::NodeApiIsolateLocker::Current()->AddRef();
+    } else {
+      ::new V8RuntimeEnv::NodeApiIsolateLocker(m_runtime);
+    }
+    *scope = reinterpret_cast<jsr_napi_env_scope>(
+        V8RuntimeEnv::NodeApiIsolateLocker::Current());
+    return napi_ok;
+  }
+
+  napi_status closeEnvScope(jsr_napi_env_scope scope) {
+    CHECK_ARG(env, scope);
+    V8RuntimeEnv::NodeApiIsolateLocker* locker =
+        reinterpret_cast<V8RuntimeEnv::NodeApiIsolateLocker*>(scope);
+    if (locker != V8RuntimeEnv::NodeApiIsolateLocker::Current()) {
+      return napi_generic_failure;
+    }
+    locker->Release();
+    return napi_ok;
+  }
+
+  napi_status getAndClearLastUnhandledPromiseRejection(napi_value* result) {
+    CHECK_ARG(env, result);
+    auto rejectionInfo = m_runtime->GetAndClearLastUnhandledPromiseRejection();
+    if (!rejectionInfo) {
+      *result = v8impl::JsValueFromV8LocalValue(v8::Undefined(isolate));
+      return napi_ok;
+    }
+    *result =
+        v8impl::JsValueFromV8LocalValue(rejectionInfo->value.Get(isolate));
+    return napi_ok;
+  }
+
+  napi_status runScript(napi_value source,
+                        const char* source_url,
+                        napi_value* result) {
+    NAPI_PREAMBLE(env);
+    CHECK_ARG(env, source);
+    CHECK_ARG(env, result);
+
+    v8::Local<v8::Value> v8_source = v8impl::V8LocalValueFromJsValue(source);
+    if (!v8_source->IsString()) {
+      return napi_set_last_error(env, napi_string_expected);
+    }
+
+    v8::Local<v8::Context> context = env->context();
+
+    const char* checked_source_url = source_url ? source_url : "";
+    v8::Local<v8::String> urlV8String =
+        v8::String::NewFromUtf8(context->GetIsolate(), checked_source_url)
+            .ToLocalChecked();
+    v8::ScriptOrigin origin(urlV8String);
+
+    auto maybe_script = v8::Script::Compile(
+        context, v8::Local<v8::String>::Cast(v8_source), &origin);
+    CHECK_MAYBE_EMPTY(env, maybe_script, napi_generic_failure);
+
+    auto script_result = maybe_script.ToLocalChecked()->Run(context);
+    CHECK_MAYBE_EMPTY(env, script_result, napi_generic_failure);
+
+    *result = v8impl::JsValueFromV8LocalValue(script_result.ToLocalChecked());
+    return GET_RETURN_STATUS(env);
+  }
+
+  // W8: prepare/run prepared scripts directly via V8 + the runtime's
+  // script-cache callbacks. Replaces the legacy V8Runtime::prepareJavaScript2
+  // / evaluatePreparedJavaScript2 round-trip through facebook::jsi types.
+  napi_status createPreparedScript(const uint8_t* scriptData,
+                                   size_t scriptLength,
+                                   jsr_data_delete_cb scriptDeleteCallback,
+                                   void* deleterData,
+                                   const char* sourceUrl,
+                                   jsr_prepared_script* result) {
+    NAPI_PREAMBLE(env);
+    CHECK_ARG(env, scriptData);
+    CHECK_ARG(env, sourceUrl);
+    CHECK_ARG(env, result);
+
+    auto cache = v8rt_internal::getScriptCacheCallbacks(m_runtime->abiRuntime());
+
+    uint64_t source_hash = 0;
+    if (cache.load_cb || cache.store_cb) {
+      murmurhash(scriptData, scriptLength, source_hash);
+    }
+
+    v8::Local<v8::String> sourceV8String =
+        v8::String::NewFromUtf8(isolate,
+                                 reinterpret_cast<const char*>(scriptData),
+                                 v8::NewStringType::kNormal,
+                                 static_cast<int>(scriptLength))
+            .ToLocalChecked();
+
+    if (scriptDeleteCallback != nullptr) {
+      // The buffer was copied into V8 by NewFromUtf8 above; release it.
+      scriptDeleteCallback(const_cast<uint8_t*>(scriptData), deleterData);
+    }
+
+    v8::Local<v8::String> urlV8String =
+        v8::String::NewFromUtf8(isolate, sourceUrl).ToLocalChecked();
+    v8::ScriptOrigin origin(urlV8String);
+
+    static constexpr const char* kCacheTag = "perf";
+    static constexpr const char* kRuntimeName = "V8";
+    const uint64_t runtime_version = v8::ScriptCompiler::CachedDataVersionTag();
+
+    v8::ScriptCompiler::CompileOptions options =
+        v8::ScriptCompiler::CompileOptions::kNoCompileOptions;
+    v8::ScriptCompiler::CachedData* cached_data = nullptr;
+    const uint8_t* cache_buffer = nullptr;
+    size_t cache_buffer_size = 0;
+    jsi_data_delete_cb cache_buffer_delete_cb = nullptr;
+    void* cache_buffer_deleter_data = nullptr;
+
+    if (cache.load_cb) {
+      cache.load_cb(cache.data,
+                     sourceUrl,
+                     source_hash,
+                     kRuntimeName,
+                     runtime_version,
+                     kCacheTag,
+                     &cache_buffer,
+                     &cache_buffer_size,
+                     &cache_buffer_delete_cb,
+                     &cache_buffer_deleter_data);
+      if (cache_buffer && cache_buffer_size > 0) {
+        cached_data = new v8::ScriptCompiler::CachedData(
+            cache_buffer, static_cast<int>(cache_buffer_size));
+        options = v8::ScriptCompiler::CompileOptions::kConsumeCodeCache;
+      }
+    }
+
+    v8::ScriptCompiler::Source script_source(sourceV8String, origin,
+                                              cached_data);
+
+    v8::Local<v8::Script> compiled;
+    bool compile_ok =
+        v8::ScriptCompiler::Compile(env->context(), &script_source, options)
+            .ToLocal(&compiled);
+
+    if (cache_buffer_delete_cb) {
+      cache_buffer_delete_cb(const_cast<uint8_t*>(cache_buffer),
+                              cache_buffer_deleter_data);
+    }
+
+    CHECK_MAYBE_EMPTY(env, v8::MaybeLocal<v8::Script>(
+                              compile_ok ? compiled : v8::Local<v8::Script>()),
+                       napi_generic_failure);
+    if (!compile_ok) return GET_RETURN_STATUS(env);
+
+    v8::Local<v8::UnboundScript> unbound = compiled->GetUnboundScript();
+
+    if (cache.store_cb &&
+        options != v8::ScriptCompiler::CompileOptions::kConsumeCodeCache) {
+      v8::ScriptCompiler::CachedData* codeCache =
+          v8::ScriptCompiler::CreateCodeCache(unbound);
+      if (codeCache) {
+        // Stateless lambda ΓåÆ function pointer via unary +; assign through a
+        // typed function-pointer variable so the conversion is well-formed.
+        jsi_data_delete_cb delete_cb = +[](void* /*data*/,
+                                             void* deleter_data) {
+          delete static_cast<v8::ScriptCompiler::CachedData*>(deleter_data);
+        };
+        cache.store_cb(cache.data,
+                        sourceUrl,
+                        source_hash,
+                        kRuntimeName,
+                        runtime_version,
+                        kCacheTag,
+                        codeCache->data,
+                        static_cast<size_t>(codeCache->length),
+                        delete_cb,
+                        codeCache);
+      }
+    }
+
+    auto* prepared = new NodeApiPreparedScript();
+    prepared->unbound.Reset(isolate, unbound);
+    *result = reinterpret_cast<jsr_prepared_script>(prepared);
+    return GET_RETURN_STATUS(env);
+  }
+
+  napi_status deletePreparedScript(jsr_prepared_script preparedScript) {
+    CHECK_ARG(env, preparedScript);
+    delete reinterpret_cast<NodeApiPreparedScript*>(preparedScript);
+    return napi_clear_last_error(env);
+  }
+
+  napi_status runPreparedScript(jsr_prepared_script preparedScript,
+                                napi_value* result) {
+    NAPI_PREAMBLE(env);
+    CHECK_ARG(env, preparedScript);
+    CHECK_ARG(env, result);
+
+    auto* prepared = reinterpret_cast<NodeApiPreparedScript*>(preparedScript);
+    v8::Local<v8::UnboundScript> unbound = prepared->unbound.Get(isolate);
+    v8::Local<v8::Script> script = unbound->BindToCurrentContext();
+
+    auto script_result = script->Run(env->context());
+    CHECK_MAYBE_EMPTY(env, script_result, napi_generic_failure);
+
+    *result = v8impl::JsValueFromV8LocalValue(script_result.ToLocalChecked());
+    return GET_RETURN_STATUS(env);
+  }
+
+  napi_status createNodeApi(int32_t apiVersion, napi_env* env_out) {
+    *env_out = m_runtime->createNodeApi(apiVersion);
+    return napi_ok;
+  }
+
+  napi_status runTask(jsr_task_run_cb task_cb, void* data) {
+    CallIntoModule([task_cb, data](napi_env env) { task_cb(data); });
+    return napi_ok;
+  }
+
+  napi_status instrumentationGetGCStats(jsr_string_output_cb cb, void* cb_ctx) {
+    CHECK_ARG(env, cb);
+    facebook::jsi::Instrumentation& instrumentation =
+        m_runtime->instrumentation();
+    std::string stats = instrumentation.getRecordedGCStats();
+    cb(cb_ctx, stats.data(), stats.size());
+    return napi_ok;
+  }
+
+  napi_status instrumentationGetHeapInfo(bool include_expensive,
+                                         jsr_heap_info_cb cb,
+                                         void* cb_ctx) {
+    CHECK_ARG(env, cb);
+    facebook::jsi::Instrumentation& instrumentation =
+        m_runtime->instrumentation();
+    std::unordered_map<std::string, int64_t> heap_info =
+        instrumentation.getHeapInfo(include_expensive);
+    for (const auto& entry : heap_info) {
+      cb(cb_ctx, entry.first.c_str(), entry.second);
+    }
+    return napi_ok;
+  }
+
+  napi_status instrumentationCollectGarbage(const char* cause) {
+    facebook::jsi::Instrumentation& instrumentation =
+        m_runtime->instrumentation();
+    instrumentation.collectGarbage(cause);
+    return napi_ok;
+  }
+
+  napi_status instrumentationStartHeapSampling(size_t sampling_interval) {
+    facebook::jsi::Instrumentation& instrumentation =
+        m_runtime->instrumentation();
+    instrumentation.startHeapSampling(sampling_interval);
+    return napi_ok;
+  }
+
+  napi_status instrumentationStopHeapSampling(jsr_string_output_cb cb,
+                                              void* cb_ctx) {
+    facebook::jsi::Instrumentation& instrumentation =
+        m_runtime->instrumentation();
+    std::stringstream stream;
+    instrumentation.stopHeapSampling(stream);
+    std::string out = stream.str();
+    cb(cb_ctx, out.data(), out.size());
+    return napi_ok;
+  }
+
+  napi_status instrumentationCreateHeapSnapshot(bool capture_numeric_value,
+                                                jsr_string_output_cb cb,
+                                                void* cb_ctx) {
+    CHECK_ARG(env, cb);
+    facebook::jsi::Instrumentation& instrumentation =
+        m_runtime->instrumentation();
+    std::stringstream stream;
+#if JSI_VERSION >= 13
+    facebook::jsi::Instrumentation::HeapSnapshotOptions options;
+    options.captureNumericValue = capture_numeric_value;
+    instrumentation.createSnapshotToStream(stream, options);
+#else
+    instrumentation.createSnapshotToStream(stream);
+#endif
+    std::string out = stream.str();
+    cb(cb_ctx, out.data(), out.size());
+    return napi_ok;
+  }
+
+ private:
+  V8RuntimeEnv* m_runtime;
+  napi_env env{this};
+  bool m_isDestructing{};
+  bool m_isFinalizationScheduled{};
+};
+
+// V8RuntimeEnv method bodies that need NodeApiEnv to be a complete type.
+
+NodeApiEnv* V8RuntimeEnv::createNodeApi(int32_t apiVersion) {
+  NodeApiEnv* env = new NodeApiEnv(this, apiVersion);
+  moduleEnvList_.push_back(env);
+  return env;
+}
+
+napi_status V8RuntimeEnv::getRootNodeApi(napi_env* env) {
+  *env = rootEnv_;
+  return napi_ok;
+}
+
+void V8RuntimeEnv::removeModuleEnv(NodeApiEnv* env) {
+  auto it = std::find(moduleEnvList_.begin(), moduleEnvList_.end(), env);
+  if (it != moduleEnvList_.end()) {
+    moduleEnvList_.erase(it);
+  }
+  if (rootEnv_ == env) {
+    rootEnv_ = nullptr;
+  }
+}
+
+void V8RuntimeEnv::Unref(NodeApiEnv* env) {
+  env->Unref();
+}
+
+//============================================================================
+// RuntimeWrapper ΓÇö backs the public jsr_runtime opaque type.
+//
+// Owns a jsi_runtime (created via v8_create_runtime) and the V8RuntimeEnv
+// attached on top via v8_attach_node_api. The V8RuntimeEnv lifetime is
+// managed via JsiRuntimeState's attached-owner hook, so ~RuntimeWrapper
+// just calls jsi_release on the abi runtime and the cascade tears down
+// V8RuntimeEnv ΓåÆ root napi_env ΓåÆ ~JsiRuntimeState ΓåÆ V8 isolate.
+//============================================================================
+class RuntimeWrapper {
+ public:
+  RuntimeWrapper(jsi_runtime* abiRuntime, napi_env rootEnv) noexcept
+      : abiRuntime_(abiRuntime), rootEnv_(rootEnv) {}
+
+  ~RuntimeWrapper() {
+    // Release the abi runtime; this triggers ~JsiRuntimeState which fires
+    // the attached-owner hook and tears down V8RuntimeEnv (which Unrefs
+    // rootEnv_ ΓåÆ ~NodeApiEnv).
+    if (abiRuntime_ && abiRuntime_->vt && abiRuntime_->vt->release) {
+      abiRuntime_->vt->release(abiRuntime_);
+    }
+  }
+
+  jsi_runtime* abiRuntime() const noexcept { return abiRuntime_; }
+
+  napi_status getNodeApi(napi_env* env) noexcept {
+    *env = rootEnv_;
+    return napi_ok;
+  }
+
+  napi_status getJsiRuntime(jsi_runtime** out) noexcept {
+    if (!out) return napi_invalid_arg;
+    *out = abiRuntime_;
+    return napi_ok;
+  }
+
+  napi_status createNodeApi(int32_t apiVersion, napi_env* env) {
+    auto* nodeEnv = static_cast<NodeApiEnv*>(rootEnv_);
+    *env = nodeEnv->runtime()->createNodeApi(apiVersion);
+    return napi_ok;
+  }
+
+ private:
+  jsi_runtime* abiRuntime_;
+  napi_env rootEnv_;
+};
+
+//============================================================================
+// V8TaskRunner / V8ScriptCache ΓÇö local config helpers
+//
+// W8: these own the consumer-supplied task runner / script cache C
+// callback bundles. ConfigWrapper holds them; on jsr_create_runtime they
+// are translated into v8_jsi_config setters that hand a C-callback pair to
+// the JSI ABI. The wrapper lifetime is governed by the ABI's deleter
+// contract ΓÇö the deleter the wrapper passes to v8_jsi_config_set_*
+// outlives the config and is invoked exactly once on runtime destruction.
+//============================================================================
+class V8TaskRunner {
+ public:
+  V8TaskRunner(void* taskRunnerData,
+               jsr_task_runner_post_task_cb postTaskCallback,
+               jsr_data_delete_cb deleteCallback,
+               void* deleterData) noexcept
+      : taskRunnerData_(taskRunnerData),
+        postTaskCallback_(postTaskCallback),
+        deleteCallback_(deleteCallback),
+        deleterData_(deleterData) {}
+
+  ~V8TaskRunner() {
+    if (deleteCallback_ != nullptr) {
+      deleteCallback_(taskRunnerData_, deleterData_);
+    }
+  }
+
+  V8TaskRunner(const V8TaskRunner&) = delete;
+  V8TaskRunner& operator=(const V8TaskRunner&) = delete;
+
+  void* taskRunnerData() const noexcept { return taskRunnerData_; }
+  jsr_task_runner_post_task_cb postTaskCallback() const noexcept {
+    return postTaskCallback_;
+  }
+
+ private:
+  void* taskRunnerData_;
+  jsr_task_runner_post_task_cb postTaskCallback_;
+  jsr_data_delete_cb deleteCallback_;
+  void* deleterData_;
+};
+
+class V8ScriptCache {
+ public:
+  V8ScriptCache(void* scriptCacheData,
+                jsr_script_cache_load_cb scriptCacheLoadCallback,
+                jsr_script_cache_store_cb scriptCacheStoreCallback,
+                jsr_data_delete_cb scriptCacheDataDeleteCallback,
+                void* deleterData) noexcept
+      : scriptCacheData_(scriptCacheData),
+        scriptCacheLoadCallback_(scriptCacheLoadCallback),
+        scriptCacheStoreCallback_(scriptCacheStoreCallback),
+        scriptCacheDataDeleteCallback_(scriptCacheDataDeleteCallback),
+        deleterData_(deleterData) {}
+
+  ~V8ScriptCache() {
+    if (scriptCacheDataDeleteCallback_) {
+      scriptCacheDataDeleteCallback_(scriptCacheData_, deleterData_);
+    }
+  }
+
+  V8ScriptCache(const V8ScriptCache&) = delete;
+  V8ScriptCache& operator=(const V8ScriptCache&) = delete;
+
+  void* scriptCacheData() const noexcept { return scriptCacheData_; }
+  jsr_script_cache_load_cb loadCb() const noexcept {
+    return scriptCacheLoadCallback_;
+  }
+  jsr_script_cache_store_cb storeCb() const noexcept {
+    return scriptCacheStoreCallback_;
+  }
+
+ private:
+  void* scriptCacheData_{};
+  jsr_script_cache_load_cb scriptCacheLoadCallback_{};
+  jsr_script_cache_store_cb scriptCacheStoreCallback_{};
+  jsr_data_delete_cb scriptCacheDataDeleteCallback_{};
+  void* deleterData_{};
+};
+
+//============================================================================
+// ConfigWrapper ΓÇö backs the public jsr_config opaque type.
+//
+// W8: stores the consumer-facing values directly (no V8RuntimeArgs round
+// trip). On jsr_create_runtime the values are pushed into a jsi_config via
+// v8_jsi_config_set_* setters, then v8_create_runtime + v8_attach_node_api
+// build the final jsr_runtime.
+//============================================================================
+class ConfigWrapper {
+ public:
+  napi_status enableInspector(bool value) {
+    enableInspector_ = value;
+    return napi_ok;
+  }
+
+  napi_status enableGCApi(bool value) {
+    enableGCApi_ = value;
+    return napi_ok;
+  }
+
+  napi_status enableMultithreading(bool value) {
+    enableMultithreading_ = value;
+    return napi_ok;
+  }
+
+  napi_status setInspectorRuntimeName(std::string name) {
+    inspectorRuntimeName_ = std::move(name);
+    return napi_ok;
+  }
+
+  napi_status setInspectorPort(uint16_t port) {
+    inspectorPort_ = port;
+    return napi_ok;
+  }
+
+  napi_status setInspectorBreakOnStart(bool value) {
+    inspectorBreakOnStart_ = value;
+    return napi_ok;
+  }
+
+  napi_status setTaskRunner(std::shared_ptr<V8TaskRunner> taskRunner) {
+    taskRunner_ = std::move(taskRunner);
+    return napi_ok;
+  }
+
+  napi_status setScriptCache(std::shared_ptr<V8ScriptCache> scriptCache) {
+    scriptCache_ = std::move(scriptCache);
+    return napi_ok;
+  }
+
+  // Populate a factory-owned jsi_config from this wrapper's fields. Called from
+  // the v8_create_runtime configure callback — the factory owns cfg's lifetime.
+  void buildJsiConfigInto(jsi_config cfg) const {
+    v8_jsi_config_enable_inspector(cfg, enableInspector_);
+    v8_jsi_config_set_inspector_port(cfg, inspectorPort_);
+    v8_jsi_config_set_inspector_break_on_start(cfg, inspectorBreakOnStart_);
+    v8_jsi_config_set_debugger_runtime_name(cfg,
+                                              inspectorRuntimeName_.c_str());
+    v8_jsi_config_enable_gc_api(cfg, enableGCApi_);
+    v8_jsi_config_enable_multi_thread(cfg, enableMultithreading_);
+
+    if (taskRunner_) {
+      // Forward the consumer-supplied C task runner straight through. We
+      // hand a shared_ptr<V8TaskRunner>* to the ABI as runner_data; the
+      // ABI's deleter releases the holder, and ~V8TaskRunner runs the
+      // consumer's data-deleter callback exactly once.
+      auto* runnerHolder = new std::shared_ptr<V8TaskRunner>(taskRunner_);
+      v8_jsi_config_set_task_runner(
+          cfg,
+          /*task_runner_data:*/ runnerHolder,
+          /*post_task_cb:*/
+          [](void* runner_data, void* task_data,
+             v8_jsi_task_run_cb task_run_cb,
+             jsi_data_delete_cb task_data_delete_cb, void* deleter_data) {
+            auto* runner =
+                static_cast<std::shared_ptr<V8TaskRunner>*>(runner_data);
+            // jsr_*_cb and v8_jsi_*_cb have the same call signature
+            // (void(*)(void*) and void(*)(void*, void*)) ΓÇö both __cdecl on
+            // Windows, both unspecified on POSIX. reinterpret_cast is well
+            // defined here.
+            (*runner)->postTaskCallback()(
+                (*runner)->taskRunnerData(),
+                task_data,
+                reinterpret_cast<jsr_task_run_cb>(task_run_cb),
+                reinterpret_cast<jsr_data_delete_cb>(task_data_delete_cb),
+                deleter_data);
+          },
+          /*task_runner_data_delete_cb:*/
+          [](void* runner_data, void* /*deleter_data*/) {
+            delete static_cast<std::shared_ptr<V8TaskRunner>*>(runner_data);
+          },
+          /*deleter_data:*/ nullptr);
+    }
+
+    if (scriptCache_) {
+      auto* cacheHolder = new std::shared_ptr<V8ScriptCache>(scriptCache_);
+      v8_jsi_config_set_script_cache(
+          cfg,
+          /*script_cache_data:*/ cacheHolder,
+          /*load_cb:*/
+          [](void* data, const char* source_url, uint64_t source_hash,
+             const char* runtime_name, uint64_t runtime_version,
+             const char* cache_tag, const uint8_t** buffer,
+             size_t* buffer_size, jsi_data_delete_cb* buffer_delete_cb,
+             void** deleter_data) {
+            auto* holder = static_cast<std::shared_ptr<V8ScriptCache>*>(data);
+            (*holder)->loadCb()(
+                (*holder)->scriptCacheData(), source_url, source_hash,
+                runtime_name, runtime_version, cache_tag, buffer, buffer_size,
+                reinterpret_cast<jsr_data_delete_cb*>(buffer_delete_cb),
+                deleter_data);
+          },
+          /*store_cb:*/
+          [](void* data, const char* source_url, uint64_t source_hash,
+             const char* runtime_name, uint64_t runtime_version,
+             const char* cache_tag, const uint8_t* buffer, size_t buffer_size,
+             jsi_data_delete_cb buffer_delete_cb, void* deleter_data) {
+            auto* holder = static_cast<std::shared_ptr<V8ScriptCache>*>(data);
+            (*holder)->storeCb()(
+                (*holder)->scriptCacheData(), source_url, source_hash,
+                runtime_name, runtime_version, cache_tag, buffer, buffer_size,
+                reinterpret_cast<jsr_data_delete_cb>(buffer_delete_cb),
+                deleter_data);
+          },
+          /*data_delete_cb:*/
+          [](void* data, void* /*deleter_data*/) {
+            delete static_cast<std::shared_ptr<V8ScriptCache>*>(data);
+          },
+          /*deleter_data:*/ nullptr);
+    }
+  }
+
+ private:
+  bool enableInspector_{};
+  bool enableMultithreading_{};
+  bool enableGCApi_{};
+  std::string inspectorRuntimeName_;
+  uint16_t inspectorPort_{9223};
+  bool inspectorBreakOnStart_{};
+  std::shared_ptr<V8TaskRunner> taskRunner_;
+  std::shared_ptr<V8ScriptCache> scriptCache_;
+};
+
+}  // namespace v8impl
+
+//============================================================================
+// v8_attach_node_api ΓÇö JSI ABI dual-API attachment seam.
+//============================================================================
+
+JSI_API napi_status JSI_CDECL v8_attach_node_api(jsi_runtime* runtime,
+                                                  int32_t /*api_version*/,
+                                                  napi_env* env_out) {
+  if (!runtime || !env_out) return napi_invalid_arg;
+
+  auto* v8Env = new v8impl::V8RuntimeEnv(runtime);
+  napi_env root{};
+  napi_status s = v8Env->getRootNodeApi(&root);
+  if (s != napi_ok) {
+    delete v8Env;
+    return s;
+  }
+
+  // Register the V8RuntimeEnv as the runtime's attached owner. ~JsiRuntimeState
+  // will invoke this destroy callback before disposing V8 state.
+  v8rt_internal::setAttachedOwner(
+      runtime, v8Env,
+      [](void* owner) {
+        delete static_cast<v8impl::V8RuntimeEnv*>(owner);
+      });
+
+  *env_out = root;
+  return napi_ok;
+}
+
+// Provides a hint to run garbage collection.
+JSR_API jsr_collect_garbage(napi_env env) {
+  return CHECKED_ENV(env)->collectGarbage();
+}
+
+JSR_API jsr_has_unhandled_promise_rejection(napi_env env, bool* result) {
+  return CHECKED_ENV(env)->hasUnhandledPromiseRejection(result);
+}
+
+JSR_API jsr_get_and_clear_last_unhandled_promise_rejection(napi_env env,
+                                                           napi_value* result) {
+  return CHECKED_ENV(env)->getAndClearLastUnhandledPromiseRejection(result);
+}
+
+JSR_API jsr_get_description(napi_env env, const char** result) {
+  return CHECKED_ENV(env)->getDescription(result);
+}
+
+JSR_API jsr_drain_microtasks(napi_env env,
+                             int32_t max_count_hint,
+                             bool* result) {
+  return CHECKED_ENV(env)->drainMicrotasks(max_count_hint, result);
+}
+
+JSR_API jsr_is_inspectable(napi_env env, bool* result) {
+  return CHECKED_ENV(env)->isInspectable(result);
+}
+
+JSR_API jsr_open_napi_env_scope(napi_env env, jsr_napi_env_scope* scope) {
+  return CHECKED_ENV(env)->openEnvScope(scope);
+}
+
+JSR_API jsr_close_napi_env_scope(napi_env env, jsr_napi_env_scope scope) {
+  return CHECKED_ENV(env)->closeEnvScope(scope);
+}
+
+JSR_API jsr_run_script(napi_env env,
+                       napi_value source,
+                       const char* source_url,
+                       napi_value* result) {
+  return CHECKED_ENV(env)->runScript(source, source_url, result);
+}
+
+JSR_API jsr_create_prepared_script(napi_env env,
+                                   const uint8_t* script_data,
+                                   size_t script_length,
+                                   jsr_data_delete_cb script_delete_cb,
+                                   void* deleter_data,
+                                   const char* source_url,
+                                   jsr_prepared_script* result) {
+  return CHECKED_ENV(env)->createPreparedScript(script_data,
+                                                script_length,
+                                                script_delete_cb,
+                                                deleter_data,
+                                                source_url,
+                                                result);
+}
+
+JSR_API jsr_delete_prepared_script(napi_env env,
+                                   jsr_prepared_script prepared_script) {
+  return CHECKED_ENV(env)->deletePreparedScript(prepared_script);
+}
+
+JSR_API jsr_prepared_script_run(napi_env env,
+                                jsr_prepared_script prepared_script,
+                                napi_value* result) {
+  return CHECKED_ENV(env)->runPreparedScript(prepared_script, result);
+}
+
+// Configure trampoline for v8_create_runtime: the factory hands us a config and
+// we populate it from the ConfigWrapper carried in cb_data. The runtime takes
+// ownership of the cache/runner data via the ABI's deleter contract; the config
+// shell itself is owned and freed by the factory.
+static jsi_error_code JSI_CDECL configureFromWrapper(void* cb_data,
+                                                     jsi_config cfg) {
+  static_cast<const v8impl::ConfigWrapper*>(cb_data)->buildJsiConfigInto(cfg);
+  return jsi_no_error;
+}
+
+JSR_API jsr_create_runtime(jsr_config config, jsr_runtime* runtime) {
+  V8_CHECK_ARG(config);
+  V8_CHECK_ARG(runtime);
+
+  auto* configWrapper = reinterpret_cast<v8impl::ConfigWrapper*>(config);
+
+  // Create the foundation ABI runtime, populating its config via the pull
+  // callback. v8_create_runtime owns the jsi_config lifetime; the runtime takes
+  // ownership of the cache/runner data via the ABI's deleter contract.
+  jsi_runtime* abiRuntime =
+      v8_create_runtime(JSI_ABI_VERSION, configureFromWrapper, configWrapper);
+  if (!abiRuntime) return napi_generic_failure;
+
+  napi_env rootEnv{};
+  napi_status s = v8_attach_node_api(abiRuntime, NAPI_VERSION_EXPERIMENTAL,
+                                      &rootEnv);
+  if (s != napi_ok) {
+    if (abiRuntime->vt && abiRuntime->vt->release) {
+      abiRuntime->vt->release(abiRuntime);
+    }
+    return s;
+  }
+
+  *runtime = reinterpret_cast<jsr_runtime>(
+      new v8impl::RuntimeWrapper(abiRuntime, rootEnv));
+  return napi_ok;
+}
+
+JSR_API jsr_delete_runtime(jsr_runtime runtime) {
+  V8_CHECK_ARG(runtime);
+  delete reinterpret_cast<v8impl::RuntimeWrapper*>(runtime);
+  return napi_ok;
+}
+
+JSR_API v8_platform_dispose() {
+  v8rt::V8PlatformHolder::disposePlatform();
+  return napi_ok;
+}
+
+JSR_API jsr_runtime_get_node_api_env(jsr_runtime runtime, napi_env* env) {
+  return CHECKED_RUNTIME(runtime)->getNodeApi(env);
+}
+
+JSR_API jsr_runtime_get_jsi_runtime(jsr_runtime runtime,
+                                     struct jsi_runtime** abi_runtime) {
+  return CHECKED_RUNTIME(runtime)->getJsiRuntime(abi_runtime);
+}
+
+JSR_API jsr_create_node_api_env(napi_env root_env,
+                                int32_t api_version,
+                                napi_env* env) {
+  return CHECKED_ENV(root_env)->createNodeApi(api_version, env);
+}
+
+JSR_API jsr_run_task(napi_env env, jsr_task_run_cb task_cb, void* data) {
+  return CHECKED_ENV(env)->runTask(task_cb, data);
+}
+
+JSR_API jsr_create_config(jsr_config* config) {
+  V8_CHECK_ARG(config);
+  *config = reinterpret_cast<jsr_config>(new v8impl::ConfigWrapper());
+  return napi_ok;
+}
+
+JSR_API jsr_delete_config(jsr_config config) {
+  V8_CHECK_ARG(config);
+  delete reinterpret_cast<v8impl::ConfigWrapper*>(config);
+  return napi_ok;
+}
+
+JSR_API jsr_config_enable_inspector(jsr_config config, bool value) {
+  return CHECKED_CONFIG(config)->enableInspector(value);
+}
+
+JSR_API jsr_config_enable_gc_api(jsr_config config, bool value) {
+  return CHECKED_CONFIG(config)->enableGCApi(value);
+}
+
+JSR_API v8_config_enable_multithreading(jsr_config config, bool value) {
+  return CHECKED_CONFIG(config)->enableMultithreading(value);
+}
+
+JSR_API jsr_config_set_inspector_runtime_name(jsr_config config,
+                                              const char* name) {
+  return CHECKED_CONFIG(config)->setInspectorRuntimeName(name);
+}
+
+JSR_API jsr_config_set_inspector_port(jsr_config config, uint16_t port) {
+  return CHECKED_CONFIG(config)->setInspectorPort(port);
+}
+
+JSR_API jsr_config_set_inspector_break_on_start(jsr_config config, bool value) {
+  return CHECKED_CONFIG(config)->setInspectorBreakOnStart(value);
+}
+
+JSR_API jsr_config_set_task_runner(
+    jsr_config config,
+    void* task_runner_data,
+    jsr_task_runner_post_task_cb task_runner_post_task_cb,
+    jsr_data_delete_cb task_runner_data_delete_cb,
+    void* deleter_data) {
+  return CHECKED_CONFIG(config)->setTaskRunner(
+      std::make_shared<v8impl::V8TaskRunner>(task_runner_data,
+                                             task_runner_post_task_cb,
+                                             task_runner_data_delete_cb,
+                                             deleter_data));
+}
+
+JSR_API jsr_config_set_script_cache(
+    jsr_config config,
+    void* script_cache_data,
+    jsr_script_cache_load_cb script_cache_load_cb,
+    jsr_script_cache_store_cb script_cache_store_cb,
+    jsr_data_delete_cb script_cache_data_delete_cb,
+    void* deleter_data) {
+  return CHECKED_CONFIG(config)->setScriptCache(
+      std::make_shared<v8impl::V8ScriptCache>(script_cache_data,
+                                              script_cache_load_cb,
+                                              script_cache_store_cb,
+                                              script_cache_data_delete_cb,
+                                              deleter_data));
+}
+
+namespace node {
+
+namespace per_process {
+// From node.cc ΓÇö tells whether the per-process V8::Initialize() is called and
+// whether it is safe to call v8::Isolate::GetCurrent().
+bool v8_initialized = false;
+}  // namespace per_process
+
+// From node_errors.cc
+[[noreturn]] void Assert(const AssertionInfo& info) {
+#ifdef _WIN32
+  char* processName{};
+  _get_pgmptr(&processName);
+
+  fprintf(stderr,
+          "%s: %s:%s%s Assertion `%s' failed.\n",
+          processName,
+          info.file_line,
+          info.function,
+          *info.function ? ":" : "",
+          info.message);
+  fflush(stderr);
+#endif  // _WIN32
+
+  std::terminate();
+}
+
+}  // namespace node
+
+// The created Buffer is the Uint8Array as in Node.js with version >= 4.
+napi_status NAPI_CDECL
+napi_create_external_buffer(napi_env env,
+                            size_t length,
+                            void* data,
+                            node_api_nogc_finalize finalize_cb,
+                            void* finalize_hint,
+                            napi_value* result) {
+  NAPI_PREAMBLE(env);
+  CHECK_ARG(env, result);
+
+  struct DeleterData {
+    napi_env env;
+    node_api_nogc_finalize finalize_cb;
+    void* finalize_hint;
+  };
+
+  v8::Isolate* isolate = env->isolate;
+
+  DeleterData* deleterData =
+      finalize_cb != nullptr ? new DeleterData{env, finalize_cb, finalize_hint}
+                             : nullptr;
+  std::unique_ptr<v8::BackingStore> backingStore =
+      v8::ArrayBuffer::NewBackingStore(
+          data,
+          length,
+          [](void* data, size_t length, void* deleter_data) {
+            DeleterData* deleterData = static_cast<DeleterData*>(deleter_data);
+            if (deleterData != nullptr) {
+              deleterData->finalize_cb(
+                  deleterData->env, data, deleterData->finalize_hint);
+              delete deleterData;
+            }
+          },
+          deleterData);
+
+  v8::Local<v8::ArrayBuffer> arrayBuffer = v8::ArrayBuffer::New(
+      isolate, std::shared_ptr<v8::BackingStore>(std::move(backingStore)));
+  if (data == nullptr) {
+    arrayBuffer->Detach(v8::Local<v8::Value>()).Check();
+    if (deleterData != nullptr) {
+      deleterData->finalize_cb(
+          deleterData->env, nullptr, deleterData->finalize_hint);
+      delete deleterData;
+    }
+  }
+
+  v8::Local<v8::Uint8Array> buffer =
+      v8::Uint8Array::New(arrayBuffer, 0, length);
+
+  *result = v8impl::JsValueFromV8LocalValue(buffer);
+  return GET_RETURN_STATUS(env);
+}
+
+//=============================================================================
+// JSI instrumentation
+//=============================================================================
+
+JSR_API jsr_instrumentation_get_gc_stats(napi_env env,
+                                         jsr_string_output_cb cb,
+                                         void* cb_ctx) {
+  return CHECKED_ENV(env)->instrumentationGetGCStats(cb, cb_ctx);
+}
+
+JSR_API jsr_instrumentation_get_heap_info(napi_env env,
+                                          bool include_expensive,
+                                          jsr_heap_info_cb cb,
+                                          void* cb_ctx) {
+  return CHECKED_ENV(env)->instrumentationGetHeapInfo(
+      include_expensive, cb, cb_ctx);
+}
+
+JSR_API jsr_instrumentation_collect_garbage(napi_env env, const char* cause) {
+  return CHECKED_ENV(env)->instrumentationCollectGarbage(cause);
+}
+
+JSR_API jsr_instrumentation_start_heap_sampling(napi_env env,
+                                                size_t sampling_interval) {
+  return CHECKED_ENV(env)->instrumentationStartHeapSampling(sampling_interval);
+}
+
+JSR_API jsr_instrumentation_stop_heap_sampling(napi_env env,
+                                               jsr_string_output_cb cb,
+                                               void* cb_ctx) {
+  return CHECKED_ENV(env)->instrumentationStopHeapSampling(cb, cb_ctx);
+}
+
+JSR_API jsr_instrumentation_create_heap_snapshot(napi_env env,
+                                                 bool capture_numeric_value,
+                                                 jsr_string_output_cb cb,
+                                                 void* cb_ctx) {
+  return CHECKED_ENV(env)->instrumentationCreateHeapSnapshot(
+      capture_numeric_value, cb, cb_ctx);
+}

--- a/src/public/V8JsiRuntime.cpp
+++ b/src/public/V8JsiRuntime.cpp
@@ -1,0 +1,304 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// Consumer-side definition of v8runtime::makeV8Runtime.
+//
+// This translation unit ships as source in the NuGet alongside V8JsiRuntime.h
+// (see also include/node-api-jsi/NodeApiJsiRuntime.cpp for the same pattern).
+// The consumer compiles it locally; only the C-stable v8_jsi_config_* setters,
+// the v8_create_runtime entry point, and the JsiAbiRuntime C++ wrapper (also
+// compiled in the consumer) cross into v8jsi.dll.
+
+#include "V8JsiRuntime.h"
+
+#include "jsi_abi/JsiAbiRuntime.h"
+#include "jsi_abi/v8_jsi_config.h"
+#include "ScriptStore.h"
+
+namespace v8runtime {
+
+namespace {
+
+// Wraps a buffer that crosses the DLL boundary back into a facebook::jsi::Buffer
+// so the consumer's PreparedScriptStore::persistPreparedScript can hold on to
+// the bytes for later retrieval. The supplied delete callback frees the bytes
+// in whichever CRT allocated them — ours, when invoked from inside V8jsi.dll's
+// store path; theirs, when invoked from a recursive load.
+class V8JsiBuffer final : public facebook::jsi::Buffer {
+ public:
+  V8JsiBuffer(
+      const uint8_t *buffer,
+      size_t bufferSize,
+      jsi_data_delete_cb bufferDeleteCallback,
+      void *deleterData) noexcept
+      : buffer_(buffer),
+        bufferSize_(bufferSize),
+        bufferDeleteCallback_(bufferDeleteCallback),
+        deleterData_(deleterData) {}
+
+  ~V8JsiBuffer() override {
+    if (bufferDeleteCallback_) {
+      bufferDeleteCallback_(
+          const_cast<uint8_t *>(buffer_), deleterData_);
+    }
+  }
+
+  V8JsiBuffer(const V8JsiBuffer &) = delete;
+  V8JsiBuffer &operator=(const V8JsiBuffer &) = delete;
+
+  const uint8_t *data() const override { return buffer_; }
+  size_t size() const override { return bufferSize_; }
+
+ private:
+  const uint8_t *buffer_;
+  size_t bufferSize_;
+  jsi_data_delete_cb bufferDeleteCallback_;
+  void *deleterData_;
+};
+
+// Adapter from the consumer's std::shared_ptr<facebook::jsi::PreparedScriptStore>
+// to the C-callback shape expected by v8_jsi_config_set_script_cache. Modeled
+// on react-native-windows/vnext/Shared/JSI/V8RuntimeHolder.cpp's V8ScriptCache.
+//
+// Allocated and freed entirely in the consumer's CRT — the DLL only sees an
+// opaque void* and three function pointers.
+class V8ScriptCache {
+ public:
+  static void Create(
+      jsi_config config,
+      std::shared_ptr<facebook::jsi::PreparedScriptStore> scriptStore) {
+    v8_jsi_config_set_script_cache(
+        config,
+        new V8ScriptCache(std::move(scriptStore)),
+        &LoadScript,
+        &StoreScript,
+        &Delete,
+        nullptr);
+  }
+
+ private:
+  explicit V8ScriptCache(
+      std::shared_ptr<facebook::jsi::PreparedScriptStore> scriptStore)
+      : scriptStore_(std::move(scriptStore)) {}
+
+  static void __cdecl LoadScript(
+      void *scriptCache,
+      const char *sourceUrl,
+      uint64_t sourceHash,
+      const char *runtimeName,
+      uint64_t runtimeVersion,
+      const char *cacheTag,
+      const uint8_t **buffer,
+      size_t *bufferSize,
+      jsi_data_delete_cb *bufferDeleteCallback,
+      void **deleterData) {
+    auto &scriptStore =
+        reinterpret_cast<V8ScriptCache *>(scriptCache)->scriptStore_;
+    std::shared_ptr<const facebook::jsi::Buffer> preparedScript =
+        scriptStore->tryGetPreparedScript(
+            facebook::jsi::ScriptSignature{sourceUrl, sourceHash},
+            facebook::jsi::JSRuntimeSignature{runtimeName, runtimeVersion},
+            cacheTag);
+    if (preparedScript) {
+      *buffer = preparedScript->data();
+      *bufferSize = preparedScript->size();
+      *bufferDeleteCallback = [](void * /*data*/, void *deleterData) {
+        delete reinterpret_cast<
+            std::shared_ptr<const facebook::jsi::Buffer> *>(deleterData);
+      };
+      *deleterData = new std::shared_ptr<const facebook::jsi::Buffer>(
+          std::move(preparedScript));
+    } else {
+      *buffer = nullptr;
+      *bufferSize = 0;
+      *bufferDeleteCallback = nullptr;
+      *deleterData = nullptr;
+    }
+  }
+
+  static void __cdecl StoreScript(
+      void *scriptCache,
+      const char *sourceUrl,
+      uint64_t sourceHash,
+      const char *runtimeName,
+      uint64_t runtimeVersion,
+      const char *cacheTag,
+      const uint8_t *buffer,
+      size_t bufferSize,
+      jsi_data_delete_cb bufferDeleteCallback,
+      void *deleterData) {
+    auto &scriptStore =
+        reinterpret_cast<V8ScriptCache *>(scriptCache)->scriptStore_;
+    scriptStore->persistPreparedScript(
+        std::make_shared<V8JsiBuffer>(
+            buffer, bufferSize, bufferDeleteCallback, deleterData),
+        facebook::jsi::ScriptSignature{sourceUrl, sourceHash},
+        facebook::jsi::JSRuntimeSignature{runtimeName, runtimeVersion},
+        cacheTag);
+  }
+
+  static void __cdecl Delete(void *scriptCache, void * /*deleterData*/) {
+    delete reinterpret_cast<V8ScriptCache *>(scriptCache);
+  }
+
+  std::shared_ptr<facebook::jsi::PreparedScriptStore> scriptStore_;
+};
+
+// Adapter from the consumer's std::shared_ptr<JSITaskRunner> to the C-callback
+// shape expected by v8_jsi_config_set_task_runner. Modeled on
+// react-native-windows/vnext/Shared/JSI/V8RuntimeHolder.cpp's V8TaskRunner.
+//
+// Allocated and freed entirely in the consumer's CRT — the DLL only sees an
+// opaque void* and two function pointers.
+class V8TaskRunner {
+ public:
+  static void Create(jsi_config config,
+                     std::shared_ptr<JSITaskRunner> taskRunner) {
+    v8_jsi_config_set_task_runner(
+        config,
+        new V8TaskRunner(std::move(taskRunner)),
+        &PostTask,
+        &Delete,
+        nullptr);
+  }
+
+ private:
+  explicit V8TaskRunner(std::shared_ptr<JSITaskRunner> taskRunner)
+      : taskRunner_(std::move(taskRunner)) {}
+
+  // Wraps the C-callback pair as a JSITask the consumer's runner can post.
+  // Destructor invokes the DLL-supplied delete callback so the DLL frees
+  // the task in its own CRT.
+  class CTask final : public JSITask {
+   public:
+    CTask(void *taskData,
+          v8_jsi_task_run_cb taskRunCb,
+          jsi_data_delete_cb taskDataDeleteCb,
+          void *deleterData) noexcept
+        : taskData_(taskData),
+          taskRunCb_(taskRunCb),
+          taskDataDeleteCb_(taskDataDeleteCb),
+          deleterData_(deleterData) {}
+
+    ~CTask() override {
+      if (taskDataDeleteCb_) {
+        taskDataDeleteCb_(taskData_, deleterData_);
+      }
+    }
+
+    CTask(const CTask &) = delete;
+    CTask &operator=(const CTask &) = delete;
+
+    void run() override {
+      if (taskRunCb_) {
+        taskRunCb_(taskData_);
+      }
+    }
+
+   private:
+    void *taskData_;
+    v8_jsi_task_run_cb taskRunCb_;
+    jsi_data_delete_cb taskDataDeleteCb_;
+    void *deleterData_;
+  };
+
+  static void __cdecl PostTask(
+      void *taskRunnerData,
+      void *taskData,
+      v8_jsi_task_run_cb taskRunCb,
+      jsi_data_delete_cb taskDataDeleteCb,
+      void *deleterData) {
+    auto &taskRunner =
+        reinterpret_cast<V8TaskRunner *>(taskRunnerData)->taskRunner_;
+    taskRunner->postTask(std::make_unique<CTask>(
+        taskData, taskRunCb, taskDataDeleteCb, deleterData));
+  }
+
+  static void __cdecl Delete(void *taskRunnerData, void * /*deleterData*/) {
+    delete reinterpret_cast<V8TaskRunner *>(taskRunnerData);
+  }
+
+  std::shared_ptr<JSITaskRunner> taskRunner_;
+};
+
+void applyArgs(jsi_config cfg, const V8RuntimeArgs &args) {
+  v8_jsi_config_set_initial_heap_size(cfg, args.initial_heap_size_in_bytes);
+  v8_jsi_config_set_maximum_heap_size(cfg, args.maximum_heap_size_in_bytes);
+  v8_jsi_config_set_thread_pool_size(cfg, args.flags.thread_pool_size);
+  v8_jsi_config_set_debugger_runtime_name(
+      cfg, args.debuggerRuntimeName.c_str());
+  v8_jsi_config_enable_inspector(cfg, args.flags.enableInspector);
+  v8_jsi_config_set_inspector_port(cfg, args.inspectorPort);
+  v8_jsi_config_set_inspector_break_on_start(cfg, args.flags.waitForDebugger);
+  v8_jsi_config_set_explicit_microtask_policy(
+      cfg, args.flags.explicitMicrotaskPolicy);
+  v8_jsi_config_set_ignore_unhandled_promises(
+      cfg, args.flags.ignoreUnhandledPromises);
+  v8_jsi_config_enable_gc_api(cfg, args.flags.enableGCApi);
+  v8_jsi_config_enable_multi_thread(cfg, args.flags.enableMultiThread);
+  v8_jsi_config_enable_jit_tracing(cfg, args.flags.enableJitTracing);
+  v8_jsi_config_enable_message_tracing(cfg, args.flags.enableMessageTracing);
+  v8_jsi_config_enable_gc_tracing(cfg, args.flags.enableGCTracing);
+  v8_jsi_config_enable_system_instrumentation(
+      cfg, args.flags.enableSystemInstrumentation);
+  // Process-global V8 engine flags (sparkplug, predictable, optimize_for_size,
+  // always_compact, jitless, lite_mode) are NOT set here — they go through the
+  // process-level v8_jsi_set_v8_flags in makeV8Runtime (see applyV8Flags).
+  if (args.preparedScriptStore) {
+    V8ScriptCache::Create(cfg, args.preparedScriptStore);
+  }
+  if (args.foreground_task_runner) {
+    V8TaskRunner::Create(cfg, args.foreground_task_runner);
+  }
+}
+
+// Configure trampoline: v8_create_runtime hands us a factory-owned config and
+// we populate it from the V8RuntimeArgs carried in cb_data. The args outlive
+// the synchronous create call, so the pointer stays valid. (Pull in the ABI
+// does not mean pull in C++ — V8RuntimeArgs stays a plain struct.)
+jsi_error_code JSI_CDECL configureFromArgs(void *cb_data, jsi_config cfg) {
+  applyArgs(cfg, *static_cast<const V8RuntimeArgs *>(cb_data));
+  return jsi_no_error;
+}
+
+// Forward the process-global V8 engine flags carried on V8RuntimeArgs to the
+// process-level setter before the first runtime triggers V8 init. They are
+// process-global and first-init-only; on later runtimes this is effectively a
+// no-op (matching the historical per-config behavior). Static mutable storage
+// because V8::SetFlagsFromCommandLine takes char** and may split "name=value"
+// in place (these boolean flags have no '=', but static arrays keep us safe).
+void applyV8Flags(const V8RuntimeArgs &args) {
+  static char kSparkplug[] = "--sparkplug";
+  static char kPredictable[] = "--predictable";
+  static char kOptimizeForSize[] = "--optimize_for_size";
+  static char kAlwaysCompact[] = "--always_compact";
+  static char kJitless[] = "--jitless";
+  static char kLiteMode[] = "--lite_mode";
+
+  char *argv[6];
+  size_t argc = 0;
+  const auto &f = args.flags;
+  if (f.sparkplug) argv[argc++] = kSparkplug;
+  if (f.predictable) argv[argc++] = kPredictable;
+  if (f.optimize_for_size) argv[argc++] = kOptimizeForSize;
+  if (f.always_compact) argv[argc++] = kAlwaysCompact;
+  if (f.jitless) argv[argc++] = kJitless;
+  if (f.lite_mode) argv[argc++] = kLiteMode;
+  if (argc == 0) return;
+
+  // remove_flags=false: we pass only known flags, nothing to report back.
+  v8_jsi_set_v8_flags(&argc, argv, /*remove_flags:*/ false);
+}
+
+} // namespace
+
+std::unique_ptr<facebook::jsi::Runtime> __cdecl makeV8Runtime(
+    V8RuntimeArgs &&args) {
+  // Process-global engine flags must be set before the first runtime triggers
+  // V8 init; per-runtime config flows through the configure callback.
+  applyV8Flags(args);
+  return ::jsi::abi::makeJsiAbiRuntime(
+      &v8_create_runtime, &configureFromArgs, &args);
+}
+
+} // namespace v8runtime

--- a/src/public/v8_api.h
+++ b/src/public/v8_api.h
@@ -1,6 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/* ===========================================================================
+ * EXPERIMENTAL API - NOT YET ABI-STABLE
+ *
+ * This API is experimental and subject to change. Although it is C-based, it is
+ * NOT ABI-safe yet: function signatures, struct fields, and enum values may
+ * change without notice while the API remains in experimental mode. Do not
+ * depend on binary compatibility across builds. Once the API leaves
+ * experimental mode it will become ABI-stable and this notice will be removed.
+ * =========================================================================== */
+
 #ifndef V8_API_H_
 #define V8_API_H_
 

--- a/src/v8_core.cpp
+++ b/src/v8_core.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/// \file v8_core.cpp
+/// \brief Implementation of shared V8 infrastructure.
+
+#include "v8_core.h"
+
+namespace v8rt {
+
+//==============================================================================
+// V8PlatformHolder Static Members
+//==============================================================================
+
+std::mutex V8PlatformHolder::mutex_;
+std::unique_ptr<v8::Platform> V8PlatformHolder::platform_;
+bool V8PlatformHolder::is_initialized_ = false;
+bool V8PlatformHolder::is_disposed_ = false;
+
+//==============================================================================
+// Runtime Context Tag
+//==============================================================================
+
+int const RuntimeContextTag = 0x7e7f75;
+void* const RuntimeContextTagPtr =
+    const_cast<void*>(static_cast<const void*>(&RuntimeContextTag));
+
+//==============================================================================
+// Isolate Creation
+//==============================================================================
+
+v8::Isolate* createIsolate(const IsolateConfig& config) {
+  v8::Isolate::CreateParams create_params;
+
+  // Set up array buffer allocator
+  create_params.array_buffer_allocator = v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+
+  // Configure heap constraints if specified
+  if (config.initial_heap_size > 0 || config.maximum_heap_size > 0) {
+    v8::ResourceConstraints constraints;
+    constraints.ConfigureDefaultsFromHeapSize(
+        config.initial_heap_size,
+        config.maximum_heap_size);
+    create_params.constraints = constraints;
+  }
+
+  // Allocate and initialize the isolate
+  v8::Isolate* isolate = v8::Isolate::Allocate();
+  if (isolate == nullptr) {
+    delete create_params.array_buffer_allocator;
+    return nullptr;
+  }
+
+  v8::Isolate::Initialize(isolate, create_params);
+
+  // Create and attach IsolateData
+  IsolateData* isolate_data = new IsolateData(isolate, config.task_runner);
+  isolate_data->attachToIsolate();
+
+  // Configure microtasks policy
+  isolate->SetMicrotasksPolicy(config.microtasks_policy);
+
+  return isolate;
+}
+
+v8::Local<v8::Context> createContext(v8::Isolate* isolate) {
+  v8::Local<v8::ObjectTemplate> global = v8::ObjectTemplate::New(isolate);
+  return v8::Context::New(isolate, nullptr, global);
+}
+
+}  // namespace v8rt

--- a/src/v8_core.h
+++ b/src/v8_core.h
@@ -1,0 +1,398 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/// \file v8_core.h
+/// \brief Shared V8 infrastructure for JSI ABI and Node-API implementations.
+///
+/// This file provides common V8 utilities used by:
+/// - jsi_abi_v8.cpp (JSI ABI implementation)
+/// - v8_api_abi.cpp (Node-API implementation)
+///
+/// Design principles:
+/// - No JSI dependencies (pure V8)
+/// - No C++ exceptions (matches Node.js/V8 style)
+/// - Minimal abstractions
+
+#pragma once
+
+#include "v8.h"
+#include "libplatform/libplatform.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <functional>
+#include <optional>
+
+namespace v8rt {
+
+//==============================================================================
+// Forward Declarations
+//==============================================================================
+
+struct IsolateData;
+
+//==============================================================================
+// Task Runner Interface
+//==============================================================================
+
+/// Abstract interface for posting tasks to the JavaScript thread.
+/// Used for foreground task execution (microtasks, immediate callbacks, etc.)
+class TaskRunner {
+ public:
+  virtual ~TaskRunner() = default;
+
+  /// A task that can be run on the JS thread.
+  class Task {
+   public:
+    virtual ~Task() = default;
+    virtual void run() = 0;
+  };
+
+  /// Post a task to be executed on the JS thread.
+  virtual void postTask(std::unique_ptr<Task> task) = 0;
+};
+
+//==============================================================================
+// V8 Platform Management
+//==============================================================================
+
+/// Manages the V8 platform singleton.
+/// Ensures the platform is initialized and disposed only once.
+/// Thread-safe.
+///
+/// The platform must be initialized before any V8 isolate is created.
+/// The platform must be disposed before process exit to avoid random
+/// failures from tasks still in the delayed task queue.
+class V8PlatformHolder {
+ public:
+  /// Initialize the V8 platform.
+  /// \param thread_pool_size 0 for default (V8 uses min(N-1, 16) where N = cores)
+  /// \param init_callback Called once during first initialization for custom setup
+  template <typename InitCallback>
+  static void initializePlatform(int thread_pool_size, InitCallback&& init_callback) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (is_initialized_) {
+      return;
+    }
+    is_initialized_ = true;
+    init_callback();
+    platform_ = v8::platform::NewDefaultPlatform(thread_pool_size);
+    v8::V8::InitializePlatform(platform_.get());
+    v8::V8::Initialize();
+  }
+
+  /// Dispose the V8 platform.
+  /// Should be called before process exit.
+  static void disposePlatform() {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (!is_initialized_ || is_disposed_) {
+      return;
+    }
+    is_disposed_ = true;
+    v8::V8::Dispose();
+    v8::V8::DisposePlatform();
+    platform_ = nullptr;
+  }
+
+  /// Check if the platform is initialized.
+  static bool isInitialized() {
+    std::lock_guard<std::mutex> guard(mutex_);
+    return is_initialized_ && !is_disposed_;
+  }
+
+  V8PlatformHolder() = delete;
+  V8PlatformHolder(const V8PlatformHolder&) = delete;
+  V8PlatformHolder& operator=(const V8PlatformHolder&) = delete;
+
+ private:
+  static std::mutex mutex_;
+  static std::unique_ptr<v8::Platform> platform_;
+  static bool is_initialized_;
+  static bool is_disposed_;
+};
+
+//==============================================================================
+// Isolate Data Slots
+//==============================================================================
+
+/// Well-known slots for data associated with a V8 isolate.
+constexpr int kIsolateDataSlot = 0;
+constexpr int kIsolateInspectorSlot = 1;
+
+//==============================================================================
+// Per-Isolate Data
+//==============================================================================
+
+/// Data associated with each V8 isolate.
+/// Stored in the isolate's embedder slot.
+struct IsolateData {
+  /// Create IsolateData for an isolate.
+  /// \param isolate The V8 isolate (must not be null)
+  /// \param task_runner Optional task runner for foreground tasks
+  IsolateData(v8::Isolate* isolate, std::shared_ptr<TaskRunner> task_runner = nullptr) noexcept
+      : foreground_task_runner_(std::move(task_runner)), isolate_(isolate) {}
+
+  /// Get the isolate this data is associated with.
+  v8::Isolate* isolate() const noexcept { return isolate_; }
+
+  /// Get the foreground task runner.
+  std::shared_ptr<TaskRunner> taskRunner() const noexcept { return foreground_task_runner_; }
+
+  //----------------------------------------------------------------------------
+  // Private Property Keys
+  //----------------------------------------------------------------------------
+
+  /// Get or create the private key for Node-API type tags.
+  v8::Local<v8::Private> napi_type_tag() {
+    return getOrCreatePrivateKey(napi_type_tag_, "node:napi:type_tag");
+  }
+
+  /// Get or create the private key for Node-API wrappers.
+  v8::Local<v8::Private> napi_wrapper() {
+    return getOrCreatePrivateKey(napi_wrapper_, "node:napi:wrapper");
+  }
+
+  /// Get or create the private key for native state.
+  v8::Local<v8::Private> nativeStateKey() {
+    return getOrCreatePrivateKey(native_state_key_, "v8rt:nativeState");
+  }
+
+  /// Get or create the private key for host object proxies.
+  v8::Local<v8::Private> hostObjectKey() {
+    return getOrCreatePrivateKey(host_object_key_, "v8rt:hostObject");
+  }
+
+  //----------------------------------------------------------------------------
+  // Isolate Data Accessors
+  //----------------------------------------------------------------------------
+
+  /// Get IsolateData from an isolate.
+  /// Returns nullptr if no IsolateData is associated.
+  static IsolateData* fromIsolate(v8::Isolate* isolate) noexcept {
+    return static_cast<IsolateData*>(isolate->GetData(kIsolateDataSlot));
+  }
+
+  /// Associate this IsolateData with its isolate.
+  void attachToIsolate() noexcept {
+    isolate_->SetData(kIsolateDataSlot, this);
+  }
+
+  /// Public access to foreground task runner (for backwards compatibility)
+  std::shared_ptr<TaskRunner> foreground_task_runner_;
+
+ private:
+  v8::Local<v8::Private> getOrCreatePrivateKey(
+      v8::Eternal<v8::Private>& key,
+      const char* name) {
+    if (key.IsEmpty()) {
+      v8::Local<v8::String> key_name = v8::String::NewFromUtf8(
+          isolate_, name, v8::NewStringType::kInternalized).ToLocalChecked();
+      key.Set(isolate_, v8::Private::New(isolate_, key_name));
+    }
+    return key.Get(isolate_);
+  }
+
+  // Note: isolate_ is declared after foreground_task_runner_ to match init order
+  v8::Isolate* isolate_;
+  v8::Eternal<v8::Private> napi_type_tag_;
+  v8::Eternal<v8::Private> napi_wrapper_;
+  v8::Eternal<v8::Private> native_state_key_;
+  v8::Eternal<v8::Private> host_object_key_;
+};
+
+//==============================================================================
+// RAII Scope Helpers
+//==============================================================================
+
+/// RAII helper for V8 isolate scope.
+/// Does NOT throw exceptions.
+class IsolateScope {
+ public:
+  explicit IsolateScope(v8::Isolate* isolate) noexcept
+      : isolate_scope_(isolate) {}
+
+ private:
+  v8::Isolate::Scope isolate_scope_;
+};
+
+/// RAII helper for V8 handle scope.
+/// Does NOT throw exceptions.
+class HandleScope {
+ public:
+  explicit HandleScope(v8::Isolate* isolate) noexcept
+      : handle_scope_(isolate) {}
+
+ private:
+  v8::HandleScope handle_scope_;
+};
+
+/// RAII helper for V8 context scope.
+/// Does NOT throw exceptions.
+class ContextScope {
+ public:
+  explicit ContextScope(v8::Local<v8::Context> context) noexcept
+      : context_scope_(context) {}
+
+ private:
+  v8::Context::Scope context_scope_;
+};
+
+/// Combined RAII helper for isolate + handle + context scopes.
+/// Useful for most V8 API calls.
+class V8Scope {
+ public:
+  V8Scope(v8::Isolate* isolate, v8::Local<v8::Context> context) noexcept
+      : isolate_scope_(isolate),
+        handle_scope_(isolate),
+        context_scope_(context) {}
+
+ private:
+  v8::Isolate::Scope isolate_scope_;
+  v8::HandleScope handle_scope_;
+  v8::Context::Scope context_scope_;
+};
+
+/// RAII wrapper for multi-threaded V8 isolate access. Acquires v8::Locker
+/// (when enabled), then enters Isolate::Scope, HandleScope, Context::Scope.
+/// Order matters: Locker must be acquired first when the isolate is shared
+/// across threads, then the HandleScope must be live before any Local is
+/// derived from a Global<Context> for the Context::Scope.
+///
+/// The Global<Context> overload exists because callers that derive a Local
+/// at the call site would do so without a HandleScope of their own (the
+/// one inside the locker is not yet built). Passing the Global lets the
+/// locker derive the Local under its own HandleScope.
+///
+/// Migrated from V8Runtime::IsolateLocker (W8). Used by Node-API's
+/// NodeApiIsolateLocker which extends it with TLS-current tracking.
+class IsolateLocker {
+ public:
+  IsolateLocker(v8::Isolate* isolate,
+                const v8::Global<v8::Context>& context,
+                bool enable_multi_thread) noexcept
+      : locker_(makeOptionalLocker(isolate, enable_multi_thread)),
+        isolate_scope_(isolate),
+        handle_scope_(isolate),
+        context_scope_(context.Get(isolate)) {}
+
+ protected:
+  static std::optional<v8::Locker> makeOptionalLocker(
+      v8::Isolate* isolate, bool enabled) noexcept {
+    if (enabled) {
+      return std::make_optional<v8::Locker>(isolate);
+    }
+    return std::nullopt;
+  }
+
+  std::optional<v8::Locker> locker_;
+  v8::Isolate::Scope isolate_scope_;
+  v8::HandleScope handle_scope_;
+  v8::Context::Scope context_scope_;
+};
+
+//==============================================================================
+// TryCatch Wrapper
+//==============================================================================
+
+/// Wrapper around v8::TryCatch that stores caught exceptions for later retrieval.
+/// Similar to Node-API's v8impl::TryCatch.
+/// Does NOT use C++ exceptions.
+class TryCatch {
+ public:
+  explicit TryCatch(v8::Isolate* isolate) noexcept
+      : try_catch_(isolate) {}
+
+  /// Check if a JavaScript exception was caught.
+  bool hasCaught() const noexcept { return try_catch_.HasCaught(); }
+
+  /// Get the caught exception value.
+  v8::Local<v8::Value> exception() const { return try_catch_.Exception(); }
+
+  /// Get the exception message.
+  v8::Local<v8::Message> message() const { return try_catch_.Message(); }
+
+  /// Reset the TryCatch state.
+  void reset() { try_catch_.Reset(); }
+
+  /// Rethrow the caught exception (if any).
+  void rethrow() { try_catch_.ReThrow(); }
+
+ private:
+  v8::TryCatch try_catch_;
+};
+
+//==============================================================================
+// Isolate Creation
+//==============================================================================
+
+/// Configuration for creating a new V8 isolate.
+struct IsolateConfig {
+  /// Initial heap size in bytes (0 for default).
+  size_t initial_heap_size = 0;
+
+  /// Maximum heap size in bytes (0 for default).
+  size_t maximum_heap_size = 0;
+
+  /// Task runner for foreground tasks.
+  std::shared_ptr<TaskRunner> task_runner;
+
+  /// Whether to track GC object statistics.
+  bool track_gc_object_stats = false;
+
+  /// Whether to expose the gc() function.
+  bool enable_gc_api = false;
+
+  /// Microtask policy.
+  v8::MicrotasksPolicy microtasks_policy = v8::MicrotasksPolicy::kAuto;
+};
+
+/// Create a new V8 isolate with the given configuration.
+/// The caller owns the returned isolate and must dispose it.
+/// Returns nullptr on failure.
+v8::Isolate* createIsolate(const IsolateConfig& config);
+
+/// Create a new V8 context in the given isolate.
+/// The isolate must be entered (have an active Isolate::Scope).
+v8::Local<v8::Context> createContext(v8::Isolate* isolate);
+
+//==============================================================================
+// Context Embedder Data Indices
+//==============================================================================
+
+/// Well-known embedder data indices for V8 contexts.
+struct ContextEmbedderIndex {
+  /// Slot 0 — back-pointer from a context to the JSI ABI runtime that owns it.
+  /// Set by JsiRuntimeState::create (W8). Read by static callbacks (e.g.
+  /// PromiseRejectCallback) that only have a context handle and need to find
+  /// the owning runtime.
+  static constexpr int kRuntime = 0;
+
+  /// Slot 1 — RuntimeContextTagPtr (a stable per-process address). Used as a
+  /// "this is a v8jsi context" marker so upstream Node.js Environment::GetCurrent
+  /// patterns recognize it.
+  static constexpr int kContextTag = 1;
+};
+
+/// A stable per-process address used to mark v8jsi-created contexts. Set into
+/// ContextEmbedderIndex::kContextTag of every context created by
+/// JsiRuntimeState::create. Has no in-tree readers today; preserved for
+/// upstream Node.js Environment::GetCurrent compatibility.
+extern int const RuntimeContextTag;
+extern void* const RuntimeContextTagPtr;
+
+//==============================================================================
+// Unhandled Promise Tracking
+//==============================================================================
+
+/// Captured by the V8 PromiseRejectCallback when a promise is rejected with no
+/// handler. Stored on JsiRuntimeState; read by Node-API's
+/// hasUnhandledPromiseRejection / getAndClearLastUnhandledPromiseRejection.
+/// Pure V8 types — no JSI dependency.
+struct UnhandledPromiseRejection {
+  v8::Global<v8::Promise> promise;
+  v8::Global<v8::Message> message;
+  v8::Global<v8::Value> value;
+};
+
+}  // namespace v8rt

--- a/src/v8jsi.cpp
+++ b/src/v8jsi.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// Minimal v8jsi implementation for prototype testing
+
+#include "v8.h"
+#include "libplatform/libplatform.h"
+
+#ifdef _WIN32
+#define V8JSI_EXPORT __declspec(dllexport)
+#else
+#define V8JSI_EXPORT __attribute__((visibility("default")))
+#endif
+
+namespace v8jsi {
+
+// Simple version info export to verify the DLL is working
+extern "C" V8JSI_EXPORT const char* v8jsi_version() {
+  return "0.1.0-prototype";
+}
+
+// Export V8 version to verify V8 is linked correctly
+extern "C" V8JSI_EXPORT const char* v8jsi_v8_version() {
+  return v8::V8::GetVersion();
+}
+
+// Minimal test function that creates a V8 isolate
+extern "C" V8JSI_EXPORT int v8jsi_test_v8() {
+  // Create a new Isolate and make it the current one.
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator =
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+
+  v8::Isolate* isolate = v8::Isolate::New(create_params);
+
+  if (isolate == nullptr) {
+    return -1;
+  }
+
+  {
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+
+    // Create a context
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    v8::Context::Scope context_scope(context);
+
+    // Simple test: evaluate "1 + 2"
+    v8::Local<v8::String> source =
+        v8::String::NewFromUtf8Literal(isolate, "1 + 2");
+
+    v8::Local<v8::Script> script =
+        v8::Script::Compile(context, source).ToLocalChecked();
+
+    v8::Local<v8::Value> result = script->Run(context).ToLocalChecked();
+
+    // Should be 3
+    int32_t value = result->Int32Value(context).ToChecked();
+    if (value != 3) {
+      isolate->Dispose();
+      delete create_params.array_buffer_allocator;
+      return -2;
+    }
+  }
+
+  isolate->Dispose();
+  delete create_params.array_buffer_allocator;
+
+  return 0; // Success
+}
+
+}  // namespace v8jsi

--- a/src/v8jsi.gyp
+++ b/src/v8jsi.gyp
@@ -1,0 +1,368 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#
+# v8jsi.gyp - Build configuration for v8jsi shared library
+# This builds v8jsi.dll using V8 from Node.js
+#
+# Note: When this file is included via node.gyp's 'includes' directive,
+# all relative paths are resolved from node.gyp's directory (deps/nodejs),
+# NOT from this file's directory.
+#
+# This file lives in the v8-jsi repo src folder.
+# The v8jsi_root variable points to the v8-jsi repo root (../../ from deps/nodejs).
+{
+  # v8jsi_settings.gypi carries shared MSVC settings (Hybrid CRT in B1;
+  # BinSkim/CFG/Spectre will land here in B3). Included at the top level so
+  # its `target_defaults` merges into every target in this file.
+  'includes': [ 'v8jsi_settings.gypi' ],
+
+  'variables': {
+    # Path to v8-jsi repo root relative to deps/nodejs
+    'v8jsi_root': '../..',
+
+    # Enable inspector support (sets V8JSI_ENABLE_INSPECTOR).
+    # v8-jsi must always ship with inspector ON — Office's enableDebugging and
+    # RNW's useDirectDebugger both depend on it. Setting this to 0 is only
+    # valid as a transient state during V8 13.x modernization.
+    'v8jsi_enable_inspector%': 1,
+
+    # Enable test-only ABI hooks (sets JSI_TESTING_ONLY). When 1 (default),
+    # v8jsi.dll exports `v8_jsi_test_post_foreground_task` and any other
+    # symbols guarded by `#ifdef JSI_TESTING_ONLY`. Production / release
+    # builds can flip this to 0 to drop those exports. Note: with this 0,
+    # the v8jsi_test target will fail to link any test that references a
+    # gated symbol.
+    'v8jsi_test_hooks%': 1,
+
+    # Shared V8 core infrastructure (used by legacy code and ABI)
+    'v8jsi_core_sources': [
+      '<(v8jsi_root)/src/v8_core.h',
+      '<(v8jsi_root)/src/v8_core.cpp',
+    ],
+
+    # Core v8jsi sources. After W8 there is no legacy V8Runtime class — only
+    # JSI core, V8 instrumentation, MurmurHash, and the public C++ headers
+    # consumers depend on.
+    'v8jsi_sources': [
+      '<(v8jsi_root)/src/v8jsi.cpp',
+      '<(v8jsi_root)/src/MurmurHash.cpp',
+      '<(v8jsi_root)/src/MurmurHash.h',
+      '<(v8jsi_root)/src/V8Instrumentation.cpp',
+      '<(v8jsi_root)/src/V8Instrumentation.h',
+      '<(v8jsi_root)/src/jsi/JSIDynamic.h',
+      '<(v8jsi_root)/src/jsi/decorator.h',
+      '<(v8jsi_root)/src/jsi/instrumentation.h',
+      '<(v8jsi_root)/src/jsi/jsi-inl.h',
+      '<(v8jsi_root)/src/jsi/jsi.cpp',
+      '<(v8jsi_root)/src/jsi/jsi.h',
+      '<(v8jsi_root)/src/jsi/jsilib.h',
+      '<(v8jsi_root)/src/jsi/threadsafe.h',
+      '<(v8jsi_root)/src/public/ScriptStore.h',
+      '<(v8jsi_root)/src/public/V8JsiRuntime.h',
+    ],
+
+    # JSI ABI sources — exception-free code (uses TryCatch + Maybe instead of
+    # throw/catch). Node.js default is /EHs-c- (no exceptions), but these
+    # are compiled with /EHsc because they share the v8jsi target with
+    # legacy code that uses C++ exceptions. Separating into a static lib
+    # with the default no-exception flags would require solving MSVC DLL
+    # symbol export issues (/WHOLEARCHIVE or explicit forwarding).
+    'v8jsi_abi_sources': [
+      '<(v8jsi_root)/src/jsi_abi/jsi_abi.h',
+      '<(v8jsi_root)/src/jsi_abi/jsi_abi_helpers.h',
+      '<(v8jsi_root)/src/jsi_abi/jsi_abi_v8.cpp',
+      '<(v8jsi_root)/src/jsi_abi/jsi_abi_v8_internal.h',
+      '<(v8jsi_root)/src/jsi_abi/v8_jsi_config.h',
+      '<(v8jsi_root)/src/jsi_abi/v8_node_api_attach.h',
+    ],
+
+    # Node-API sources (W6) — restored to the GYP build after being lost in the
+    # GN→GYP migration. Always-on; v8jsi.dll ships with Node-API support.
+    # Office, RNW, and other consumers depend on the napi_* / jsr_* exports.
+    'v8jsi_node_api_sources': [
+      '<(v8jsi_root)/src/node-api/env-inl.h',
+      '<(v8jsi_root)/src/node-api/js_native_api.h',
+      '<(v8jsi_root)/src/node-api/js_native_api_types.h',
+      '<(v8jsi_root)/src/node-api/js_native_api_v8.cc',
+      '<(v8jsi_root)/src/node-api/js_native_api_v8.h',
+      '<(v8jsi_root)/src/node-api/js_native_api_v8_internals.h',
+      '<(v8jsi_root)/src/node-api/js_native_api_v8_internals_abi.h',
+      '<(v8jsi_root)/src/node-api/js_runtime_api.h',
+      '<(v8jsi_root)/src/node-api/util-inl.h',
+      '<(v8jsi_root)/src/node-api/v8_api_abi.cpp',
+      '<(v8jsi_root)/src/public/compat.h',
+      '<(v8jsi_root)/src/public/v8_api.h',
+    ],
+
+    # Windows-specific sources
+    'v8jsi_sources_win': [
+      '<(v8jsi_root)/src/jsi/jsilib-windows.cpp',
+      '<(v8jsi_root)/src/etw/tracing.cpp',
+      '<(v8jsi_root)/src/etw/tracing.h',
+      '<(v8jsi_root)/src/version_gen.rc',
+    ],
+
+    # Inspector sources (Windows only, when v8jsi_enable_inspector is set)
+    'v8jsi_inspector_sources': [
+      '<(v8jsi_root)/src/inspector/inspector_agent.cpp',
+      '<(v8jsi_root)/src/inspector/inspector_agent.h',
+      '<(v8jsi_root)/src/inspector/inspector_socket.cpp',
+      '<(v8jsi_root)/src/inspector/inspector_socket.h',
+      '<(v8jsi_root)/src/inspector/inspector_socket_server.cpp',
+      '<(v8jsi_root)/src/inspector/inspector_socket_server.h',
+      '<(v8jsi_root)/src/inspector/inspector_tcp.cpp',
+      '<(v8jsi_root)/src/inspector/inspector_tcp.h',
+      '<(v8jsi_root)/src/inspector/inspector_utils.cpp',
+      '<(v8jsi_root)/src/inspector/inspector_utils.h',
+      '<(v8jsi_root)/src/inspector/llhttp.c',
+      '<(v8jsi_root)/src/inspector/llhttp.h',
+      '<(v8jsi_root)/src/inspector/llhttp_api.c',
+      '<(v8jsi_root)/src/inspector/llhttp_http.c',
+    ],
+
+    # Posix-specific sources
+    'v8jsi_sources_posix': [
+      '<(v8jsi_root)/src/jsi/jsilib-posix.cpp',
+    ],
+  },
+
+  'targets': [
+    {
+      'target_name': 'v8jsi_version_gen',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'generate_version_rc',
+          'inputs': [
+            '<(v8jsi_root)/config.json',
+            '<(v8jsi_root)/src/version.rc',
+            '<(v8jsi_root)/src/generate_version_rc.ts',
+          ],
+          'outputs': [
+            '<(v8jsi_root)/src/version_gen.rc',
+          ],
+          'action': [
+            'node',
+            '<(v8jsi_root)/src/generate_version_rc.ts',
+            '--config', '<(v8jsi_root)/config.json',
+            '--template', '<(v8jsi_root)/src/version.rc',
+            '--output', '<(v8jsi_root)/src/version_gen.rc',
+          ],
+        },
+      ],
+    },  # v8jsi_version_gen target
+
+    {
+      'target_name': 'v8jsi',
+      'type': 'shared_library',
+
+      'dependencies': [
+        # V8 dependencies from Node.js
+        # v8_snapshot provides the V8 embedded blob (required for V8 to work)
+        # Use --without-intl to reduce size from ~69MB to ~33MB
+        'tools/v8_gypfiles/v8.gyp:v8_snapshot',
+        'tools/v8_gypfiles/v8.gyp:v8_libplatform',
+        # Generate version_gen.rc before building
+        'v8jsi_version_gen',
+      ],
+
+      'include_dirs': [
+        'deps/v8/include',
+        '<(v8jsi_root)/src',
+        '<(v8jsi_root)/src/jsi',
+        '<(v8jsi_root)/src/jsi_abi',
+        '<(v8jsi_root)/src/node-api',
+        '<(v8jsi_root)/src/public',
+        '<(v8jsi_root)/include',
+      ],
+
+      'sources': [
+        '<@(v8jsi_core_sources)',
+        '<@(v8jsi_sources)',
+        '<@(v8jsi_abi_sources)',
+        '<@(v8jsi_node_api_sources)',
+      ],
+
+      'defines': [
+        'BUILDING_V8JSI_SHARED',
+        'JSI_ABI_BUILDING',
+        'V8JSI_ENABLE_NODE_API',
+      ],
+
+      'conditions': [
+        ['v8jsi_test_hooks==1', {
+          'defines': [
+            'JSI_TESTING_ONLY',
+          ],
+        }],
+        ['OS=="win"', {
+          'sources': [
+            '<@(v8jsi_sources_win)',
+          ],
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              # Enable C++ exceptions (/EHsc)
+              'ExceptionHandling': 1,
+            },
+            'VCLinkerTool': {
+              'AdditionalDependencies': [
+                'dbghelp.lib',
+                'bcrypt.lib',
+                'shlwapi.lib',
+                'winmm.lib',
+              ],
+            },
+          },
+          'conditions': [
+            ['v8jsi_enable_inspector==1', {
+              'sources': [
+                '<@(v8jsi_inspector_sources)',
+              ],
+              'include_dirs': [
+                '<(v8jsi_root)/deps/asio/include',
+              ],
+              'defines': [
+                'V8JSI_ENABLE_INSPECTOR',
+                # asio standalone mode — no Boost dependency.
+                'ASIO_STANDALONE',
+                # asio's Win32 SDK target — required when ASIO_STANDALONE is set
+                # and not provided by the toolchain. Windows 7 (0x0601) matches
+                # the rest of v8-jsi.
+                '_WIN32_WINNT=0x0601',
+              ],
+            }],
+          ],
+        }],
+        ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
+          'sources': [
+            '<@(v8jsi_sources_posix)',
+          ],
+          'ldflags': [
+            '-Wl,--whole-archive',
+            '<(obj_dir)/tools/v8_gypfiles/<(STATIC_LIB_PREFIX)v8_base_without_compiler<(STATIC_LIB_SUFFIX)',
+            '-Wl,--no-whole-archive',
+            '-Wl,--allow-multiple-definition',
+            '-Wl,--version-script=<(v8jsi_root)/src/makev8jsi.lst',
+          ],
+        }],
+        ['OS=="mac"', {
+          'sources': [
+            '<@(v8jsi_sources_posix)',
+          ],
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [
+              '-Wl,-force_load,<(PRODUCT_DIR)/<(STATIC_LIB_PREFIX)v8_base_without_compiler<(STATIC_LIB_SUFFIX)',
+            ],
+          },
+        }],
+      ],
+    },  # v8jsi target
+
+    {
+      'target_name': 'v8jsi_test',
+      'type': 'executable',
+
+      'dependencies': [
+        'v8jsi',
+        'deps/googletest/googletest.gyp:gtest',
+        'tools/v8_gypfiles/v8.gyp:v8_libplatform',
+      ],
+
+      'include_dirs': [
+        'deps/v8/include',
+        '<(v8jsi_root)/src',
+        '<(v8jsi_root)/src/jsi',
+        '<(v8jsi_root)/src/jsi_abi',
+        '<(v8jsi_root)/src/node-api',
+        '<(v8jsi_root)/src/public',
+      ],
+
+      'defines': [
+        'JSI_V8_IMPL',
+        'JSI_SUPPORT_MICROTASKS',
+      ],
+
+      'sources': [
+        # Test main with runtime factory (no Node-API)
+        '<(v8jsi_root)/src/jsitests_main.cpp',
+        # JSI test library
+        '<(v8jsi_root)/src/jsi/test/testlib.cpp',
+        '<(v8jsi_root)/src/jsi/test/testlib.h',
+        '<(v8jsi_root)/src/jsi/test/testlib_ext.cpp',
+        '<(v8jsi_root)/src/jsi/test/testlib_abi.h',
+        # JSI headers needed for tests
+        '<(v8jsi_root)/src/jsi/JSIDynamic.h',
+        '<(v8jsi_root)/src/jsi/decorator.h',
+        '<(v8jsi_root)/src/jsi/instrumentation.h',
+        '<(v8jsi_root)/src/jsi/jsi-inl.h',
+        '<(v8jsi_root)/src/jsi/jsi.cpp',
+        '<(v8jsi_root)/src/jsi/jsi.h',
+        '<(v8jsi_root)/src/jsi/jsilib.h',
+        '<(v8jsi_root)/src/jsi/threadsafe.h',
+        '<(v8jsi_root)/src/public/compat.h',
+        # JSI ABI runtime wrapper for tests
+        '<(v8jsi_root)/src/jsi_abi/JsiAbiRuntime.h',
+        '<(v8jsi_root)/src/jsi_abi/JsiAbiRuntime.cpp',
+        '<(v8jsi_root)/src/jsi_abi/jsi_abi.h',
+        '<(v8jsi_root)/src/jsi_abi/jsi_abi_helpers.h',
+        '<(v8jsi_root)/src/jsi_abi/v8_jsi_config.h',
+        # Consumer-side definition of makeV8Runtime (W2). Ships as source in
+        # the NuGet; compiled here to prove the round-trip works end-to-end.
+        '<(v8jsi_root)/src/public/V8JsiRuntime.cpp',
+      ],
+
+      'conditions': [
+        ['OS=="win"', {
+          'sources': [
+            '<(v8jsi_root)/src/jsi/jsilib-windows.cpp',
+          ],
+          # Enable RTTI - needed for dynamic_pointer_cast in tests
+          'cflags_cc': [ '-frtti' ],
+          'cflags_cc!': [ '-fno-rtti' ],
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'ExceptionHandling': 1,
+              'RuntimeTypeInfo': 'true',
+            },
+            'VCLinkerTool': {
+              'AdditionalDependencies': [
+                'dbghelp.lib',
+                'winmm.lib',
+              ],
+            },
+          },
+          'configurations': {
+            'Release': {
+              'msvs_settings': {
+                'VCCLCompilerTool': {
+                  'RuntimeTypeInfo': 'true',
+                  'ExceptionHandling': 1,
+                },
+              },
+            },
+            'Debug': {
+              'msvs_settings': {
+                'VCCLCompilerTool': {
+                  'RuntimeTypeInfo': 'true',
+                  'ExceptionHandling': 1,
+                },
+              },
+            },
+          },
+        }],
+        ['OS=="win" and v8jsi_enable_inspector==1', {
+          'defines': [
+            'V8JSI_ENABLE_INSPECTOR',
+          ],
+        }],
+        ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris" or OS=="mac"', {
+          'sources': [
+            '<(v8jsi_root)/src/jsi/jsilib-posix.cpp',
+          ],
+          'cflags_cc': [ '-frtti' ],
+          'cflags_cc!': [ '-fno-rtti' ],
+        }],
+      ],
+    },  # v8jsi_test target
+  ],
+}

--- a/src/v8jsi_settings.gypi
+++ b/src/v8jsi_settings.gypi
@@ -1,0 +1,140 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#
+# v8jsi_settings.gypi -- shared MSVC settings for the v8jsi targets.
+#
+# This file is the GYP forward-port of PR #233 (commits c3d219a9d1c and
+# a1b7255b342) onto the Node.js-sources/GYP build pipeline. PR #233 lands two
+# related hardening blocks: the Hybrid CRT swap (Stage B1) and the BinSkim
+# compliance flags (Stage B3). Both live here so v8jsi.dll's "shipping
+# substrate" -- CRT layout + compliance flags -- is set in one place.
+#
+# Hybrid CRT (Stage B1)
+# ---------------------
+# Node.js's deps/nodejs/common.gypi defaults `MSVC_runtimeType` to /MT[d]
+# (`RuntimeLibrary = 0/1`) whenever `node_shared != "true"`, which is the
+# case for our `vcbuild.bat ... v8jsi without-intl` invocation. So the App
+# CRT (vcruntime, libcpmt) is already statically linked into v8jsi.dll by
+# default -- `dumpbin /DEPENDENTS v8jsi.dll` shows no vcruntime140.dll /
+# msvcp140.dll on the pre-B1 baseline.
+#
+# What `/MT[d]` also pulls in by default is the **static UCRT**
+# (libucrt.lib / libucrtd.lib). The Hybrid CRT model swaps that static UCRT
+# for the dynamic system UCRT (ucrtbase.dll), which has been an OS
+# component since Windows 10 and is CRT-version-agnostic. The net effect:
+# v8jsi.dll keeps its private static App CRT (so STL/allocator state never
+# crosses the DLL boundary) but binds to the same shared ucrtbase.dll that
+# every other binary on the box uses (so Debug-CRT consumers and a Release
+# Hybrid-CRT v8jsi.dll agree on UCRT-managed state -- the basis for B2's
+# Debug-drop).
+#
+# The swap is two linker flags per config:
+#   Release: /NODEFAULTLIB:libucrt.lib  + /DEFAULTLIB:ucrt.lib
+#   Debug:   /NODEFAULTLIB:libucrtd.lib + /DEFAULTLIB:ucrtd.lib
+# In GYP terms those are `IgnoreSpecificDefaultLibraries` +
+# `AdditionalDependencies` on VCLinkerTool. (GYP wants the MSVS-side name
+# `IgnoreDefaultLibraryNames`; using `IgnoreSpecificDefaultLibraries` makes
+# GYP drop the setting silently.)
+#
+# BinSkim compliance (Stage B3)
+# -----------------------------
+# Phase-1 master-plan gate #5 requires v8jsi.dll to pass BinSkim with CFG +
+# Spectre verified. PR #233's `:win_msvc_cfg` GN config gives the
+# canonical flag set: `/guard:cf` (compile + link), `/Qspectre` (compile),
+# `/W3` (already common.gypi default).
+#
+# We extend that with two defensive additions for BinSkim coverage:
+#   - `/CETCOMPAT` (link) -- BA2025 EnableShadowStack. Arch-independent
+#     metadata; the linker accepts the flag on arm64/x86 and the bit just
+#     isn't honored at runtime there.
+#   - Pin `RandomizedBaseAddress` (/DYNAMICBASE) and
+#     `DataExecutionPrevention` (/NXCOMPAT) explicitly. MSBuild v143 +
+#     x64 defaults both to true; pinning means BinSkim sees the flags in
+#     the .vcxproj regardless of toolchain defaults.
+#
+# `/HIGHENTROPYVA` is left at the v143 x64 default (on); add it to
+# `AdditionalOptions` if BinSkim ever flags it missing.
+# `BufferSecurityCheck` (/GS) is already set globally by Node.js's
+# common.gypi at line 326; we pin it here for clarity.
+# `/Qspectre` automatically links Spectre-mitigated runtime libraries when
+# the VS "Spectre Mitigations" component is installed (CI image has it),
+# so we don't need a separate `-vcvars_spectre_libs=spectre` step.
+#
+# GYP key notes
+# -------------
+# GYP's MSVSSettings.py has first-class keys for `RandomizedBaseAddress`,
+# `DataExecutionPrevention`, and `BufferSecurityCheck`. It does NOT have
+# first-class keys for `ControlFlowGuard`, `SpectreMitigation`, `CETCompat`,
+# or `HighEntropyVA` -- those flow through `AdditionalOptions` on the
+# appropriate tool. PR #233's GN config uses raw `cflags` / `ldflags` for
+# the same reason.
+#
+# Scope
+# -----
+# Included at the top of src/v8jsi.gyp via `'includes': ['v8jsi_settings.gypi']`,
+# so `target_defaults` merges into every target defined in v8jsi.gyp -- the
+# v8jsi DLL, the v8jsi_test EXE, and the no-op v8jsi_version_gen action
+# target (which has no compilation, so the compile/link blocks are moot
+# for it).
+#
+# Not included from src/node-api/test/node_api_tests.gyp. The N-API
+# conformance addon DLLs and node_lite/node_api_tests EXEs are test-only
+# binaries that don't ship; BinSkim compliance is a *shipping* gate, so
+# applying it to test-only targets would expand blast radius for no
+# acceptance-gate benefit. (PR #233 did extend the Hybrid CRT swap to
+# the test addons; we diverge here intentionally to match B1's scope
+# decision.)
+{
+  'target_defaults': {
+    'msvs_settings': {
+      'VCCLCompilerTool': {
+        # /guard:cf -- Control Flow Guard (BA2008).
+        # /Qspectre  -- Spectre v1 mitigation (BA2024). Auto-pulls
+        #               Spectre-mitigated runtime libs when the VS
+        #               "Spectre Mitigations" component is installed.
+        'AdditionalOptions': [ '/guard:cf', '/Qspectre' ],
+        # /GS -- buffer security cookies (BA2011). Already true via
+        # common.gypi globally; pinned here for clarity.
+        'BufferSecurityCheck': 'true',
+      },
+      'VCLinkerTool': {
+        # /guard:cf -- Control Flow Guard link-side instrumentation.
+        # NOTE: /CETCOMPAT was tried and reverted -- V8's heap-snapshot
+        # serialization calls a virtual OutputStream::WriteAsciiChunk
+        # through an indirect call that lands in code V8 doesn't mark as
+        # shadow-stack-safe; CET enforcement triggers a FAST_FAIL
+        # (0xC0000409 STATUS_STACK_BUFFER_OVERRUN) in
+        # JSITestExt.V8Instrumentation_CreateHeapSnapshotToFile.
+        # BA2025 (EnableShadowStack) accepted as a residual finding --
+        # blocked by V8 upstream; see impl-b3-results.md.
+        'AdditionalOptions': [ '/guard:cf' ],
+        # /DYNAMICBASE -- ASLR opt-in (BA2009).
+        'RandomizedBaseAddress': 'true',
+        # /NXCOMPAT -- DEP opt-in (BA2016).
+        'DataExecutionPrevention': 'true',
+      },
+    },
+    'configurations': {
+      'Release': {
+        'msvs_settings': {
+          'VCLinkerTool': {
+            'AdditionalDependencies': [ 'ucrt.lib' ],
+            # GYP wants the MSVS-side name `IgnoreDefaultLibraryNames`. The
+            # MSBuild-side name `IgnoreSpecificDefaultLibraries` is silently
+            # dropped by GYP's MSVSSettings.py emit pass -- linker then sees
+            # both libucrt.lib and ucrt.lib and fails with duplicate symbols.
+            'IgnoreDefaultLibraryNames': [ 'libucrt.lib' ],
+          },
+        },
+      },
+      'Debug': {
+        'msvs_settings': {
+          'VCLinkerTool': {
+            'AdditionalDependencies': [ 'ucrtd.lib' ],
+            'IgnoreDefaultLibraryNames': [ 'libucrtd.lib' ],
+          },
+        },
+      },
+    },
+  },
+}

--- a/src/v8jsi_test.cc
+++ b/src/v8jsi_test.cc
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// Tests for v8jsi.dll - loads the DLL and tests V8 functionality
+
+#include "gtest/gtest.h"
+#include "v8.h"
+#include "libplatform/libplatform.h"
+
+#include <memory>
+
+#ifdef _WIN32
+#include <windows.h>
+#define V8JSI_IMPORT __declspec(dllimport)
+#else
+#define V8JSI_IMPORT
+#endif
+
+// Import functions from v8jsi.dll
+extern "C" {
+  V8JSI_IMPORT const char* v8jsi_version();
+  V8JSI_IMPORT const char* v8jsi_v8_version();
+  V8JSI_IMPORT int v8jsi_test_v8();
+}
+
+class V8JsiTest : public ::testing::Test {
+ protected:
+  static std::unique_ptr<v8::Platform> platform_;
+
+  static void SetUpTestSuite() {
+    // Initialize V8 platform once for all tests
+    platform_ = v8::platform::NewDefaultPlatform();
+    v8::V8::InitializePlatform(platform_.get());
+    v8::V8::Initialize();
+  }
+
+  static void TearDownTestSuite() {
+    v8::V8::Dispose();
+    v8::V8::DisposePlatform();
+    platform_.reset();
+  }
+};
+
+std::unique_ptr<v8::Platform> V8JsiTest::platform_;
+
+// Test that we can get the v8jsi version
+TEST_F(V8JsiTest, GetVersion) {
+  const char* version = v8jsi_version();
+  ASSERT_NE(version, nullptr);
+  EXPECT_STRNE(version, "");
+  std::cout << "v8jsi version: " << version << std::endl;
+}
+
+// Test that we can get the V8 version from the DLL
+TEST_F(V8JsiTest, GetV8Version) {
+  const char* v8_version = v8jsi_v8_version();
+  ASSERT_NE(v8_version, nullptr);
+  EXPECT_STRNE(v8_version, "");
+  std::cout << "V8 version: " << v8_version << std::endl;
+}
+
+// Test basic V8 functionality through the DLL
+TEST_F(V8JsiTest, BasicV8Test) {
+  int result = v8jsi_test_v8();
+  EXPECT_EQ(result, 0) << "v8jsi_test_v8() failed with code: " << result;
+}
+
+// Test creating an isolate directly
+TEST_F(V8JsiTest, CreateIsolate) {
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator =
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+
+  v8::Isolate* isolate = v8::Isolate::New(create_params);
+  ASSERT_NE(isolate, nullptr);
+
+  {
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    ASSERT_FALSE(context.IsEmpty());
+  }
+
+  isolate->Dispose();
+  delete create_params.array_buffer_allocator;
+}
+
+// Test running JavaScript code
+TEST_F(V8JsiTest, RunJavaScript) {
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator =
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+
+  v8::Isolate* isolate = v8::Isolate::New(create_params);
+  ASSERT_NE(isolate, nullptr);
+
+  {
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    v8::Context::Scope context_scope(context);
+
+    // Test simple expression
+    v8::Local<v8::String> source =
+        v8::String::NewFromUtf8Literal(isolate, "40 + 2");
+    v8::Local<v8::Script> script =
+        v8::Script::Compile(context, source).ToLocalChecked();
+    v8::Local<v8::Value> result = script->Run(context).ToLocalChecked();
+
+    EXPECT_TRUE(result->IsNumber());
+    EXPECT_EQ(42, result->Int32Value(context).ToChecked());
+  }
+
+  isolate->Dispose();
+  delete create_params.array_buffer_allocator;
+}
+
+// Test creating and calling a JavaScript function
+TEST_F(V8JsiTest, CallJavaScriptFunction) {
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator =
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+
+  v8::Isolate* isolate = v8::Isolate::New(create_params);
+  ASSERT_NE(isolate, nullptr);
+
+  {
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    v8::Context::Scope context_scope(context);
+
+    // Create a function
+    v8::Local<v8::String> source = v8::String::NewFromUtf8Literal(
+        isolate, "(function(a, b) { return a + b; })");
+    v8::Local<v8::Script> script =
+        v8::Script::Compile(context, source).ToLocalChecked();
+    v8::Local<v8::Value> func_value = script->Run(context).ToLocalChecked();
+
+    EXPECT_TRUE(func_value->IsFunction());
+    v8::Local<v8::Function> func = v8::Local<v8::Function>::Cast(func_value);
+
+    // Call the function with arguments
+    v8::Local<v8::Value> args[2] = {
+        v8::Number::New(isolate, 10),
+        v8::Number::New(isolate, 32)
+    };
+    v8::Local<v8::Value> result =
+        func->Call(context, context->Global(), 2, args).ToLocalChecked();
+
+    EXPECT_TRUE(result->IsNumber());
+    EXPECT_EQ(42, result->Int32Value(context).ToChecked());
+  }
+
+  isolate->Dispose();
+  delete create_params.array_buffer_allocator;
+}
+
+// Test string handling
+TEST_F(V8JsiTest, StringHandling) {
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator =
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+
+  v8::Isolate* isolate = v8::Isolate::New(create_params);
+  ASSERT_NE(isolate, nullptr);
+
+  {
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    v8::Context::Scope context_scope(context);
+
+    // Test string concatenation
+    v8::Local<v8::String> source = v8::String::NewFromUtf8Literal(
+        isolate, "'Hello, ' + 'World!'");
+    v8::Local<v8::Script> script =
+        v8::Script::Compile(context, source).ToLocalChecked();
+    v8::Local<v8::Value> result = script->Run(context).ToLocalChecked();
+
+    EXPECT_TRUE(result->IsString());
+    v8::String::Utf8Value utf8(isolate, result);
+    EXPECT_STREQ(*utf8, "Hello, World!");
+  }
+
+  isolate->Dispose();
+  delete create_params.array_buffer_allocator;
+}


### PR DESCRIPTION
## Summary

This PR adds a new way to build `v8jsi.dll` using the V8 engine bundled in the
vendored Node.js 24.x sources (`deps/nodejs/`), instead of a standalone Google V8
checkout. It is the first in a series of PRs that move v8-jsi onto the Node.js V8
distribution.

This is a work-in-progress, foundational PR. The existing build is left intact —
the old and new builds are produced **side by side** for now, so nothing
downstream breaks. Follow-up PRs will package a NuGet from the new build and,
once consumers migrate, remove the old build.

## What's included

- **New build path.** `scripts/build.ts` drives `deps/nodejs/vcbuild.bat` to
  build `v8jsi.dll` and its test binaries from the Node.js tree. Output goes to
  `deps/nodejs/out/{Debug,Release}/`. The existing GN/depot_tools build is
  unchanged and still produces `out/{Debug,Release}/v8jsi.dll`.
- **JSI ABI layer (`src/jsi_abi/`).** A binary-stable C ABI for JSI so a single
  DLL can serve consumers built with different toolchains, plus a C++ wrapper
  (`JsiAbiRuntime`) that implements `facebook::jsi::Runtime` over it. This surface
  is **experimental and not yet ABI-stable** (the headers say so) and may change
  until it is stabilized.
- **Node-API integration.** The `jsr_*` / Node-API surface is bridged onto the
  same V8 runtime, so one isolate can be driven through both JSI and Node-API.
- **Tests.** New gtest suites — `v8jsi_test.exe` (JSI) and `node_api_tests.exe`
  (Node-API) — run against the new build.
- **Versioning & CI.** `config.json` gains version fields, `docs/versioning.md`
  documents the scheme, and CI builds and tests the new path alongside the old
  one across the existing matrix.

## Building

Existing build (unchanged):
```powershell
.\scripts\build.ps1 -Configuration Release -Platform x64
# -> out/Release/v8jsi.dll
```

New build (this PR):
```powershell
cd scripts
node build.ts --platform x64 --configuration release
# -> deps/nodejs/out/Release/{v8jsi.dll, v8jsi_test.exe, node_api_tests.exe}
```

Run the new tests:
```powershell
& .\deps\nodejs\out\Release\v8jsi_test.exe --gtest_brief=1
& .\deps\nodejs\out\Release\node_api_tests.exe --gtest_brief=1
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/241)