### PR TITLE
Create Microsoft.JavaScript.V8 NuGet package

### DIFF
--- a/.ado/windows-build-new.yml
+++ b/.ado/windows-build-new.yml
@@ -19,71 +19,54 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.fakeBuild, false) }}:
-  # OpenSSL (built from the Node.js tree) assembles its crypto with NASM on
-  # x86/x64. Provision NASM and prepend it to PATH for the build step. Not needed
-  # on arm64, where the OpenSSL asm path is skipped.
-  - task: PowerShell@2
-    displayName: Download NASM 2.16.03
-    condition: and(succeeded(), not(startsWith('${{parameters.buildPlatform}}', 'arm')))
-    inputs:
-      targetType: inline
-      workingDirectory: $(Build.SourcesDirectory)
-      script: |
-        $ErrorActionPreference = 'Stop'
-        Invoke-WebRequest -Uri https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/win64/nasm-2.16.03-win64.zip -OutFile nasm-2.16.03-win64.zip
-        Expand-Archive nasm-2.16.03-win64.zip -DestinationPath nasm -Force
-
-  - task: PowerShell@2
+    # Every step is a single scripts/build.ts invocation so the whole flow is
+    # reproducible locally. build.ts provisions NASM itself (needed for the
+    # x86/x64 OpenSSL asm), so there is no separate NASM step. The pwsh task
+    # propagates build.ts's exit code, so each step fails on its own.
+  - pwsh: |
+      node scripts/build.ts `
+          --platform ${{parameters.buildPlatform}} `
+          --configuration ${{parameters.buildConfiguration}}
     displayName: Build v8jsi.dll via scripts/build.ts
-    inputs:
-      targetType: inline
-      workingDirectory: $(Build.SourcesDirectory)
-      script: |
-        $ErrorActionPreference = 'Stop'
-        node scripts/build.ts `
+    workingDirectory: $(Build.SourcesDirectory)
+
+    # Runs both gtest binaries (v8jsi_test + node_api_tests). build.ts skips
+    # tests for cross-platform builds (e.g. arm64 on an x64 agent).
+  - pwsh: |
+      node scripts/build.ts --no-build --test `
+          --platform ${{parameters.buildPlatform}} `
+          --configuration ${{parameters.buildConfiguration}}
+    displayName: Run tests via scripts/build.ts
+    workingDirectory: $(Build.SourcesDirectory)
+
+    # ---------------------------------------------------------------------
+    # Release cells: stage the per-RID NuGet content (Microsoft.JavaScript.V8).
+    # scripts/build.ts --pack lays out pkg-staging/build/native/<rid>/ with the
+    # v8jsi.dll, the import lib (renamed v8jsi.dll.lib), and the PDB, plus the
+    # shared headers + consumer-side source TUs, and produces this cell's per-RID
+    # .nupkg under <outputPath>/pkg. The V8JsiCreateNugetNew aggregator downloads
+    # every Release cell's pkg-staging and re-runs --pack to emit the 4-pack
+    # (3 per-RID + 1 meta). Debug v8jsi.dll variants are not packaged (Hybrid CRT
+    # lets a Debug-CRT consumer link the Release DLL), so this runs Release-only.
+    # ---------------------------------------------------------------------
+  - ${{ if eq(parameters.buildConfiguration, 'Release') }}:
+    - pwsh: |
+        node scripts/build.ts --no-build --no-test --pack `
             --platform ${{parameters.buildPlatform}} `
-            --configuration ${{parameters.buildConfiguration}}
-        if ($LASTEXITCODE -ne 0) { throw "scripts/build.ts failed (exit $LASTEXITCODE)" }
-    env:
-      path: $(Build.SourcesDirectory)\nasm\nasm-2.16.03;$(path)
-
-  - task: PowerShell@2
-    displayName: Run v8jsi_test.exe
-    inputs:
-      targetType: inline
+            --configuration ${{parameters.buildConfiguration}} `
+            --output-path '${{parameters.outputPath}}'
+      displayName: Stage pkg-staging + pack per-RID NuGet
       workingDirectory: $(Build.SourcesDirectory)
-      script: |
-        $ErrorActionPreference = 'Stop'
-        $exe = "deps/nodejs/out/${{parameters.buildConfiguration}}/v8jsi_test.exe"
-        if (-not (Test-Path $exe)) { throw "Test executable not found: $exe" }
-        & $exe --gtest_brief=1
-        if ($LASTEXITCODE -ne 0) { throw "v8jsi_test.exe failed (exit $LASTEXITCODE)" }
-    condition: and(succeeded(), not(startsWith('${{parameters.buildPlatform}}', 'arm')))
 
-  - task: PowerShell@2
-    displayName: Run node_api_tests.exe
-    inputs:
-      targetType: inline
-      workingDirectory: $(Build.SourcesDirectory)
-      script: |
-        $ErrorActionPreference = 'Stop'
-        $exe = "deps/nodejs/out/${{parameters.buildConfiguration}}/node_api_tests.exe"
-        if (-not (Test-Path $exe)) { throw "Test executable not found: $exe" }
-        & $exe --gtest_brief=1
-        if ($LASTEXITCODE -ne 0) { throw "node_api_tests.exe failed (exit $LASTEXITCODE)" }
-    condition: and(succeeded(), not(startsWith('${{parameters.buildPlatform}}', 'arm')))
-
-  - task: PowerShell@2
-    displayName: Stage v8jsi.dll artifact
-    inputs:
-      targetType: inline
-      workingDirectory: $(Build.SourcesDirectory)
-      script: |
-        $ErrorActionPreference = 'Stop'
-        $src = "deps/nodejs/out/${{parameters.buildConfiguration}}"
-        $dest = '${{parameters.outputPath}}'
-        New-Item -ItemType Directory -Force -Path $dest | Out-Null
-        Copy-Item -Path (Join-Path $src 'v8jsi.dll') -Destination $dest
-        if (Test-Path (Join-Path $src 'v8jsi.dll.pdb')) {
-          Copy-Item -Path (Join-Path $src 'v8jsi.dll.pdb') -Destination $dest
-        }
+      # x64 Release cell smokes the freshly-packed per-RID .nupkg through a real
+      # consumer (test-harness/consumer.vcxproj). build.ts --smoke drives the
+      # x64-only harness in both Release/Release (links the Release Hybrid-CRT
+      # DLL) and Debug/Release (exercises the cross-CRT boundary).
+    - ${{ if eq(parameters.buildPlatform, 'x64') }}:
+      - pwsh: |
+          node scripts/build.ts --no-build --no-test --smoke `
+              --platform ${{parameters.buildPlatform}} `
+              --configuration ${{parameters.buildConfiguration}} `
+              --output-path '${{parameters.outputPath}}'
+        displayName: Smoke via scripts/build.ts (R/R + D/R)
+        workingDirectory: $(Build.SourcesDirectory)

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -191,6 +191,13 @@ extends:
             inputs:
               versionSpec: '24.x'
 
+            # The Release cells pack (build.ts --pack) and smoke (run-smoke.ps1)
+            # both need nuget.exe on PATH.
+          - task: NuGetToolInstaller@1
+            displayName: Install NuGet tools
+            inputs:
+              versionSpec: ">=4.6.0"
+
           - template: /.ado/windows-build-new.yml@self
             parameters:
               outputPath: $(Build.StagingDirectory)\out-new

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -167,9 +167,16 @@ extends:
 
           templateContext:
             outputs:
-            - output: pipelineArtifact
-              artifactName: ${{ matrix.Name }}-new
-              targetPath: $(Build.StagingDirectory)\out-new
+              # Only Release cells stage a NuGet artifact: build.ts --pack lays
+              # out-new/pkg-staging for the V8JsiCreateNugetNew aggregator. Debug
+              # cells just build + run gtests (no NuGet ships from Debug), so the
+              # outputs list is empty for them. Publishing only pkg-staging (not
+              # the whole out-new) keeps the per-cell artifact to the binaries +
+              # headers the aggregator needs — it omits the unused per-cell .nupkg.
+            - ${{ if eq(matrix.BuildConfiguration, 'Release') }}:
+              - output: pipelineArtifact
+                artifactName: ${{ matrix.Name }}-new
+                targetPath: $(Build.StagingDirectory)\out-new\pkg-staging
 
           steps:
           - task: UsePythonVersion@0
@@ -264,6 +271,107 @@ extends:
               folderPath: $(Build.StagingDirectory)\out\pkg
               pattern: |
                 ReactNative.V8Jsi.Windows.*.nupkg
+              useMinimatch: true
+              signConfigType: inlineSignParams
+              inlineOperation: |
+                [
+                  {
+                    "KeyCode" : "CP-401405",
+                    "OperationCode" : "NuGetSign",
+                    "Parameters" : {},
+                    "ToolName" : "sign",
+                    "ToolVersion" : "1.0"
+                  },
+                  {
+                    "KeyCode" : "CP-401405",
+                    "OperationCode" : "NuGetVerify",
+                    "Parameters" : {},
+                    "ToolName" : "sign",
+                    "ToolVersion" : "1.0"
+                  }
+                ]
+
+        # =====================================================================
+        # New (Node.js-source) NuGet aggregator: Microsoft.JavaScript.V8.
+        # Additive sibling of V8JsiCreateNuget above — that job keeps packing
+        # the legacy ReactNative.V8Jsi.Windows package unchanged. This one
+        # collects the per-RID pkg-staging that each Release V8JsiBuildNew_*
+        # cell uploaded and runs scripts/build.ts --pack to emit the 4-pack
+        # (3 per-RID Microsoft.JavaScript.V8.<rid>.nupkg + 1 meta
+        # Microsoft.JavaScript.V8.nupkg). It publishes a separate
+        # published-packages-new artifact so the release pipeline can push the
+        # new package alongside the old one during the migration window.
+        # =====================================================================
+      - job: V8JsiCreateNugetNew
+        dependsOn:
+        - ${{ each matrix in parameters.BuildMatrix }}:
+          - ${{ if eq(matrix.BuildConfiguration, 'Release') }}:
+            - V8JsiBuildNew_${{ matrix.Name }}
+        displayName: Create Nuget (Node.js source)
+
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            targetPath: $(Build.StagingDirectory)\out\pkg
+            artifactName: published-packages-new
+
+        steps:
+          # Aggregator needs source: scripts/build.ts:packNuGet stages shared
+          # headers + consumer source TUs from src/, and runs the 4-pack flow
+          # (3 per-RID + 1 meta) for Microsoft.JavaScript.V8.
+        - checkout: self
+
+        - task: NodeTool@0
+          displayName: Use Node.js 24.x
+          inputs:
+            versionSpec: '24.x'
+
+        - task: NuGetToolInstaller@1
+          displayName: Install NuGet tools
+          inputs:
+            versionSpec: ">=4.6.0"
+
+          # Download each Release cell's pkg-staging (build/native/<rid>/ with
+          # v8jsi.dll + import lib + PDB, plus the shared headers/TUs). Each
+          # artifact is the cell's pkg-staging content, so it lands directly
+          # under out/pkg-staging; merging all three gives packNuGet a complete
+          # per-RID staging so the meta package's <dependencies> resolve.
+        - ${{ each matrix in parameters.BuildMatrix }}:
+          - ${{ if eq(matrix.BuildConfiguration, 'Release') }}:
+            - task: DownloadPipelineArtifact@2
+              displayName: Download ${{ matrix.Name }}-new pkg-staging
+              inputs:
+                artifact: ${{ matrix.Name }}-new
+                path: $(Build.StagingDirectory)\out\pkg-staging
+
+          # Pack: 3 per-RID Microsoft.JavaScript.V8.<rid>.nupkg + meta
+          # Microsoft.JavaScript.V8.nupkg, plus the per-RID PDBs staged under
+          # pkg/symbols/<rid>/ for the release pipeline's symbol publish. No
+          # local build needed — packNuGet's pre-staged binary fallback reuses
+          # the matrix-uploaded build/native/<rid>/ content. A successful pack
+          # with all three platforms guarantees the 4-pack, so there is no
+          # separate verify step.
+        - pwsh: |
+            node scripts/build.ts --no-build --no-test --pack `
+                --platform x86 --platform x64 --platform arm64 `
+                --output-path $(Build.StagingDirectory)\out
+          displayName: NuGet Pack (3 per-RID + meta + symbols)
+          workingDirectory: $(Build.SourcesDirectory)
+
+          # Sign the NuGet packages only for the CI builds.
+        - ${{ if parameters.isPublish }}:
+          - task: EsrpCodeSigning@6
+            displayName: CodeSign NuGets
+            inputs:
+              connectedServiceName: 'ESRP-JSHost3'
+              appRegistrationClientId: '0a35e01f-eadf-420a-a2bf-def002ba898d'
+              appRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
+              authAKVName: 'OGX-JSHost-KV'
+              authCertName: 'OGX-JSHost-Auth4'
+              authSignCertName: 'OGX-JSHost-Sign3'
+              folderPath: $(Build.StagingDirectory)\out\pkg
+              pattern: |
+                Microsoft.JavaScript.V8.*.nupkg
               useMinimatch: true
               signConfigType: inlineSignParams
               inlineOperation: |

--- a/.ado/windows-release.yml
+++ b/.ado/windows-release.yml
@@ -212,3 +212,177 @@ extends:
             SymbolsArtifactName: V8Jsi-Symbols-$(Build.BuildId)
             DetailedLog: true
             TreatNotIndexedAsWarning: false
+
+      # =====================================================================
+      # New (Node.js-source) package: Microsoft.JavaScript.V8.
+      # Additive siblings of the three jobs above — those keep publishing the
+      # legacy ReactNative.V8Jsi.Windows package unchanged. These consume the
+      # separate published-packages-new artifact (produced by the
+      # V8JsiCreateNugetNew CI aggregator) and push Microsoft.JavaScript.V8.*
+      # to the same two feeds, plus its symbols to the Symbol Server. Both
+      # packages publish during the consumer migration window.
+      # =====================================================================
+      - job: ms_react_native_nuget_job_new
+        displayName: Publish Nuget (Microsoft.JavaScript.V8) to ms/react-native-public
+        condition: succeeded()
+        timeoutInMinutes: 30
+
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: microsoft.v8-jsi.ci
+            artifactName: published-packages-new
+            targetPath: $(Pipeline.Workspace)\published-packages-new
+
+        steps:
+        - template: .ado/templates/publish-nuget-to-ado-feed.yml@self
+          parameters:
+            endpointId: '29e4c04c-ae69-4453-b9f3-bfef7a4c8d32'
+            nugetFeedUrl: 'https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json'
+            packageParentPath: '$(Pipeline.Workspace)/published-packages-new'
+            packagesToPush: '$(Pipeline.Workspace)/published-packages-new/Microsoft.JavaScript.V8.*.nupkg'
+            publishFeedCredentials: 'Nuget - ms/react-native-public'
+            feedDisplayName: 'ms/react-native-public'
+
+      - job: office_nuget_job_new
+        displayName: Publish Nuget (Microsoft.JavaScript.V8) to office
+        condition: succeeded()
+        timeoutInMinutes: 30
+
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: microsoft.v8-jsi.ci
+            artifactName: published-packages-new
+            targetPath: $(Pipeline.Workspace)\published-packages-new
+
+        steps:
+        - script: dir /S $(Pipeline.Workspace)\published-packages-new
+          displayName: Show NuGet packages before cleanup
+
+        - pwsh: |
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+            $feedUrl = 'https://pkgs.dev.azure.com/office/_packaging/office/nuget/v3/index.json'
+            $token = "$env:SYSTEM_ACCESSTOKEN"
+            $headers = @{ Authorization = "Bearer $token" }
+
+            # Discover the flat container (PackageBaseAddress) URL from the V3 index
+            $index = Invoke-RestMethod -Uri $feedUrl -Headers $headers
+            $baseAddress = ($index.resources |
+              Where-Object { $_.'@type' -like 'PackageBaseAddress*' } |
+              Select-Object -First 1).'@id'
+            if (-not $baseAddress) { throw "Could not find PackageBaseAddress in NuGet V3 index at $feedUrl" }
+            if (-not $baseAddress.EndsWith('/')) { $baseAddress += '/' }
+            Write-Host "PackageBaseAddress: $baseAddress"
+
+            $nupkgs = Get-ChildItem -Path '$(Pipeline.Workspace)/published-packages-new' -Filter '*.nupkg' -Recurse
+            $removedCount = 0
+
+            foreach ($file in $nupkgs) {
+              # Read the .nuspec from inside the nupkg (zip) to get the exact id and version
+              $zip = [System.IO.Compression.ZipFile]::OpenRead($file.FullName)
+              try {
+                $nuspecEntry = $zip.Entries | Where-Object { $_.FullName -like '*.nuspec' } | Select-Object -First 1
+                $reader = New-Object System.IO.StreamReader($nuspecEntry.Open())
+                [xml]$nuspec = $reader.ReadToEnd()
+                $reader.Close()
+              } finally { $zip.Dispose() }
+
+              $id = $nuspec.package.metadata.id
+              $version = $nuspec.package.metadata.version
+
+              $versionsUrl = "${baseAddress}$($id.ToLower())/index.json"
+              try {
+                $result = Invoke-RestMethod -Uri $versionsUrl -Headers $headers -ErrorAction Stop
+                if ($version.ToLower() -in $result.versions) {
+                  Write-Host "  SKIP $id $version — already on office feed"
+                  Remove-Item $file.FullName
+                  $removedCount++
+                  continue
+                }
+              } catch {
+                if ($_.Exception.Response.StatusCode -eq [System.Net.HttpStatusCode]::NotFound) {
+                  # Package has never been published — keep it
+                } else { throw }
+              }
+              Write-Host "  PUSH $id $version — new"
+            }
+
+            $remaining = (Get-ChildItem -Path '$(Pipeline.Workspace)/published-packages-new' -Filter '*.nupkg' -Recurse).Count
+            Write-Host "Removed $removedCount already-published package(s). $remaining package(s) to push."
+            Write-Host "##vso[task.setvariable variable=HasNewPackages]$($remaining -gt 0)"
+          displayName: Remove already-published packages
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+        - script: dir /S $(Pipeline.Workspace)\published-packages-new
+          displayName: Show NuGet packages after cleanup
+
+        - task: 1ES.PublishNuGet@1
+          displayName: NuGet push to office
+          condition: and(succeeded(), eq(variables['HasNewPackages'], 'True'))
+          inputs:
+            useDotNetTask: true
+            packageParentPath: '$(Pipeline.Workspace)/published-packages-new'
+            packagesToPush: '$(Pipeline.Workspace)/published-packages-new/Microsoft.JavaScript.V8.*.nupkg'
+            nuGetFeedType: internal
+            publishFeedCredentials: 'ES365-Office-Nuget-Package-Publisher'
+            publishPackageMetadata: true
+            publishVstsFeed: 'office'
+
+      - job: publish_symbols_job_new
+        displayName: Publish PDB Symbols (Microsoft.JavaScript.V8) to Symbol Server
+        condition: succeeded()
+        timeoutInMinutes: 30
+
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: microsoft.v8-jsi.ci
+            artifactName: published-packages-new
+            targetPath: $(Pipeline.Workspace)\published-packages-new
+
+        steps:
+          # V8JsiCreateNugetNew stages the raw v8jsi.dll.pdb files alongside the
+          # .nupkgs under published-packages-new/symbols/<rid>/. Read them
+          # directly — no zip-extract dance against the .nupkg. (PDBs are also
+          # kept inside each per-RID .nupkg at runtimes/<rid>/native/ for
+          # consumer convenience.)
+        - pwsh: |
+            $symbolsDir = "$(Pipeline.Workspace)/published-packages-new/symbols"
+            if (-not (Test-Path $symbolsDir)) {
+              Write-Host "##vso[task.logissue type=warning]No symbols/ dir in published-packages-new artifact"
+              exit 0
+            }
+            $pdbs = Get-ChildItem $symbolsDir -Recurse -Filter "*.pdb"
+            Write-Host "Found $($pdbs.Count) PDB files in $symbolsDir`:"
+            foreach ($pdb in $pdbs) {
+              Write-Host "  $($pdb.FullName) ($([math]::Round($pdb.Length / 1MB, 2)) MB)"
+            }
+            if ($pdbs.Count -eq 0) {
+              Write-Host "##vso[task.logissue type=warning]No PDB files found"
+            }
+          displayName: Inspect symbols/ in published-packages-new
+
+        - task: PublishSymbols@2
+          displayName: Publish Symbols to Microsoft Symbol Server
+          continueOnError: true
+          inputs:
+            UseNetCoreClientTool: true
+            ConnectedServiceName: Office-V8-Jsi-Bot
+            SymbolsFolder: '$(Pipeline.Workspace)/published-packages-new/symbols'
+            SearchPattern: '**/*.pdb'
+            SymbolServerType: TeamServices
+            IndexSources: false
+            SymbolsProduct: V8Jsi
+            SymbolsVersion: $(Build.BuildNumber)
+            SymbolsArtifactName: V8Jsi-Symbols-New-$(Build.BuildId)
+            DetailedLog: true
+            TreatNotIndexedAsWarning: false

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -406,7 +406,12 @@ async function runBuild(
   const env = { ...process.env };
   if (!platform.startsWith("arm")) {
     const nasmDir = await ensureNasm(toolsPath);
-    env.PATH = `${nasmDir};${env.PATH ?? ""}`;
+    // Update the EXISTING path variable in place. Windows stores it as "Path";
+    // assigning env.PATH would add a second, conflicting key that shadows the
+    // real one (dropping System32, so cmd.exe/vcbuild can't be found).
+    const pathKey =
+      Object.keys(env).find((k) => k.toUpperCase() === "PATH") ?? "Path";
+    env[pathKey] = `${nasmDir};${env[pathKey] ?? ""}`;
   }
 
   run("cmd.exe", ["/c", ...vcbuildArgs], { cwd: nodejsDir, env });

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -24,6 +24,9 @@ const binskimNuGetSource = "https://api.nuget.org/v3/index.json";
 const nugetDownloadUrl =
   "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe";
 
+const nasmVersion = "2.16.03";
+const nasmDownloadUrl = `https://www.nasm.us/pub/nasm/releasebuilds/${nasmVersion}/win64/nasm-${nasmVersion}-win64.zip`;
+
 // =============================================================================
 // CLI Parsing
 // =============================================================================
@@ -33,7 +36,10 @@ const options = {
   build: { type: "boolean" as const, default: true },
   test: { type: "boolean" as const, default: false },
   pack: { type: "boolean" as const, default: false },
+  smoke: { type: "boolean" as const, default: false },
   binskim: { type: "boolean" as const, default: false },
+  "check-crt": { type: "boolean" as const, default: false },
+  "count-exports": { type: "boolean" as const, default: false },
   "clean-all": { type: "boolean" as const, default: false },
   "clean-build": { type: "boolean" as const, default: false },
   "clean-pkg": { type: "boolean" as const, default: false },
@@ -175,6 +181,43 @@ async function ensureNuGet(toolsPath: string): Promise<string> {
   return localNuget;
 }
 
+// Ensure NASM is available and return the directory containing nasm.exe.
+// The Node.js OpenSSL build assembles its crypto with NASM on x86/x64 (the
+// arm64 build skips that asm path). Mirrors ensureNuGet: prefer PATH, else a
+// cached copy under toolsPath, else download + extract the official zip.
+async function ensureNasm(toolsPath: string): Promise<string> {
+  try {
+    const onPath = execSync("where nasm.exe", { encoding: "utf-8" })
+      .split(/\r?\n/)
+      .find((l: string) => l.trim().length > 0)
+      ?.trim();
+    if (onPath) return path.dirname(onPath);
+  } catch {
+    // Not on PATH; fall through to the cached/download path.
+  }
+
+  const nasmDir = path.join(toolsPath, "nasm", `nasm-${nasmVersion}`);
+  if (fs.existsSync(path.join(nasmDir, "nasm.exe"))) {
+    return nasmDir;
+  }
+
+  console.log(`Downloading NASM ${nasmVersion}...`);
+  const zipPath = path.join(toolsPath, `nasm-${nasmVersion}-win64.zip`);
+  await downloadFile(nasmDownloadUrl, zipPath);
+  const extractDir = path.join(toolsPath, "nasm");
+  ensureDir(extractDir);
+  run("powershell.exe", [
+    "-NoProfile",
+    "-Command",
+    `"Expand-Archive -Path '${zipPath}' -DestinationPath '${extractDir}' -Force"`,
+  ]);
+  if (!fs.existsSync(path.join(nasmDir, "nasm.exe"))) {
+    throw new Error(`NASM not found after extraction at ${nasmDir}`);
+  }
+  console.log(`NASM ready at ${nasmDir}`);
+  return nasmDir;
+}
+
 function configDir(configuration: string): string {
   return configuration.charAt(0).toUpperCase() + configuration.slice(1);
 }
@@ -299,7 +342,11 @@ Boolean flags (all support --no- prefix):
   --build             Build v8jsi.dll (default: true)
   --test              Run v8jsi_test.exe
   --pack              Create NuGet package
+  --smoke             Build the real-consumer test-harness against the packed
+                      .nupkg (x64; Release/Release + Debug/Release)
   --binskim           Run BinSkim security validation
+  --check-crt         Report v8jsi.dll's C/C++ runtime imports (Hybrid CRT check)
+  --count-exports     Report v8jsi.dll's exported symbol counts by API family
   --clean-all         Delete entire output folder
   --clean-build       Delete build outputs for targeted configs
   --clean-pkg         Delete pkg and pkg-staging folders
@@ -324,7 +371,11 @@ Examples:
 // Build Operation
 // =============================================================================
 
-function runBuild(platform: string, configuration: string): void {
+async function runBuild(
+  platform: string,
+  configuration: string,
+  toolsPath: string,
+): Promise<void> {
   console.log(`\n=== Building v8jsi (${platform} ${configuration}) ===\n`);
 
   // vcbuild.bat accepts x86 / x64 / arm64 as order-independent target-arch
@@ -351,7 +402,14 @@ function runBuild(platform: string, configuration: string): void {
     process.env.V8JSI_FILE_VERSION = args["file-version"];
   }
 
-  run("cmd.exe", ["/c", ...vcbuildArgs], { cwd: nodejsDir });
+  // The x86/x64 OpenSSL build needs NASM on PATH; arm64 skips the asm path.
+  const env = { ...process.env };
+  if (!platform.startsWith("arm")) {
+    const nasmDir = await ensureNasm(toolsPath);
+    env.PATH = `${nasmDir};${env.PATH ?? ""}`;
+  }
+
+  run("cmd.exe", ["/c", ...vcbuildArgs], { cwd: nodejsDir, env });
 }
 
 // =============================================================================
@@ -368,13 +426,16 @@ function runTests(platform: string, configuration: string): void {
     return;
   }
 
-  const testExe = path.join(buildOutputDir(configuration), "v8jsi_test.exe");
-  if (!fs.existsSync(testExe)) {
-    console.error(`Test executable not found: ${testExe}`);
-    process.exit(1);
+  // Run both gtest binaries: the JSI suite and the Node-API conformance suite.
+  const outDir = buildOutputDir(configuration);
+  for (const exeName of ["v8jsi_test.exe", "node_api_tests.exe"]) {
+    const testExe = path.join(outDir, exeName);
+    if (!fs.existsSync(testExe)) {
+      console.error(`Test executable not found: ${testExe}`);
+      process.exit(1);
+    }
+    run(testExe, ["--gtest_brief=1"]);
   }
-
-  run(testExe, []);
 }
 
 // =============================================================================
@@ -462,6 +523,126 @@ async function runBinSkim(
 }
 
 // =============================================================================
+// DLL Reports (dumpbin)
+// =============================================================================
+
+// Locate dumpbin.exe via vswhere (works across VS editions/versions), falling
+// back to PATH. Cached after the first lookup.
+let cachedDumpbin: string | undefined;
+function findDumpbin(): string {
+  if (cachedDumpbin) return cachedDumpbin;
+
+  const programFilesX86 =
+    process.env["ProgramFiles(x86)"] ??
+    process.env["ProgramFiles"] ??
+    "C:\\Program Files (x86)";
+  const vswhere = path.join(
+    programFilesX86,
+    "Microsoft Visual Studio",
+    "Installer",
+    "vswhere.exe",
+  );
+  if (fs.existsSync(vswhere)) {
+    try {
+      const out = execSync(
+        `"${vswhere}" -latest -products * -find "**\\Hostx64\\x64\\dumpbin.exe"`,
+        { encoding: "utf-8" },
+      ).trim();
+      const first = out.split(/\r?\n/).find((l) => l.trim().length > 0)?.trim();
+      if (first && fs.existsSync(first)) {
+        cachedDumpbin = first;
+        return first;
+      }
+    } catch {
+      // Fall through to the PATH lookup.
+    }
+  }
+
+  try {
+    const onPath = execSync("where dumpbin.exe", { encoding: "utf-8" })
+      .split(/\r?\n/)
+      .find((l: string) => l.trim().length > 0)
+      ?.trim();
+    if (onPath && fs.existsSync(onPath)) {
+      cachedDumpbin = onPath;
+      return onPath;
+    }
+  } catch {
+    // Not on PATH either.
+  }
+
+  throw new Error(
+    "dumpbin.exe not found (install the Visual Studio C++ tools or run from a VS developer prompt).",
+  );
+}
+
+function builtDllPath(configuration: string): string {
+  const dll = path.join(buildOutputDir(configuration), "v8jsi.dll");
+  if (!fs.existsSync(dll)) {
+    console.error(`v8jsi.dll not found: ${dll}`);
+    process.exit(1);
+  }
+  return dll;
+}
+
+// Report v8jsi.dll's C/C++ runtime imports. The Hybrid CRT contract means the
+// only shared runtime should be the UCRT (api-ms-win-crt-* / ucrtbase.dll) —
+// there must be no vcruntime140 / msvcp140 (App-CRT is statically private).
+function reportCrtDependencies(platform: string, configuration: string): void {
+  console.log(`\n=== CRT dependencies (${platform} ${configuration}) ===\n`);
+  const dll = builtDllPath(configuration);
+  const dumpbin = findDumpbin();
+  const out = execSync(`"${dumpbin}" /DEPENDENTS "${dll}"`, {
+    encoding: "utf-8",
+  });
+  const crtRe = /vcruntime|msvcp|ucrtbase|api-ms-win-crt|ucrt/i;
+  const crtLines = out
+    .split(/\r?\n/)
+    .map((l: string) => l.trim())
+    .filter((l: string) => crtRe.test(l));
+
+  console.log(`dumpbin: ${dumpbin}`);
+  console.log(`==== ${dll} ====`);
+  for (const l of crtLines) console.log(`  ${l}`);
+
+  const violations = crtLines.filter((l: string) => /vcruntime|msvcp/i.test(l));
+  if (violations.length) {
+    console.log(
+      `\nWARNING: Hybrid CRT contract broken — non-UCRT shared runtime present: ${violations.join(", ")}`,
+    );
+  } else {
+    console.log(
+      "\nHybrid CRT OK: only the UCRT (api-ms-win-crt-* / ucrtbase) is shared.",
+    );
+  }
+}
+
+// Report v8jsi.dll's exported symbol counts by API family. Handy for spotting
+// an unexpected change in the export surface.
+function reportExports(platform: string, configuration: string): void {
+  console.log(`\n=== Export counts (${platform} ${configuration}) ===\n`);
+  const dll = builtDllPath(configuration);
+  const dumpbin = findDumpbin();
+  const out = execSync(`"${dumpbin}" /EXPORTS "${dll}"`, { encoding: "utf-8" });
+
+  // Export-table rows look like: "    1    0 00001000 napi_foo".
+  const rowRe = /^\s+\d+\s+\w+\s+\w+\s+(\S+)/;
+  const names: string[] = [];
+  for (const line of out.split(/\r?\n/)) {
+    const m = rowRe.exec(line);
+    if (m) names.push(m[1]);
+  }
+  const count = (prefix: string): number =>
+    names.filter((n: string) => n.startsWith(prefix)).length;
+
+  console.log(`napi_*:     ${count("napi_")}`);
+  console.log(`jsr_*:      ${count("jsr_")}`);
+  console.log(`node_api_*: ${count("node_api_")}`);
+  console.log(`v8_*:       ${count("v8_")}`);
+  console.log(`total:      ${names.length}`);
+}
+
+// =============================================================================
 // Pack Operation
 // =============================================================================
 
@@ -527,7 +708,20 @@ function packNuGet(outputPath: string, platforms: string[], configurations: stri
         );
       }
       // PDB is optional (Q2 decision: ship in per-RID .nupkg when present).
-      copyFile("v8jsi.dll.pdb", outDir, ridDir, true);
+      // Like the import lib, the GYP build names it v8jsi.pdb while the
+      // MSBuild legacy emitted v8jsi.dll.pdb; stage it as v8jsi.dll.pdb either
+      // way so the .targets copy rule and the symbol-publish staging resolve.
+      if (fs.existsSync(path.join(outDir, "v8jsi.dll.pdb"))) {
+        copyFile("v8jsi.dll.pdb", outDir, ridDir);
+      } else if (fs.existsSync(path.join(outDir, "v8jsi.pdb"))) {
+        ensureDir(ridDir);
+        fs.copyFileSync(
+          path.join(outDir, "v8jsi.pdb"),
+          path.join(ridDir, "v8jsi.dll.pdb"),
+        );
+      } else {
+        console.log("Skipping copy of v8jsi.dll.pdb (file not found, optional)");
+      }
     }
   }
 
@@ -669,7 +863,14 @@ function packNuGet(outputPath: string, platforms: string[], configurations: stri
   // RIDs are present (aggregator-pack scenario). Local single-arch builds
   // produce 1 per-RID .nupkg; the aggregator job produces 4 (meta + 3).
   // ---------------------------------------------------------------------
-  const version = args["semantic-version"] || configJson.version;
+  // The Node.js-source v8jsi NuGet (Microsoft.JavaScript.V8) versions on the
+  // Node.js-aligned 24.x.y scheme carried in config.json.v8jsi_version, which
+  // is distinct from config.json.version (the legacy ReactNative.V8Jsi.Windows
+  // scheme that the old NuGet still ships on). Prefer v8jsi_version; an
+  // explicit --semantic-version always wins, and config.json.version remains
+  // the last-resort fallback.
+  const version =
+    args["semantic-version"] || configJson.v8jsi_version || configJson.version;
   const repoUrl = "https://github.com/microsoft/v8-jsi";
 
   let repoCommit = "unknown";
@@ -736,6 +937,29 @@ function packNuGet(outputPath: string, platforms: string[], configurations: stri
   );
   if (allRidsPresent) {
     packOne("Microsoft.JavaScript.V8.nuspec");
+
+    // Stage each RID's PDB next to the .nupkgs under pkg/symbols/<rid>/ so the
+    // release pipeline can publish them to the Symbol Server directly (no
+    // extracting from inside the .nupkg). The PDB also ships inside each per-RID
+    // .nupkg at runtimes/<rid>/native/ for consumer convenience (Stage-D Q2).
+    // Only done for the full RID set — i.e. the release aggregate; a single-arch
+    // per-cell pack skips it (the symbols are reproduced by the aggregator pack),
+    // which keeps the per-cell CI artifact from carrying a duplicate ~422 MB PDB.
+    for (const rid of stagedRids) {
+      const pdbSrc = path.join(
+        pkgStagingPath,
+        "build",
+        "native",
+        rid,
+        "v8jsi.dll.pdb",
+      );
+      if (fs.existsSync(pdbSrc)) {
+        const symbolsDir = path.join(pkgPath, "symbols", rid);
+        ensureDir(symbolsDir);
+        fs.copyFileSync(pdbSrc, path.join(symbolsDir, "v8jsi.dll.pdb"));
+        console.log(`Staged ${rid} PDB under pkg/symbols/${rid}/.`);
+      }
+    }
   } else {
     const missing = ALL_WINDOWS_RIDS.filter(
       (r) =>
@@ -749,6 +973,43 @@ function packNuGet(outputPath: string, platforms: string[], configurations: stri
   }
 
   console.log(`\nNuGet packages created in ${pkgPath}`);
+}
+
+// =============================================================================
+// Smoke Operation
+// =============================================================================
+
+// Build the real-consumer test-harness against the freshly-packed per-RID
+// .nupkg via test-harness/run-smoke.ps1. The harness is x64-only; it builds an
+// x64 consumer in both Release and Debug against the Release v8jsi.dll (the
+// Debug/Release leg exercises the Hybrid CRT cross-CRT boundary).
+function runSmoke(outputPath: string, platforms: string[]): void {
+  console.log("\n=== Smoke (real-consumer) ===\n");
+
+  if (!platforms.includes("x64")) {
+    console.log(
+      "Skipping smoke: the harness is x64-only and x64 was not targeted.",
+    );
+    return;
+  }
+
+  const smokeScript = path.join(repoRoot, "test-harness", "run-smoke.ps1");
+  const pkgDir = path.join(outputPath, "pkg");
+  for (const consumerConfig of ["Release", "Debug"]) {
+    run("powershell.exe", [
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      `"${smokeScript}"`,
+      "-Configuration",
+      consumerConfig,
+      "-Platform",
+      "x64",
+      "-PkgDir",
+      `"${pkgDir}"`,
+    ]);
+  }
 }
 
 // =============================================================================
@@ -831,7 +1092,7 @@ async function main(): Promise<void> {
         cleanBuild(configuration);
       }
       if (args.build) {
-        runBuild(platform, configuration);
+        await runBuild(platform, configuration, toolsPath);
       }
       if (args.test) {
         runTests(platform, configuration);
@@ -839,12 +1100,23 @@ async function main(): Promise<void> {
       if (args.binskim) {
         await runBinSkim(platform, configuration, toolsPath);
       }
+      if (args["check-crt"]) {
+        reportCrtDependencies(platform, configuration);
+      }
+      if (args["count-exports"]) {
+        reportExports(platform, configuration);
+      }
     }
   }
 
   // Package operation (after all builds)
   if (args.pack) {
     packNuGet(outputPath, platforms, configurations);
+  }
+
+  // Real-consumer smoke (after packing)
+  if (args.smoke) {
+    runSmoke(outputPath, platforms);
   }
 
   // Report elapsed time

--- a/scripts/nuget/LICENSE
+++ b/scripts/nuget/LICENSE
@@ -1,0 +1,23 @@
+React Native V8 JSI adapter
+
+Copyright (c) Microsoft Corporation.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/nuget/Microsoft.JavaScript.V8.native.rid.props
+++ b/scripts/nuget/Microsoft.JavaScript.V8.native.rid.props
@@ -1,0 +1,30 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <!-- If V8JsiIncludePublicHeaders == False then don't add include directories for the V8 JSI public headers. -->
+    <V8JsiIncludePublicHeaders Condition=" '$(V8JsiIncludePublicHeaders)' == '' ">True</V8JsiIncludePublicHeaders>
+
+    <!-- If V8JsiIncludeNodeApiHeaders == False then don't add include directories for the Node-API and Node-API-JSI headers. -->
+    <V8JsiIncludeNodeApiHeaders Condition=" '$(V8JsiIncludeNodeApiHeaders)' == '' ">True</V8JsiIncludeNodeApiHeaders>
+
+    <!-- If V8JsiAddLibDependency == False then don't add linker dependency on v8jsi.dll.lib. -->
+    <V8JsiAddLibDependency Condition=" '$(V8JsiAddLibDependency)' == '' ">True</V8JsiAddLibDependency>
+
+    <!-- If V8JsiAddConsumerSourceTUs == False then don't inject the consumer-side <ClCompile> items
+         (jsi.cpp, V8JsiRuntime.cpp, JsiAbiRuntime.cpp). Useful when the consumer ships its own copy. -->
+    <V8JsiAddConsumerSourceTUs Condition=" '$(V8JsiAddConsumerSourceTUs)' == '' ">True</V8JsiAddConsumerSourceTUs>
+
+    <!-- If V8JsiCopyDLL == False then don't copy the native v8jsi.dll to the target output folder. -->
+    <V8JsiCopyDLL Condition=" '$(V8JsiCopyDLL)' == '' ">True</V8JsiCopyDLL>
+  </PropertyGroup>
+
+  <!-- Detect the runtime identifier (RID) for the current platform, if none was specified. -->
+  <PropertyGroup Condition=" '$(V8JsiRuntimeIdentifier)' == '' AND $([MSBuild]::IsOsPlatform('Windows'))">
+    <V8JsiRuntimeIdentifier Condition=" '$(Platform)' == 'X64' ">win-x64</V8JsiRuntimeIdentifier>
+    <V8JsiRuntimeIdentifier Condition=" '$(Platform)' == 'X86' ">win-x86</V8JsiRuntimeIdentifier>
+    <V8JsiRuntimeIdentifier Condition=" '$(Platform)' == 'Win32' ">win-x86</V8JsiRuntimeIdentifier>
+    <V8JsiRuntimeIdentifier Condition=" '$(Platform)' == 'Arm64' ">win-arm64</V8JsiRuntimeIdentifier>
+    <V8JsiRuntimeIdentifier Condition=" '$(Platform)' == 'ARM64EC' ">win-arm64</V8JsiRuntimeIdentifier>
+  </PropertyGroup>
+
+</Project>

--- a/scripts/nuget/Microsoft.JavaScript.V8.native.rid.targets
+++ b/scripts/nuget/Microsoft.JavaScript.V8.native.rid.targets
@@ -1,0 +1,46 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Add include paths to header files. -->
+  <ItemDefinitionGroup Condition=" '$(V8JsiRuntimeIdentifier)' == '$rid$' ">
+    <ClCompile>
+      <AdditionalIncludeDirectories Condition="'$(V8JsiIncludePublicHeaders)' == 'True'">%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)include;$(MSBuildThisFileDirectory)jsi</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(V8JsiIncludeNodeApiHeaders)' == 'True'">%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)include\node-api;$(MSBuildThisFileDirectory)include\node-api-jsi</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <!-- Add v8jsi.dll.lib dependency required for MSVC C++ linker if it is part of this package. -->
+  <ItemDefinitionGroup Condition=" '$(V8JsiRuntimeIdentifier)' == '$rid$' AND '$(V8JsiAddLibDependency)' == 'True' AND Exists('$(MSBuildThisFileDirectory)$rid$\v8jsi.dll.lib') ">
+    <Link>
+      <AdditionalDependencies>v8jsi.dll.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)$rid$;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <DelayLoadDLLs>v8jsi.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <!-- Consumer-side translation units.
+       jsi.cpp ships the JSI base-class implementations (Buffer/Value/JSError/
+       Runtime destructors and virtual default impls). v8jsi.dll does not export
+       these symbols (JSI_EXPORT is a no-op unless CREATE_SHARED_LIBRARY is set,
+       which v8jsi.gyp doesn't define), so every consumer compiles jsi.cpp
+       locally.
+       V8JsiRuntime.cpp holds makeV8Runtime + the V8ScriptCache and V8TaskRunner
+       adapters. JsiAbiRuntime.cpp is the C++ wrapper that implements
+       jsi::Runtime over the JSI ABI vtable. Both compile against v8jsi.dll's
+       stable C exports (v8_jsi_config_*, get_jsi_abi_v8_vtable, etc.). -->
+  <ItemGroup Condition=" '$(V8JsiRuntimeIdentifier)' == '$rid$' AND '$(V8JsiAddConsumerSourceTUs)' == 'True' ">
+    <ClCompile Include="$(MSBuildThisFileDirectory)jsi\jsi\jsi.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)jsi\public\V8JsiRuntime.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)jsi\jsi_abi\JsiAbiRuntime.cpp" />
+  </ItemGroup>
+
+  <!-- Copy v8jsi.dll (and PDB if shipped) to the output directory. -->
+  <ItemGroup Condition=" '$(V8JsiRuntimeIdentifier)' == '$rid$' AND '$(V8JsiCopyDLL)' == 'True' ">
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\$rid$\native\$v8jsiName$" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\$rid$\native\$v8jsiName$" CopyToOutputDirectory="PreserveNewest" />
+    <!-- PDB is optional. Stage B2 / C-onward release packs include it; the
+         Exists() guard lets consumer builds pass when no PDB ships. -->
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\$rid$\native\v8jsi.dll.pdb"
+                             Condition="Exists('$(MSBuildThisFileDirectory)..\..\runtimes\$rid$\native\v8jsi.dll.pdb')" />
+  </ItemGroup>
+
+</Project>

--- a/scripts/nuget/Microsoft.JavaScript.V8.net461.rid.props
+++ b/scripts/nuget/Microsoft.JavaScript.V8.net461.rid.props
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <!-- If V8JsiCopyDLL == False then don't copy the native v8jsi.dll. -->
+    <V8JsiCopyDLL Condition=" '$(V8JsiCopyDLL)' == '' ">True</V8JsiCopyDLL>
+  </PropertyGroup>
+
+</Project>

--- a/scripts/nuget/Microsoft.JavaScript.V8.net461.rid.targets
+++ b/scripts/nuget/Microsoft.JavaScript.V8.net461.rid.targets
@@ -1,0 +1,12 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Copy the v8jsi.dll file to the output directory for transitive .NET consumers. -->
+  <ItemGroup Condition=" '$(V8JsiCopyDLL)' == 'True' ">
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\$rid$\native\$v8jsiName$">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>runtimes\$rid$\native\$v8jsiName$</TargetPath>
+      <Pack>false</Pack>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/scripts/nuget/Microsoft.JavaScript.V8.nuspec
+++ b/scripts/nuget/Microsoft.JavaScript.V8.nuspec
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.JavaScript.V8</id>
+    <version>$version$</version>
+    <description>JavaScript Interface (JSI) implementation backed by Google V8. Ships an ABI-safe C runtime API plus consumer-side C++ adapters for embedding V8 in native applications.</description>
+    <title>Microsoft V8 JSI</title>
+    <authors>Microsoft</authors>
+    <projectUrl>https://github.com/microsoft/v8-jsi</projectUrl>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <repository type="git" url="$repoUrl$" branch="$repoBranch$" commit="$repoCommit$" />
+    <language>en-US</language>
+    <readme>README.md</readme>
+    <tags>native JavaScript JS V8 JSI library Microsoft react-native</tags>
+    <!-- Two groups: netstandard2.0 silences NU5128 (paired with the
+         lib/netstandard2.0/_._ placeholder) and serves PackageReference /
+         .NET consumers; native serves packages.config consumers (NuGet's
+         framework-matching falls through to "native" for C++ projects). -->
+    <dependencies>
+      <group targetFramework="netstandard2.0">
+        <dependency id="Microsoft.JavaScript.V8.win-x86" version="$version$" />
+        <dependency id="Microsoft.JavaScript.V8.win-x64" version="$version$" />
+        <dependency id="Microsoft.JavaScript.V8.win-arm64" version="$version$" />
+      </group>
+      <group targetFramework="native">
+        <dependency id="Microsoft.JavaScript.V8.win-x86" version="$version$" />
+        <dependency id="Microsoft.JavaScript.V8.win-x64" version="$version$" />
+        <dependency id="Microsoft.JavaScript.V8.win-arm64" version="$version$" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="$nugetroot$\_._" target="lib\netstandard2.0\" />
+    <file src="$nugetroot$\LICENSE" target="LICENSE" />
+    <file src="$nugetroot$\NOTICE.txt" target="" />
+    <file src="$nugetroot$\README.md" target="" />
+  </files>
+</package>

--- a/scripts/nuget/Microsoft.JavaScript.V8.rid.nuspec
+++ b/scripts/nuget/Microsoft.JavaScript.V8.rid.nuspec
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.JavaScript.V8.$rid$</id>
+    <version>$version$</version>
+    <description>JavaScript Interface (JSI) implementation backed by Google V8 — $rid$ runtime. Ships v8jsi native binary, import library, public headers, and consumer-side C++ adapter sources.</description>
+    <title>Microsoft V8 JSI ($rid$)</title>
+    <authors>Microsoft</authors>
+    <projectUrl>https://github.com/microsoft/v8-jsi</projectUrl>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <repository type="git" url="$repoUrl$" branch="$repoBranch$" commit="$repoCommit$" />
+    <language>en-US</language>
+    <readme>README.md</readme>
+    <tags>native JavaScript JS V8 JSI library Microsoft react-native</tags>
+    <!-- The per-RID package ships only build/native/ and runtimes/ content;
+         no real dependencies. The empty netstandard2.0 group exists to
+         silence NU5128 (lib/netstandard2.0/_._ placeholder requires a
+         matching dependency group declaration). -->
+    <dependencies>
+      <group targetFramework="netstandard2.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="$nugetroot$\build\native\include\**\*.*"
+          target="build\native\include" />
+    <file src="$nugetroot$\build\native\jsi\**\*.*"
+          target="build\native\jsi" />
+    <!-- The v8jsi.dll.lib is Windows-only. We use the *.lib pattern to copy the optional file. -->
+    <file src="$nugetroot$\build\native\$rid$\*.lib"
+          target="build\native\$rid$\" />
+    <file src="$nugetroot$\Microsoft.JavaScript.V8.native.$rid$.props"
+          target="build\native\Microsoft.JavaScript.V8.$rid$.props" />
+    <file src="$nugetroot$\Microsoft.JavaScript.V8.native.$rid$.targets"
+          target="build\native\Microsoft.JavaScript.V8.$rid$.targets" />
+    <file src="$nugetroot$\Microsoft.JavaScript.V8.net461.$rid$.props"
+          target="buildTransitive\net461\Microsoft.JavaScript.V8.$rid$.props" />
+    <file src="$nugetroot$\Microsoft.JavaScript.V8.net461.$rid$.targets"
+          target="buildTransitive\net461\Microsoft.JavaScript.V8.$rid$.targets" />
+    <file src="$nugetroot$\_._" target="lib\netstandard2.0\" />
+    <file src="$nugetroot$\build\native\$rid$\$v8jsiName$"
+          target="runtimes\$rid$\native\$v8jsiName$" />
+    <!-- PDB is optional. The *.pdb pattern lets the file silently absent itself
+         from release/no-symbols builds without failing pack. -->
+    <file src="$nugetroot$\build\native\$rid$\*.pdb"
+          target="runtimes\$rid$\native\" />
+    <file src="$nugetroot$\LICENSE" target="LICENSE" />
+    <file src="$nugetroot$\NOTICE.txt" target="" />
+    <file src="$nugetroot$\README.md" target="" />
+  </files>
+</package>

--- a/scripts/nuget/NOTICE.txt
+++ b/scripts/nuget/NOTICE.txt
@@ -1,0 +1,1748 @@
+NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This software incorporates material from third parties. Microsoft makes
+certain open source code available at https://3rdpartysource.microsoft.com,
+or you may send a check or money order for US $5.00, including the product
+name, the open source component name, and version number, to:
+
+Source Code Compliance Team
+Microsoft Corporation
+One Microsoft Way
+Redmond, WA 98052
+USA
+
+Notwithstanding any other terms, you may reverse engineer this software to
+the extent required to debug changes to any libraries licensed under the
+GNU Lesser General Public License.
+
+---------------------------------------------------------
+
+Component: facebook/hermes JSI (jsi.h, jsi-inl.h, jsi.cpp,
+instrumentation.h). The JSI base-class implementations are derived from
+Meta's open source JSI surface.
+MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+Component: Node.js / Node-API (js_native_api.h, js_native_api_types.h,
+js_runtime_api.h, NodeApiJsiRuntime.{h,cpp}, ApiLoaders/*).
+Node.js is licensed for use as follows:
+
+"""
+Copyright Node.js contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+"""
+
+This license applies to parts of Node.js originating from the
+https://github.com/joyent/node repository:
+
+"""
+Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+"""
+
+The Node.js license applies to all parts of Node.js that are not externally
+maintained libraries.
+
+The externally maintained libraries used by Node.js are:
+
+- Acorn, located at deps/acorn, is licensed as follows:
+  """
+    MIT License
+
+    Copyright (C) 2012-2018 by various contributors (see AUTHORS)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+  """
+
+- Acorn plugins, located at deps/acorn-plugins, is licensed as follows:
+  """
+    Copyright (C) 2017-2018 by Adrian Heine
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+  """
+
+- c-ares, located at deps/cares, is licensed as follows:
+  """
+    Copyright (c) 2007 - 2018, Daniel Stenberg with many contributors, see AUTHORS
+    file.
+
+    Copyright 1998 by the Massachusetts Institute of Technology.
+
+    Permission to use, copy, modify, and distribute this software and its
+    documentation for any purpose and without fee is hereby granted, provided that
+    the above copyright notice appear in all copies and that both that copyright
+    notice and this permission notice appear in supporting documentation, and that
+    the name of M.I.T. not be used in advertising or publicity pertaining to
+    distribution of the software without specific, written prior permission.
+    M.I.T. makes no representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied warranty.
+  """
+
+- cjs-module-lexer, located at deps/cjs-module-lexer, is licensed as follows:
+  """
+    MIT License
+    -----------
+
+    Copyright (C) 2018-2020 Guy Bedford
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- ICU, located at deps/icu-small, is licensed as follows:
+  """
+    COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
+
+    Copyright © 1991-2020 Unicode, Inc. All rights reserved.
+    Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of the Unicode data files and any associated documentation
+    (the "Data Files") or Unicode software and any associated documentation
+    (the "Software") to deal in the Data Files or Software
+    without restriction, including without limitation the rights to use,
+    copy, modify, merge, publish, distribute, and/or sell copies of
+    the Data Files or Software, and to permit persons to whom the Data Files
+    or Software are furnished to do so, provided that either
+    (a) this copyright and permission notice appear with all copies
+    of the Data Files or Software, or
+    (b) this copyright and permission notice appear in associated
+    Documentation.
+
+    THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+    WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+    IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+    NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+    DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+    DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+    TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+    PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+    Except as contained in this notice, the name of a copyright holder
+    shall not be used in advertising or otherwise to promote the sale,
+    use or other dealings in these Data Files or Software without prior
+    written authorization of the copyright holder.
+
+    ---------------------
+
+    Third-Party Software Licenses
+
+    This section contains third-party software notices and/or additional
+    terms for licensed third-party software components included within ICU
+    libraries.
+
+    1. ICU License - ICU 1.8.1 to ICU 57.1
+
+    COPYRIGHT AND PERMISSION NOTICE
+
+    Copyright (c) 1995-2016 International Business Machines Corporation and others
+    All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, and/or sell copies of the Software, and to permit persons
+    to whom the Software is furnished to do so, provided that the above
+    copyright notice(s) and this permission notice appear in all copies of
+    the Software and that both the above copyright notice(s) and this
+    permission notice appear in supporting documentation.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+    OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+    HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+    SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+    RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+    CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+    CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+    Except as contained in this notice, the name of a copyright holder
+    shall not be used in advertising or otherwise to promote the sale, use
+    or other dealings in this Software without prior written authorization
+    of the copyright holder.
+
+    All trademarks and registered trademarks mentioned herein are the
+    property of their respective owners.
+
+    2. Chinese/Japanese Word Break Dictionary Data (cjdict.txt)
+
+     #     The Google Chrome software developed by Google is licensed under
+     # the BSD license. Other software included in this distribution is
+     # provided under other licenses, as set forth below.
+     #
+     #  The BSD License
+     #  http://opensource.org/licenses/bsd-license.php
+     #  Copyright (C) 2006-2008, Google Inc.
+     #
+     #  All rights reserved.
+     #
+     #  Redistribution and use in source and binary forms, with or without
+     # modification, are permitted provided that the following conditions are met:
+     #
+     #  Redistributions of source code must retain the above copyright notice,
+     # this list of conditions and the following disclaimer.
+     #  Redistributions in binary form must reproduce the above
+     # copyright notice, this list of conditions and the following
+     # disclaimer in the documentation and/or other materials provided with
+     # the distribution.
+     #  Neither the name of  Google Inc. nor the names of its
+     # contributors may be used to endorse or promote products derived from
+     # this software without specific prior written permission.
+     #
+     #
+     #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+     # CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+     # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+     # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+     # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+     # LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+     # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+     # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+     # BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+     # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+     # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+     #
+     #
+     #  The word list in cjdict.txt are generated by combining three word lists
+     # listed below with further processing for compound word breaking. The
+     # frequency is generated with an iterative training against Google web
+     # corpora.
+     #
+     #  * Libtabe (Chinese)
+     #    - https://sourceforge.net/project/?group_id=1519
+     #    - Its license terms and conditions are shown below.
+     #
+     #  * IPADIC (Japanese)
+     #    - http://chasen.aist-nara.ac.jp/chasen/distribution.html
+     #    - Its license terms and conditions are shown below.
+     #
+     #  ---------COPYING.libtabe ---- BEGIN--------------------
+     #
+     #  /*
+     #   * Copyright (c) 1999 TaBE Project.
+     #   * Copyright (c) 1999 Pai-Hsiang Hsiao.
+     #   * All rights reserved.
+     #   *
+     #   * Redistribution and use in source and binary forms, with or without
+     #   * modification, are permitted provided that the following conditions
+     #   * are met:
+     #   *
+     #   * . Redistributions of source code must retain the above copyright
+     #   *   notice, this list of conditions and the following disclaimer.
+     #   * . Redistributions in binary form must reproduce the above copyright
+     #   *   notice, this list of conditions and the following disclaimer in
+     #   *   the documentation and/or other materials provided with the
+     #   *   distribution.
+     #   * . Neither the name of the TaBE Project nor the names of its
+     #   *   contributors may be used to endorse or promote products derived
+     #   *   from this software without specific prior written permission.
+     #   *
+     #   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+     #   * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+     #   * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+     #   * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+     #   * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+     #   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+     #   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+     #   * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     #   * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+     #   * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     #   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+     #   * OF THE POSSIBILITY OF SUCH DAMAGE.
+     #   */
+     #
+     #  /*
+     #   * Copyright (c) 1999 Computer Systems and Communication Lab,
+     #   *                    Institute of Information Science, Academia
+     #       *                    Sinica. All rights reserved.
+     #   *
+     #   * Redistribution and use in source and binary forms, with or without
+     #   * modification, are permitted provided that the following conditions
+     #   * are met:
+     #   *
+     #   * . Redistributions of source code must retain the above copyright
+     #   *   notice, this list of conditions and the following disclaimer.
+     #   * . Redistributions in binary form must reproduce the above copyright
+     #   *   notice, this list of conditions and the following disclaimer in
+     #   *   the documentation and/or other materials provided with the
+     #   *   distribution.
+     #   * . Neither the name of the Computer Systems and Communication Lab
+     #   *   nor the names of its contributors may be used to endorse or
+     #   *   promote products derived from this software without specific
+     #   *   prior written permission.
+     #   *
+     #   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+     #   * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+     #   * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+     #   * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+     #   * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+     #   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+     #   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+     #   * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     #   * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+     #   * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     #   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+     #   * OF THE POSSIBILITY OF SUCH DAMAGE.
+     #   */
+     #
+     #  Copyright 1996 Chih-Hao Tsai @ Beckman Institute,
+     #      University of Illinois
+     #  c-tsai4@uiuc.edu  http://casper.beckman.uiuc.edu/~c-tsai4
+     #
+     #  ---------------COPYING.libtabe-----END--------------------------------
+     #
+     #
+     #  ---------------COPYING.ipadic-----BEGIN-------------------------------
+     #
+     #  Copyright 2000, 2001, 2002, 2003 Nara Institute of Science
+     #  and Technology.  All Rights Reserved.
+     #
+     #  Use, reproduction, and distribution of this software is permitted.
+     #  Any copy of this software, whether in its original form or modified,
+     #  must include both the above copyright notice and the following
+     #  paragraphs.
+     #
+     #  Nara Institute of Science and Technology (NAIST),
+     #  the copyright holders, disclaims all warranties with regard to this
+     #  software, including all implied warranties of merchantability and
+     #  fitness, in no event shall NAIST be liable for
+     #  any special, indirect or consequential damages or any damages
+     #  whatsoever resulting from loss of use, data or profits, whether in an
+     #  action of contract, negligence or other tortuous action, arising out
+     #  of or in connection with the use or performance of this software.
+     #
+     #  A large portion of the dictionary entries
+     #  originate from ICOT Free Software.  The following conditions for ICOT
+     #  Free Software applies to the current dictionary as well.
+     #
+     #  Each User may also freely distribute the Program, whether in its
+     #  original form or modified, to any third party or parties, PROVIDED
+     #  that the provisions of Section 3 ("NO WARRANTY") will ALWAYS appear
+     #  on, or be attached to, the Program, which is distributed substantially
+     #  in the same form as set out herein and that such intended
+     #  distribution, if actually made, will neither violate or otherwise
+     #  contravene any of the laws and regulations of the countries having
+     #  jurisdiction over the User or the intended distribution itself.
+     #
+     #  NO WARRANTY
+     #
+     #  The program was produced on an experimental basis in the course of the
+     #  research and development conducted during the project and is provided
+     #  to users as so produced on an experimental basis.  Accordingly, the
+     #  program is provided without any warranty whatsoever, whether express,
+     #  implied, statutory or otherwise.  The term "warranty" used herein
+     #  includes, but is not limited to, any warranty of the quality,
+     #  performance, merchantability and fitness for a particular purpose of
+     #  the program and the nonexistence of any infringement or violation of
+     #  any right of any third party.
+     #
+     #  Each user of the program will agree and understand, and be deemed to
+     #  have agreed and understood, that there is no warranty whatsoever for
+     #  the program and, accordingly, the entire risk arising from or
+     #  otherwise connected with the program is assumed by the user.
+     #
+     #  Therefore, neither ICOT, the copyright holder, or any other
+     #  organization that participated in or was otherwise related to the
+     #  development of the program and their respective officials, directors,
+     #  officers and other employees shall be held liable for any and all
+     #  damages, including, without limitation, general, special, incidental
+     #  and consequential damages, arising out of or otherwise in connection
+     #  with the use or inability to use the program or any product, material
+     #  or result produced or otherwise obtained by using the program,
+     #  regardless of whether they have been advised of, or otherwise had
+     #  knowledge of, the possibility of such damages at any time during the
+     #  project or thereafter.  Each user will be deemed to have agreed to the
+     #  foregoing by his or her commencement of use of the program.  The term
+     #  "use" as used herein includes, but is not limited to, the use,
+     #  modification, copying and distribution of the program and the
+     #  production of secondary products from the program.
+     #
+     #  In the case where the program, whether in its original form or
+     #  modified, was distributed or delivered to or received by a user from
+     #  any person, organization or entity other than ICOT, unless it makes or
+     #  grants independently of ICOT any specific warranty to the user in
+     #  writing, such person, organization or entity, will also be exempted
+     #  from and not be held liable to the user for any such damages as noted
+     #  above as far as the program is concerned.
+     #
+     #  ---------------COPYING.ipadic-----END----------------------------------
+
+    3. Lao Word Break Dictionary Data (laodict.txt)
+
+     #  Copyright (c) 2013 International Business Machines Corporation
+     #  and others. All Rights Reserved.
+     #
+     # Project: https://github.com/veer66/lao-dictionary
+     # Dictionary: https://github.com/veer66/lao-dictionary/blob/master/Lao-Dictionary.txt
+     # License: https://github.com/veer66/lao-dictionary/blob/master/Lao-Dictionary-LICENSE.txt
+     #              (copied below)
+     #
+     #  This file is derived from the above dictionary, with slight
+     #  modifications.
+     #  ----------------------------------------------------------------------
+     #  Copyright (C) 2013 Brian Eugene Wilson, Robert Martin Campbell.
+     #  All rights reserved.
+     #
+     #  Redistribution and use in source and binary forms, with or without
+     #  modification,
+     #  are permitted provided that the following conditions are met:
+     #
+     #
+     # Redistributions of source code must retain the above copyright notice, this
+     #  list of conditions and the following disclaimer. Redistributions in
+     #  binary form must reproduce the above copyright notice, this list of
+     #  conditions and the following disclaimer in the documentation and/or
+     #  other materials provided with the distribution.
+     #
+     #
+     # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+     # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+     # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+     # FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+     # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+     # INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+     # (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+     # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+     # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+     # OF THE POSSIBILITY OF SUCH DAMAGE.
+     #  --------------------------------------------------------------------------
+
+    4. Burmese Word Break Dictionary Data (burmesedict.txt)
+
+     #  Copyright (c) 2014 International Business Machines Corporation
+     #  and others. All Rights Reserved.
+     #
+     #  This list is part of a project hosted at:
+     #    github.com/kanyawtech/myanmar-karen-word-lists
+     #
+     #  --------------------------------------------------------------------------
+     #  Copyright (c) 2013, LeRoy Benjamin Sharon
+     #  All rights reserved.
+     #
+     #  Redistribution and use in source and binary forms, with or without
+     #  modification, are permitted provided that the following conditions
+     #  are met: Redistributions of source code must retain the above
+     #  copyright notice, this list of conditions and the following
+     #  disclaimer.  Redistributions in binary form must reproduce the
+     #  above copyright notice, this list of conditions and the following
+     #  disclaimer in the documentation and/or other materials provided
+     #  with the distribution.
+     #
+     #    Neither the name Myanmar Karen Word Lists, nor the names of its
+     #    contributors may be used to endorse or promote products derived
+     #    from this software without specific prior written permission.
+     #
+     #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+     #  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+     #  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+     #  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+     #  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+     #  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+     #  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     #  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+     #  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+     #  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+     #  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+     #  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+     #  SUCH DAMAGE.
+     #  --------------------------------------------------------------------------
+
+    5. Time Zone Database
+
+      ICU uses the public domain data and code derived from Time Zone
+    Database for its time zone support. The ownership of the TZ database
+    is explained in BCP 175: Procedure for Maintaining the Time Zone
+    Database section 7.
+
+     # 7.  Database Ownership
+     #
+     #    The TZ database itself is not an IETF Contribution or an IETF
+     #    document.  Rather it is a pre-existing and regularly updated work
+     #    that is in the public domain, and is intended to remain in the
+     #    public domain.  Therefore, BCPs 78 [RFC5378] and 79 [RFC3979] do
+     #    not apply to the TZ Database or contributions that individuals make
+     #    to it.  Should any claims be made and substantiated against the TZ
+     #    Database, the organization that is providing the IANA
+     #    Considerations defined in this RFC, under the memorandum of
+     #    understanding with the IETF, currently ICANN, may act in accordance
+     #    with all competent court orders.  No ownership claims will be made
+     #    by ICANN or the IETF Trust on the database or the code.  Any person
+     #    making a contribution to the database or code waives all rights to
+     #    future claims in that contribution or in the TZ Database.
+
+    6. Google double-conversion
+
+    Copyright 2006-2011, the V8 project authors. All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials provided
+          with the distribution.
+        * Neither the name of Google Inc. nor the names of its
+          contributors may be used to endorse or promote products derived
+          from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- libuv, located at deps/uv, is licensed as follows:
+  """
+    libuv is licensed for use as follows:
+
+    ====
+    Copyright (c) 2015-present libuv project contributors.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+    ====
+
+    This license applies to parts of libuv originating from the
+    https://github.com/joyent/libuv repository:
+
+    ====
+
+    Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+
+    ====
+
+    This license applies to all parts of libuv that are not externally
+    maintained libraries.
+
+    The externally maintained libraries used by libuv are:
+
+      - tree.h (from FreeBSD), copyright Niels Provos. Two clause BSD license.
+
+      - inet_pton and inet_ntop implementations, contained in src/inet.c, are
+        copyright the Internet Systems Consortium, Inc., and licensed under the ISC
+        license.
+
+      - stdint-msvc2008.h (from msinttypes), copyright Alexander Chemeris. Three
+        clause BSD license.
+
+      - pthread-fixes.c, copyright Google Inc. and Sony Mobile Communications AB.
+        Three clause BSD license.
+
+      - android-ifaddrs.h, android-ifaddrs.c, copyright Berkeley Software Design
+        Inc, Kenneth MacKay and Emergya (Cloud4all, FP7/2007-2013, grant agreement
+        n° 289016). Three clause BSD license.
+  """
+
+- llhttp, located at deps/llhttp, is licensed as follows:
+  """
+    This software is licensed under the MIT License.
+
+    Copyright Fedor Indutny, 2018.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit
+    persons to whom the Software is furnished to do so, subject to the
+    following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+    NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+    USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- OpenSSL, located at deps/openssl, is licensed as follows:
+  """
+    Copyright (c) 1998-2019 The OpenSSL Project.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+    3. All advertising materials mentioning features or use of this
+    software must display the following acknowledgment:
+    "This product includes software developed by the OpenSSL Project
+    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+
+    4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+    endorse or promote products derived from this software without
+    prior written permission. For written permission, please contact
+    openssl-core@openssl.org.
+
+    5. Products derived from this software may not be called "OpenSSL"
+    nor may "OpenSSL" appear in their names without prior written
+    permission of the OpenSSL Project.
+
+    6. Redistributions of any form whatsoever must retain the following
+    acknowledgment:
+    "This product includes software developed by the OpenSSL Project
+    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+
+    THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+    EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+    PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+    ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+    OF THE POSSIBILITY OF SUCH DAMAGE.
+    ====================================================================
+
+    This product includes cryptographic software written by Eric Young
+    (eay@cryptsoft.com).  This product includes software written by Tim
+    Hudson (tjh@cryptsoft.com).
+  """
+
+- Punycode.js, located at lib/punycode.js, is licensed as follows:
+  """
+    Copyright Mathias Bynens <https://mathiasbynens.be/>
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- V8, located at deps/v8, is licensed as follows:
+  """
+    This license applies to all parts of V8 that are not externally
+    maintained libraries.  The externally maintained libraries used by V8
+    are:
+
+      - PCRE test suite, located in
+        test/mjsunit/third_party/regexp-pcre/regexp-pcre.js.  This is based on the
+        test suite from PCRE-7.3, which is copyrighted by the University
+        of Cambridge and Google, Inc.  The copyright notice and license
+        are embedded in regexp-pcre.js.
+
+      - Layout tests, located in test/mjsunit/third_party/object-keys.  These are
+        based on layout tests from webkit.org which are copyrighted by
+        Apple Computer, Inc. and released under a 3-clause BSD license.
+
+      - Strongtalk assembler, the basis of the files assembler-arm-inl.h,
+        assembler-arm.cc, assembler-arm.h, assembler-ia32-inl.h,
+        assembler-ia32.cc, assembler-ia32.h, assembler-x64-inl.h,
+        assembler-x64.cc, assembler-x64.h, assembler-mips-inl.h,
+        assembler-mips.cc, assembler-mips.h, assembler.cc and assembler.h.
+        This code is copyrighted by Sun Microsystems Inc. and released
+        under a 3-clause BSD license.
+
+      - Valgrind client API header, located at src/third_party/valgrind/valgrind.h
+        This is released under the BSD license.
+
+      - The Wasm C/C++ API headers, located at third_party/wasm-api/wasm.{h,hh}
+        This is released under the Apache license. The API's upstream prototype
+        implementation also formed the basis of V8's implementation in
+        src/wasm/c-api.cc.
+
+    These libraries have their own licenses; we recommend you read them,
+    as their terms may differ from the terms below.
+
+    Further license information can be found in LICENSE files located in
+    sub-directories.
+
+    Copyright 2014, the V8 project authors. All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials provided
+          with the distribution.
+        * Neither the name of Google Inc. nor the names of its
+          contributors may be used to endorse or promote products derived
+          from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- SipHash, located at deps/v8/src/third_party/siphash, is licensed as follows:
+  """
+    SipHash reference C implementation
+
+    Copyright (c) 2016 Jean-Philippe Aumasson <jeanphilippe.aumasson@gmail.com>
+
+    To the extent possible under law, the author(s) have dedicated all
+    copyright and related and neighboring rights to this software to the public
+    domain worldwide. This software is distributed without any warranty.
+  """
+
+- zlib, located at deps/zlib, is licensed as follows:
+  """
+    zlib.h -- interface of the 'zlib' general purpose compression library
+    version 1.2.11, January 15th, 2017
+
+    Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+    2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+    3. This notice may not be removed or altered from any source distribution.
+
+    Jean-loup Gailly        Mark Adler
+    jloup@gzip.org          madler@alumni.caltech.edu
+  """
+
+- npm, located at deps/npm, is licensed as follows:
+  """
+    The npm application
+    Copyright (c) npm, Inc. and Contributors
+    Licensed on the terms of The Artistic License 2.0
+
+    Node package dependencies of the npm application
+    Copyright (c) their respective copyright owners
+    Licensed on their respective license terms
+
+    The npm public registry at https://registry.npmjs.org
+    and the npm website at https://www.npmjs.com
+    Operated by npm, Inc.
+    Use governed by terms published on https://www.npmjs.com
+
+    "Node.js"
+    Trademark Joyent, Inc., https://joyent.com
+    Neither npm nor npm, Inc. are affiliated with Joyent, Inc.
+
+    The Node.js application
+    Project of Node Foundation, https://nodejs.org
+
+    The npm Logo
+    Copyright (c) Mathias Pettersson and Brian Hammond
+
+    "Gubblebum Blocky" typeface
+    Copyright (c) Tjarda Koster, https://jelloween.deviantart.com
+    Used with permission
+
+    --------
+
+    The Artistic License 2.0
+
+    Copyright (c) 2000-2006, The Perl Foundation.
+
+    Everyone is permitted to copy and distribute verbatim copies
+    of this license document, but changing it is not allowed.
+
+    Preamble
+
+    This license establishes the terms under which a given free software
+    Package may be copied, modified, distributed, and/or redistributed.
+    The intent is that the Copyright Holder maintains some artistic
+    control over the development of that Package while still keeping the
+    Package available as open source and free software.
+
+    You are always permitted to make arrangements wholly outside of this
+    license directly with the Copyright Holder of a given Package.  If the
+    terms of this license do not permit the full use that you propose to
+    make of the Package, you should contact the Copyright Holder and seek
+    a different licensing arrangement.
+
+    Definitions
+
+        "Copyright Holder" means the individual(s) or organization(s)
+        named in the copyright notice for the entire Package.
+
+        "Contributor" means any party that has contributed code or other
+        material to the Package, in accordance with the Copyright Holder's
+        procedures.
+
+        "You" and "your" means any person who would like to copy,
+        distribute, or modify the Package.
+
+        "Package" means the collection of files distributed by the
+        Copyright Holder, and derivatives of that collection and/or of
+        those files. A given Package may consist of either the Standard
+        Version, or a Modified Version.
+
+        "Distribute" means providing a copy of the Package or making it
+        accessible to anyone else, or in the case of a company or
+        organization, to others outside of your company or organization.
+
+        "Distributor Fee" means any fee that you charge for Distributing
+        this Package or providing support for this Package to another
+        party.  It does not mean licensing fees.
+
+        "Standard Version" refers to the Package if it has not been
+        modified, or has been modified only in ways explicitly requested
+        by the Copyright Holder.
+
+        "Modified Version" means the Package, if it has been changed, and
+        such changes were not explicitly requested by the Copyright
+        Holder.
+
+        "Original License" means this Artistic License as Distributed with
+        the Standard Version of the Package, in its current version or as
+        it may be modified by The Perl Foundation in the future.
+
+        "Source" form means the source code, documentation source, and
+        configuration files for the Package.
+
+        "Compiled" form means the compiled bytecode, object code, binary,
+        or any other form resulting from mechanical transformation or
+        translation of the Source form.
+
+    Permission for Use and Modification Without Distribution
+
+    (1)  You are permitted to use the Standard Version and create and use
+    Modified Versions for any purpose without restriction, provided that
+    you do not Distribute the Modified Version.
+
+    Permissions for Redistribution of the Standard Version
+
+    (2)  You may Distribute verbatim copies of the Source form of the
+    Standard Version of this Package in any medium without restriction,
+    either gratis or for a Distributor Fee, provided that you duplicate
+    all of the original copyright notices and associated disclaimers.  At
+    your discretion, such verbatim copies may or may not include a
+    Compiled form of the Package.
+
+    (3)  You may apply any bug fixes, portability changes, and other
+    modifications made available from the Copyright Holder.  The resulting
+    Package will still be considered the Standard Version, and as such
+    will be subject to the Original License.
+
+    Distribution of Modified Versions of the Package as Source
+
+    (4)  You may Distribute your Modified Version as Source (either gratis
+    or for a Distributor Fee, and with or without a Compiled form of the
+    Modified Version) provided that you clearly document how it differs
+    from the Standard Version, including, but not limited to, documenting
+    any non-standard features, executables, or modules, and provided that
+    you do at least ONE of the following:
+
+        (a)  make the Modified Version available to the Copyright Holder
+        of the Standard Version, under the Original License, so that the
+        Copyright Holder may include your modifications in the Standard
+        Version.
+
+        (b)  ensure that installation of your Modified Version does not
+        prevent the user installing or running the Standard Version. In
+        addition, the Modified Version must bear a name that is different
+        from the name of the Standard Version.
+
+        (c)  allow anyone who receives a copy of the Modified Version to
+        make the Source form of the Modified Version available to others
+        under
+
+            (i)  the Original License or
+
+            (ii)  a license that permits the licensee to freely copy,
+            modify and redistribute the Modified Version using the same
+            licensing terms that apply to the copy that the licensee
+            received, and requires that the Source form of the Modified
+            Version, and of any works derived from it, be made freely
+            available in that license fees are prohibited but Distributor
+            Fees are allowed.
+
+    Distribution of Compiled Forms of the Standard Version
+    or Modified Versions without the Source
+
+    (5)  You may Distribute Compiled forms of the Standard Version without
+    the Source, provided that you include complete instructions on how to
+    get the Source of the Standard Version.  Such instructions must be
+    valid at the time of your distribution.  If these instructions, at any
+    time while you are carrying out such distribution, become invalid, you
+    must provide new instructions on demand or cease further distribution.
+    If you provide valid instructions or cease distribution within thirty
+    days after you become aware that the instructions are invalid, then
+    you do not forfeit any of your rights under this license.
+
+    (6)  You may Distribute a Modified Version in Compiled form without
+    the Source, provided that you comply with Section 4 with respect to
+    the Source of the Modified Version.
+
+    Aggregating or Linking the Package
+
+    (7)  You may aggregate the Package (either the Standard Version or
+    Modified Version) with other packages and Distribute the resulting
+    aggregation provided that you do not charge a licensing fee for the
+    Package.  Distributor Fees are permitted, and licensing fees for other
+    components in the aggregation are permitted. The terms of this license
+    apply to the use and Distribution of the Standard or Modified Versions
+    as included in the aggregation.
+
+    (8) You are permitted to link Modified and Standard Versions with
+    other works, to embed the Package in a larger work of your own, or to
+    build stand-alone binary or bytecode versions of applications that
+    include the Package, and Distribute the result without restriction,
+    provided the result does not expose a direct interface to the Package.
+
+    Items That are Not Considered Part of a Modified Version
+
+    (9) Works (including, but not limited to, modules and scripts) that
+    merely extend or make use of the Package, do not, by themselves, cause
+    the Package to be a Modified Version.  In addition, such works are not
+    considered parts of the Package itself, and are not subject to the
+    terms of this license.
+
+    General Provisions
+
+    (10)  Any use, modification, and distribution of the Standard or
+    Modified Versions is governed by this Artistic License. By using,
+    modifying or distributing the Package, you accept this license. Do not
+    use, modify, or distribute the Package, if you do not accept this
+    license.
+
+    (11)  If your Modified Version has been derived from a Modified
+    Version made by someone other than you, you are nevertheless required
+    to ensure that your Modified Version complies with the requirements of
+    this license.
+
+    (12)  This license does not grant you the right to use any trademark,
+    service mark, tradename, or logo of the Copyright Holder.
+
+    (13)  This license includes the non-exclusive, worldwide,
+    free-of-charge patent license to make, have made, use, offer to sell,
+    sell, import and otherwise transfer the Package with respect to any
+    patent claims licensable by the Copyright Holder that are necessarily
+    infringed by the Package. If you institute patent litigation
+    (including a cross-claim or counterclaim) against any party alleging
+    that the Package constitutes direct or contributory patent
+    infringement, then this Artistic License to you shall terminate on the
+    date that such litigation is filed.
+
+    (14)  Disclaimer of Warranty:
+    THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS
+    IS' AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
+    NON-INFRINGEMENT ARE DISCLAIMED TO THE EXTENT PERMITTED BY YOUR LOCAL
+    LAW. UNLESS REQUIRED BY LAW, NO COPYRIGHT HOLDER OR CONTRIBUTOR WILL
+    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+    DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THE PACKAGE, EVEN IF
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    --------
+  """
+
+- GYP, located at tools/gyp, is licensed as follows:
+  """
+    Copyright (c) 2020 Node.js contributors. All rights reserved.
+    Copyright (c) 2009 Google Inc. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- inspector_protocol, located at tools/inspector_protocol, is licensed as follows:
+  """
+    // Copyright 2016 The Chromium Authors. All rights reserved.
+    //
+    // Redistribution and use in source and binary forms, with or without
+    // modification, are permitted provided that the following conditions are
+    // met:
+    //
+    //    * Redistributions of source code must retain the above copyright
+    // notice, this list of conditions and the following disclaimer.
+    //    * Redistributions in binary form must reproduce the above
+    // copyright notice, this list of conditions and the following disclaimer
+    // in the documentation and/or other materials provided with the
+    // distribution.
+    //    * Neither the name of Google Inc. nor the names of its
+    // contributors may be used to endorse or promote products derived from
+    // this software without specific prior written permission.
+    //
+    // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    // A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    // OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    // LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    // DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- jinja2, located at tools/inspector_protocol/jinja2, is licensed as follows:
+  """
+    Copyright (c) 2009 by the Jinja Team, see AUTHORS for more details.
+
+    Some rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+
+        * Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials provided
+          with the distribution.
+
+        * The names of the contributors may not be used to endorse or
+          promote products derived from this software without specific
+          prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- markupsafe, located at tools/inspector_protocol/markupsafe, is licensed as follows:
+  """
+    Copyright (c) 2010 by Armin Ronacher and contributors.  See AUTHORS
+    for more details.
+
+    Some rights reserved.
+
+    Redistribution and use in source and binary forms of the software as well
+    as documentation, with or without modification, are permitted provided
+    that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * The names of the contributors may not be used to endorse or
+      promote products derived from this software without specific
+      prior written permission.
+
+    THIS SOFTWARE AND DOCUMENTATION IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+    CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+    NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+    OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+    PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+    LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE AND DOCUMENTATION, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+    DAMAGE.
+  """
+
+- cpplint.py, located at tools/cpplint.py, is licensed as follows:
+  """
+    Copyright (c) 2009 Google Inc. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- ESLint, located at tools/node_modules/eslint, is licensed as follows:
+  """
+    Copyright JS Foundation and other contributors, https://js.foundation
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+  """
+
+- Babel, located at tools/node_modules/@babel, is licensed as follows:
+  """
+    MIT License
+
+    Copyright (c) 2014-present Sebastian McKenzie and other contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- gtest, located at test/cctest/gtest, is licensed as follows:
+  """
+    Copyright 2008, Google Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+        * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- nghttp2, located at deps/nghttp2, is licensed as follows:
+  """
+    The MIT License
+
+    Copyright (c) 2012, 2014, 2015, 2016 Tatsuhiro Tsujikawa
+    Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- node-inspect, located at deps/node-inspect, is licensed as follows:
+  """
+    Copyright Node.js contributors. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+  """
+
+- large_pages, located at src/large_pages, is licensed as follows:
+  """
+     Copyright (C) 2018 Intel Corporation
+
+     Permission is hereby granted, free of charge, to any person obtaining a copy
+     of this software and associated documentation files (the "Software"),
+     to deal in the Software without restriction, including without limitation
+     the rights to use, copy, modify, merge, publish, distribute, sublicense,
+     and/or sell copies of the Software, and to permit persons to whom
+     the Software is furnished to do so, subject to the following conditions:
+
+     The above copyright notice and this permission notice shall be included
+     in all copies or substantial portions of the Software.
+
+     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+     OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+     THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+     OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+     ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+     OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- caja, located at lib/internal/freeze_intrinsics.js, is licensed as follows:
+  """
+     Adapted from SES/Caja - Copyright (C) 2011 Google Inc.
+     Copyright (C) 2018 Agoric
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+  """
+
+- brotli, located at deps/brotli, is licensed as follows:
+  """
+    Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+  """
+
+- HdrHistogram, located at deps/histogram, is licensed as follows:
+  """
+    The code in this repository code was Written by Gil Tene, Michael Barker,
+    and Matt Warren, and released to the public domain, as explained at
+    http://creativecommons.org/publicdomain/zero/1.0/
+
+    For users of this code who wish to consume it under the "BSD" license
+    rather than under the public domain or CC0 contribution text mentioned
+    above, the code found under this directory is *also* provided under the
+    following license (commonly referred to as the BSD 2-Clause License). This
+    license does not detract from the above stated release of the code into
+    the public domain, and simply represents an additional license granted by
+    the Author.
+
+    -----------------------------------------------------------------------------
+    ** Beginning of "BSD 2-Clause License" text. **
+
+     Copyright (c) 2012, 2013, 2014 Gil Tene
+     Copyright (c) 2014 Michael Barker
+     Copyright (c) 2014 Matt Warren
+     All rights reserved.
+
+     Redistribution and use in source and binary forms, with or without
+     modification, are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright notice,
+        this list of conditions and the following disclaimer in the documentation
+        and/or other materials provided with the distribution.
+
+     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+     AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+     IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+     ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+     LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+     CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+     SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+     INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+     CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+     THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- highlight.js, located at doc/api_assets/highlight.pack.js, is licensed as follows:
+  """
+    BSD 3-Clause License
+
+    Copyright (c) 2006, Ivan Sagalaev.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- node-heapdump, located at src/heap_utils.cc, is licensed as follows:
+  """
+    ISC License
+
+    Copyright (c) 2012, Ben Noordhuis <info@bnoordhuis.nl>
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+    === src/compat.h src/compat-inl.h ===
+
+    ISC License
+
+    Copyright (c) 2014, StrongLoop Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  """
+
+- rimraf, located at lib/internal/fs/rimraf.js, is licensed as follows:
+  """
+    The ISC License
+
+    Copyright (c) Isaac Z. Schlueter and Contributors
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+    IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  """
+
+- uvwasi, located at deps/uvwasi, is licensed as follows:
+  """
+    MIT License
+
+    Copyright (c) 2019 Colin Ihrig and Contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  """
+
+- ngtcp2, located at deps/ngtcp2/ngtcp2/, is licensed as follows:
+  """
+    The MIT License
+
+    Copyright (c) 2016 ngtcp2 contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- nghttp3, located at deps/ngtcp2/nghttp3/, is licensed as follows:
+  """
+    The MIT License
+
+    Copyright (c) 2019 nghttp3 contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+
+---------------------------------------------------------
+
+Component: Google V8 (the JavaScript engine bundled into v8jsi.dll).
+This license applies to all parts of V8 that are not externally
+maintained libraries.  The externally maintained libraries used by V8
+are:
+
+  - PCRE test suite, located in
+    test/mjsunit/third_party/regexp-pcre/regexp-pcre.js.  This is based on the
+    test suite from PCRE-7.3, which is copyrighted by the University
+    of Cambridge and Google, Inc.  The copyright notice and license
+    are embedded in regexp-pcre.js.
+
+  - Layout tests, located in test/mjsunit/third_party/object-keys.  These are
+    based on layout tests from webkit.org which are copyrighted by
+    Apple Computer, Inc. and released under a 3-clause BSD license.
+
+  - Strongtalk assembler, the basis of the files assembler-arm-inl.h,
+    assembler-arm.cc, assembler-arm.h, assembler-ia32-inl.h,
+    assembler-ia32.cc, assembler-ia32.h, assembler-x64-inl.h,
+    assembler-x64.cc, assembler-x64.h, assembler-mips-inl.h,
+    assembler-mips.cc, assembler-mips.h, assembler.cc and assembler.h.
+    This code is copyrighted by Sun Microsystems Inc. and released
+    under a 3-clause BSD license.
+
+  - Valgrind client API header, located at src/third_party/valgrind/valgrind.h
+    This is released under the BSD license.
+
+  - The Wasm C/C++ API headers, located at third_party/wasm-api/wasm.{h,hh}
+    This is released under the Apache license. The API's upstream prototype
+    implementation also formed the basis of V8's implementation in
+    src/wasm/c-api.cc.
+
+These libraries have their own licenses; we recommend you read them,
+as their terms may differ from the terms below.
+
+Further license information can be found in LICENSE files located in 
+sub-directories.
+
+Copyright 2014, the V8 project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/scripts/nuget/README.md
+++ b/scripts/nuget/README.md
@@ -1,0 +1,7 @@
+# Description
+
+`Microsoft.JavaScript.V8` is a JavaScript Interface (JSI) implementation backed by Google V8.
+
+It ships an ABI-safe C runtime surface (`jsi_runtime_vtable`) plus consumer-side C++ adapters (`JsiAbiRuntime`, `makeV8Runtime`) so a host application can embed V8 with a stable, CRT-independent boundary.
+
+See <https://github.com/microsoft/v8-jsi>.

--- a/test-harness/consumer.vcxproj
+++ b/test-harness/consumer.vcxproj
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  B1/B2 real-consumer smoke build project.
+
+  Consumes the freshly-packed Microsoft.JavaScript.V8.<rid> NuGet the same
+  way a downstream consumer does. Under Stage D the v8-jsi NuGet is multi-
+  package (1 meta + 3 per-RID); for an x64 consumer the smoke restores
+  Microsoft.JavaScript.V8.win-x64.<version>.nupkg directly. The package's
+  Microsoft.JavaScript.V8.win-x64.targets file injects the v8jsi.dll.lib
+  link reference plus the consumer-side V8JsiRuntime.cpp / JsiAbiRuntime.cpp
+  / jsi.cpp <ClCompile> items.
+
+  The driver script (run-smoke.ps1) restores the package against a local
+  feed pointing at out/pkg, then msbuilds this project and runs the EXE,
+  passing V8JsiPackageTargets and V8JsiRuntimeIdentifier so the smoke
+  bypasses the auto-import + .props RID-detection path that a real
+  PackageReference consumer would use.
+
+  B1 wired Release|x64 only. B2 added Debug|x64 to exercise the Hybrid CRT
+  cross-CRT boundary: the consumer EXE links /MDd (Debug-CRT) while the
+  package's v8jsi.dll is the Release Hybrid-CRT build. Under Stage D the
+  Release-only single-config layout means there is no Debug subdir to fall
+  back from — Debug consumers simply link the Release v8jsi.dll.
+-->
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{8B0C4B27-9B61-4F8C-8E76-7B5C19B6F1CE}</ProjectGuid>
+    <RootNamespace>V8JsiSmokeHarness</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+
+  <ImportGroup Label="ExtensionSettings" />
+
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+
+  <PropertyGroup>
+    <OutDir>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(MSBuildThisFileDirectory)obj\$(Configuration)\$(Platform)\</IntDir>
+    <TargetName>v8jsi_smoke</TargetName>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_CONSOLE;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <ExceptionHandling>Sync</ExceptionHandling>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>Disabled</Optimization>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+
+  <!--
+    The driver (run-smoke.ps1) passes /p:V8JsiPackageProps and
+    /p:V8JsiPackageTargets after NuGet restore so these imports resolve to
+    the .props/.targets shipped by the freshly-packed .nupkg.
+
+    The .props sets V8Jsi* property defaults (V8JsiIncludePublicHeaders=True
+    etc.) and does RID detection (bypassed here by an explicit
+    /p:V8JsiRuntimeIdentifier=win-x64 from the smoke driver). The .targets
+    is the body that wires include dirs, link references, and the consumer
+    source TUs — all gated on V8JsiRuntimeIdentifier matching this
+    package's RID.
+
+    A real PackageReference consumer has NuGet auto-import both files
+    based on filename = package id. The smoke uses packages.config +
+    manual imports because it's a tighter loop. MSBuild won't accept @()
+    item-list refs in an Import Condition, so a property-pointer is the
+    clean form.
+  -->
+  <Import Project="$(V8JsiPackageProps)" Condition="'$(V8JsiPackageProps)' != '' and Exists('$(V8JsiPackageProps)')" />
+  <Import Project="$(V8JsiPackageTargets)" Condition="'$(V8JsiPackageTargets)' != '' and Exists('$(V8JsiPackageTargets)')" />
+
+  <Target Name="EnsurePackageRestored" BeforeTargets="PrepareForBuild">
+    <Error Condition="'$(V8JsiPackageTargets)' == '' or !Exists('$(V8JsiPackageTargets)')"
+           Text="V8JsiPackageTargets is not set or does not exist (value: '$(V8JsiPackageTargets)'). Run run-smoke.ps1 which performs nuget restore against the local pkg feed and passes /p:V8JsiPackageTargets to msbuild." />
+    <Error Condition="'$(V8JsiPackageProps)' == '' or !Exists('$(V8JsiPackageProps)')"
+           Text="V8JsiPackageProps is not set or does not exist (value: '$(V8JsiPackageProps)'). Run run-smoke.ps1 which performs nuget restore against the local pkg feed and passes /p:V8JsiPackageProps to msbuild." />
+  </Target>
+</Project>

--- a/test-harness/main.cpp
+++ b/test-harness/main.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// B1/B2 real-consumer smoke build. Validates the W9 .targets-driven consumer
+// path end-to-end: this TU and the consumer-side V8JsiRuntime.cpp /
+// JsiAbiRuntime.cpp / jsi.cpp (pulled in by Microsoft.JavaScript.V8.<rid>.targets)
+// all compile against the shipped header layout, link against
+// v8jsi.dll.lib, and run against v8jsi.dll at load time.
+//
+// B2 extends the smoke to exercise the Hybrid CRT cross-CRT boundary: when
+// built /MDd (Debug-CRT) and linked against a Release Hybrid-CRT v8jsi.dll,
+// every allocation/free shown below stays on the consumer-CRT side. The DLL
+// sees only the C ABI vtable; STL types (std::string, jsi::JSError, etc.)
+// never cross the boundary.
+//
+// Exit code:
+//   0 = all checks passed.
+//   1 = any failure (runtime construction, evaluation, type or value
+//       mismatch, exception not propagated, etc.).
+
+#include <V8JsiRuntime.h>
+#include <jsi/jsi.h>
+
+#include <cstdio>
+#include <exception>
+#include <memory>
+#include <string>
+
+namespace jsi = facebook::jsi;
+
+#define FAIL(msg)                                       \
+  do {                                                  \
+    std::fprintf(stderr, "test-harness: %s\n", (msg));  \
+    return 1;                                           \
+  } while (0)
+
+int main() {
+  try {
+    v8runtime::V8RuntimeArgs args;
+    auto runtime = v8runtime::makeV8Runtime(std::move(args));
+    if (!runtime) FAIL("makeV8Runtime returned null");
+
+    // 1) Baseline number evaluation (B1).
+    {
+      auto src = std::make_shared<jsi::StringBuffer>("1 + 2");
+      auto r = runtime->evaluateJavaScript(src, "smoke-num.js");
+      if (!r.isNumber() || r.getNumber() != 3.0) FAIL("1 + 2 != 3");
+    }
+
+    // 2) utf8 round-trip. JSI String allocated DLL-side via the C ABI is
+    //    surfaced to the consumer through Runtime::utf8 (defined in jsi.cpp,
+    //    consumer-compiled). The returned std::string lives entirely in the
+    //    consumer's CRT heap; the DLL never sees the std::string object.
+    {
+      auto src = std::make_shared<jsi::StringBuffer>("'hello, ' + 'world'");
+      auto r = runtime->evaluateJavaScript(src, "smoke-str.js");
+      if (!r.isString()) FAIL("expected string result");
+      std::string utf8 = r.asString(*runtime).utf8(*runtime);
+      if (utf8 != "hello, world") FAIL("utf8 round-trip mismatch");
+    }
+
+    // 3) Global property set/get. createPropNameIDFromAscii inside jsi.cpp
+    //    allocates a PropNameID handle through the C ABI; setProperty /
+    //    getProperty round-trip a number value.
+    {
+      runtime->global().setProperty(*runtime, "x", 42);
+      auto v = runtime->global().getProperty(*runtime, "x");
+      if (!v.isNumber() || v.getNumber() != 42.0) FAIL("global.x != 42");
+    }
+
+    // 4) HostFunction create + call. The std::function lambda captures
+    //    consumer-side state (the call counter); v8jsi.dll invokes it
+    //    through the C ABI host-function callback.
+    {
+      int calls = 0;
+      auto fn = jsi::Function::createFromHostFunction(
+          *runtime,
+          jsi::PropNameID::forAscii(*runtime, "add"),
+          2,
+          [&calls](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *a,
+                   size_t n) -> jsi::Value {
+            ++calls;
+            if (n != 2 || !a[0].isNumber() || !a[1].isNumber())
+              throw jsi::JSError(rt, "bad args");
+            return jsi::Value(a[0].getNumber() + a[1].getNumber());
+          });
+      auto r = fn.call(*runtime, jsi::Value(7.0), jsi::Value(35.0));
+      if (!r.isNumber() || r.getNumber() != 42.0) FAIL("host fn result != 42");
+      if (calls != 1) FAIL("host fn call counter != 1");
+    }
+
+    // 5) JS exception caught consumer-side. JSError is constructed inside
+    //    jsi.cpp (consumer-compiled) when the C ABI signals a pending
+    //    exception via jsi_status; thrown and caught entirely in the
+    //    consumer's CRT. v8jsi.dll never participates in the exception
+    //    unwinding.
+    {
+      auto src = std::make_shared<jsi::StringBuffer>("throw new Error('boom')");
+      bool caught = false;
+      try {
+        runtime->evaluateJavaScript(src, "smoke-throw.js");
+      } catch (const jsi::JSError &) {
+        caught = true;
+      }
+      if (!caught) FAIL("JSError was not propagated to consumer");
+    }
+
+    std::printf("test-harness: B2 cross-CRT smoke OK\n");
+    return 0;
+  } catch (const std::exception &ex) {
+    std::fprintf(stderr, "test-harness: unexpected exception: %s\n", ex.what());
+    return 1;
+  } catch (...) {
+    std::fprintf(stderr, "test-harness: unknown exception\n");
+    return 1;
+  }
+}

--- a/test-harness/packages.config
+++ b/test-harness/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.JavaScript.V8.win-x64" version="24.0.0" targetFramework="native" />
+</packages>

--- a/test-harness/run-smoke.ps1
+++ b/test-harness/run-smoke.ps1
@@ -1,0 +1,165 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#
+# B1 real-consumer smoke build driver.
+#
+# Stage D: the v8-jsi NuGet is now multi-package (meta + per-RID, per the
+# Microsoft.JavaScript.LibNode pattern). For an x64 consumer the smoke
+# restores the matching Microsoft.JavaScript.V8.win-x64.<version>.nupkg from
+# out/pkg directly — there is no meta dependency to resolve.
+#
+# Picks the most recent Microsoft.JavaScript.V8.<rid>.<version>.nupkg from
+# out/pkg, restores it into test-harness/packages/ against a local feed,
+# msbuilds test-harness/consumer.vcxproj as the requested Configuration|x64,
+# and runs the resulting v8jsi_smoke.exe -- which evals `1 + 2` through the
+# JSI ABI runtime and asserts the result is 3, plus four cross-CRT
+# exercises (utf8 round-trip, global property set/get, HostFunction call,
+# JSError catch).
+#
+# Exit codes:
+#   0 = smoke build green
+#   non-0 = any failure (no .nupkg, restore/build/run failure, EXE assert)
+#
+# Run after a successful `node scripts/build.ts --no-build --pack` so
+# out/pkg contains a freshly-packed .nupkg.
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot,
+    [string]$Configuration = 'Release',
+    [string]$Platform = 'x64',
+    [string]$PkgDir
+)
+
+$ErrorActionPreference = 'Stop'
+$harnessDir = $PSScriptRoot
+if (-not $harnessDir) { $harnessDir = Split-Path -Parent $MyInvocation.MyCommand.Definition }
+if (-not $RepoRoot) { $RepoRoot = (Resolve-Path (Join-Path $harnessDir '..')).Path }
+# scripts/build.ts writes the packed .nupkg to scripts/out/pkg (the build.ts
+# script roots itself at scripts/, so "out/pkg" is relative to that, not the
+# repo). Probe both locations so a future relocation doesn't silently break
+# the harness. The optional -PkgDir overrides auto-detection for CI, which
+# stages packages outside the repo tree (e.g., $(Build.StagingDirectory)\out\pkg).
+if ($PkgDir) {
+    if (-not (Test-Path $PkgDir)) {
+        throw "Provided -PkgDir does not exist: $PkgDir"
+    }
+} else {
+    foreach ($candidate in @(
+        (Join-Path $RepoRoot 'scripts\out\pkg'),
+        (Join-Path $RepoRoot 'out\pkg')
+    )) {
+        if (Test-Path $candidate) { $PkgDir = $candidate; break }
+    }
+}
+$packagesDir = Join-Path $harnessDir 'packages'
+$packagesConfig = Join-Path $harnessDir 'packages.config'
+$vcxproj = Join-Path $harnessDir 'consumer.vcxproj'
+
+if (-not $pkgDir) {
+    throw "Package staging dir not found under scripts/out/pkg or out/pkg. Run `node scripts/build.ts --no-build --pack` first."
+}
+
+# Map consumer platform (x86/x64/arm64) to the .NET runtime identifier the
+# Microsoft.JavaScript.V8.<rid>.<version>.nupkg layout uses.
+switch ($Platform.ToLower()) {
+    'x64'   { $rid = 'win-x64' }
+    'x86'   { $rid = 'win-x86' }
+    'arm64' { $rid = 'win-arm64' }
+    default { throw "Unsupported Platform for smoke harness: $Platform" }
+}
+
+# Pick the per-RID .nupkg for this platform. The aggregator pack flow also
+# produces a meta Microsoft.JavaScript.V8.<version>.nupkg (without a RID
+# suffix); the per-RID name is `Microsoft.JavaScript.V8.<rid>.<version>.nupkg`.
+# We want the per-RID one — it carries the v8jsi.dll, .lib, headers, and
+# templated .props/.targets. The meta only carries dependencies.
+$nupkg = Get-ChildItem -Path $pkgDir -Filter "*$rid*.nupkg" -File |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+if (-not $nupkg) {
+    throw "No per-RID .nupkg (*$rid*.nupkg) found in $pkgDir. Run `node scripts/build.ts --no-build --pack` first."
+}
+
+# Extract version from the .nupkg filename: <id>.<version>.nupkg, where the
+# version starts with a digit. Splitting on a digit-prefixed dot is safer
+# than just splitting on '.' because the id itself contains dots.
+$pkgBaseName = [System.IO.Path]::GetFileNameWithoutExtension($nupkg.Name)
+if ($pkgBaseName -notmatch '^(?<id>.+?)\.(?<ver>\d.*)$') {
+    throw "Cannot parse package id/version from filename: $($nupkg.Name)"
+}
+$pkgId = $Matches.id
+$pkgVersion = $Matches.ver
+Write-Host "test-harness: package = $pkgId, version = $pkgVersion ($($nupkg.FullName))"
+
+# Refresh packages.config to pin the version we're testing.
+$packagesXml = @"
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="$pkgId" version="$pkgVersion" targetFramework="native" />
+</packages>
+"@
+Set-Content -Path $packagesConfig -Value $packagesXml -Encoding UTF8
+
+# Clean prior restore so we always test against the latest pack.
+if (Test-Path $packagesDir) {
+    Remove-Item -Recurse -Force $packagesDir
+}
+
+# Locate nuget.exe (PATH or the one Node.js fork-syncs as part of the build).
+$nuget = (Get-Command nuget.exe -ErrorAction SilentlyContinue).Source
+if (-not $nuget) {
+    throw "nuget.exe not found on PATH. Install NuGet CLI or add it to PATH."
+}
+
+# Restore against the local feed pointing at out/pkg.
+& $nuget install $pkgId -Version $pkgVersion -Source $pkgDir -OutputDirectory $packagesDir
+if ($LASTEXITCODE -ne 0) {
+    throw "nuget install failed (exit $LASTEXITCODE)"
+}
+
+# Locate msbuild via vswhere.
+$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+if (-not (Test-Path $vswhere)) {
+    throw "vswhere.exe not found at $vswhere"
+}
+$msbuild = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -find 'MSBuild\**\Bin\MSBuild.exe' | Select-Object -First 1
+if (-not $msbuild) {
+    throw "MSBuild.exe not located via vswhere"
+}
+Write-Host "test-harness: msbuild = $msbuild"
+
+# Resolve the freshly-restored package's .props/.targets files and pass them
+# through to MSBuild as properties. nuget install drops the package at
+# $packagesDir\<pkgId>.<version>\. Under Stage D the .props/.targets
+# filenames match the package id (Microsoft.JavaScript.V8.<rid>.{props,targets})
+# for NuGet's auto-import contract.
+$packageDir = Join-Path $packagesDir "$pkgId.$pkgVersion"
+$pkgProps = Join-Path $packageDir "build\native\$pkgId.props"
+$pkgTargets = Join-Path $packageDir "build\native\$pkgId.targets"
+if (-not (Test-Path $pkgProps)) {
+    throw "Expected package .props not found: $pkgProps"
+}
+if (-not (Test-Path $pkgTargets)) {
+    throw "Expected package .targets not found: $pkgTargets"
+}
+
+# Build. Pass V8JsiRuntimeIdentifier explicitly to bypass the .props RID
+# auto-detection (which a real PackageReference consumer would let run on
+# its own).
+& $msbuild $vcxproj "/p:Configuration=$Configuration" "/p:Platform=$Platform" "/p:V8JsiPackageProps=$pkgProps" "/p:V8JsiPackageTargets=$pkgTargets" "/p:V8JsiRuntimeIdentifier=$rid" /restore:false /nologo /v:minimal
+if ($LASTEXITCODE -ne 0) {
+    throw "msbuild failed (exit $LASTEXITCODE)"
+}
+
+# Run.
+$exe = Join-Path $harnessDir "bin\$Configuration\$Platform\v8jsi_smoke.exe"
+if (-not (Test-Path $exe)) {
+    throw "Expected EXE not produced: $exe"
+}
+Write-Host "test-harness: running $exe"
+& $exe
+if ($LASTEXITCODE -ne 0) {
+    throw "v8jsi_smoke.exe failed (exit $LASTEXITCODE)"
+}
+Write-Host "test-harness: OK"


### PR DESCRIPTION
## Summary

This PR packages, smoke-tests, and publishes a new NuGet —
**`Microsoft.JavaScript.V8`** — built from the Node.js-source `v8jsi.dll` that
[#241](https://github.com/microsoft/v8-jsi/pull/241) added. It is **purely
additive**: the existing `ReactNative.V8Jsi.Windows` package keeps building and
publishing unchanged, so both packages ship side by side and consumers can
migrate their `PackageReference` at their own pace. No old code, scripts, NuGet
templates, or CI legs are removed.

## What's in the package

`Microsoft.JavaScript.V8` is a multi-package set:

- **Three per-RID packages** (`…win-x64`, `…win-x86`, `…win-arm64`) — each
  carries the native `v8jsi.dll`, its import lib, the public headers (JSI,
  JSI-ABI, Node-API), the consumer-compiled C++ adapter sources (`jsi.cpp`,
  `V8JsiRuntime.cpp`, `JsiAbiRuntime.cpp`), the `v8jsi.dll.pdb`, and the
  `.props`/`.targets` that wire them up.
- **One meta package** (`Microsoft.JavaScript.V8`) that depends on the three
  per-RID packages, so a consumer references a single id and NuGet resolves the
  right RID.

The package uses a Node.js-aligned `24.x.y` version (from `config.json`'s
`v8jsi_version`), distinct from the legacy package's scheme. First release:
`24.0.0`.

## Built, packed, and smoked through `scripts/build.ts`

Every build/test/pack/smoke step is a `scripts/build.ts` invocation, so the
whole flow reproduces locally — only signing and publishing are pipeline-only:

```powershell
cd scripts
node build.ts --platform x64 --configuration release       # build (provisions NASM)
node build.ts --no-build --test                            # v8jsi_test + node_api_tests
node build.ts --no-build --no-test --pack --platform x64   # per-RID .nupkg
node build.ts --no-build --no-test --smoke                 # real-consumer smoke
```

- **Pack.** `--pack` stages each RID's binaries, headers, and consumer sources
  and produces the per-RID `.nupkg`; the meta package builds once all three RIDs
  are staged.
- **Smoke.** `test-harness/` is a real consumer project that restores the
  freshly-packed `.nupkg` the way a downstream project would, compiles the
  shipped sources, links `v8jsi.dll.lib`, and runs a program that evaluates
  JavaScript and exercises the cross-CRT boundary (utf-8 round-trip, global
  get/set, host-function call, `JSError` propagation). It runs in two
  configurations — Release consumer / Release DLL, and **Debug-CRT consumer /
  Release DLL**. The latter validates the Hybrid CRT contract: the App-CRT stays
  statically private to the DLL, only the UCRT is shared, and no STL crosses the
  C ABI boundary. The harness is x64; the x86 and arm64 packages are validated
  at the DLL level.

`build.ts` also gains `--check-crt` (lists the DLL's C/C++ runtime imports and
checks the Hybrid CRT contract) and `--count-exports` (export-surface counts by
API family).

## CI and publishing

- The new-build CI path is extended so each Release cell packs its per-RID
  package (and the x64 cell runs the smoke), and a new aggregator job assembles
  the per-RID + meta packages and stages their PDBs for the symbol server.
- The release pipeline gains an additive leg that publishes
  `Microsoft.JavaScript.V8.*` to the same feeds as the legacy package and its
  PDBs to the symbol server. The legacy `ReactNative.V8Jsi.Windows` publish leg
  is unchanged — **both packages publish**.

## Files

- **Added:** `scripts/nuget/` (the NuGet templates + license/notice) and
  `test-harness/` (the smoke consumer).
- **Modified:** `scripts/build.ts` (packing, testing, smoke, and report modes)
  and the three `.ado/*.yml` (additive new-build pack/smoke jobs, the new
  aggregator, and the new publish jobs — all alongside the unchanged legacy
  jobs).

## Context

Predecessor: [#241](https://github.com/microsoft/v8-jsi/pull/241) — "Build
v8jsi from Node.js 24.x source code". Prior art:
[#239](https://github.com/microsoft/v8-jsi/pull/239) — vendored Node.js + asio.
A later PR removes the old GN build, scripts, NuGet, and CI legs once consumers
have migrated.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/242)