### PR TITLE
Use ARM64 pool for ARM64 targets

### DIFF
--- a/.ado/ensure-node10-shim.yml
+++ b/.ado/ensure-node10-shim.yml
@@ -1,0 +1,41 @@
+# TEMPORARY workaround for the 1ES "Retain Build Artifacts"
+# (BuildArtifactRetentionPolicyTask@1) post-job, which targets the Node 10 task
+# handler. Recent agents (>= 5.276) no longer ship `externals\node10`, and the
+# ARM64 agent has none at all, so the mandatory retention post-job fails with:
+#   "This step requires a node version that does not exist in the agent
+#    filesystem. Path: ...\externals\node10\bin\node.exe"
+#
+# This shims node10 to the image's installed Node.js (our image installs Node 24
+# at C:\Program Files\nodejs), falling back to the agent's own bundled node if
+# that is ever absent. Azure Pipelines task handlers are forward-compatible in
+# practice (node6->10->16->20), and the retention task is simple. If a future
+# task genuinely needs a real node10, we would instead bake node10 into the image.
+#
+# Reference it from a job's steps BEFORE its work so node10 exists by the time
+# the post-job runs on the same agent.
+steps:
+- powershell: |
+    $ErrorActionPreference = 'Stop'
+    $ext = Join-Path $env:AGENT_HOMEDIRECTORY 'externals'
+    $node10Exe = Join-Path $ext 'node10\bin\node.exe'
+    if (Test-Path $node10Exe) {
+        Write-Host "node10 already present: $node10Exe"
+    } else {
+        # Prefer the image's Node.js (our image installs Node 24); fall back to
+        # the agent's own bundled node.
+        $srcExe = @(
+            (Join-Path $env:ProgramFiles 'nodejs\node.exe'),
+            (Join-Path $ext 'node\bin\node.exe')
+        ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+        if (-not $srcExe) { throw "No Node.js found to shim node10 (checked Program Files\nodejs and agent externals\node)." }
+        Write-Host "Shimming node10 -> $srcExe"
+        New-Item -ItemType Directory -Force -Path (Split-Path $node10Exe) | Out-Null
+        try {
+            New-Item -ItemType SymbolicLink -Path $node10Exe -Target $srcExe -ErrorAction Stop | Out-Null
+        } catch {
+            Write-Warning "Symlink failed ($($_.Exception.Message)); copying instead."
+            Copy-Item $srcExe $node10Exe -Force
+        }
+        & $node10Exe --version
+    }
+  displayName: Shim node10 handler (agent lacks externals\node10)

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -37,11 +37,11 @@ parameters:
         AppPlatform: win32
     # Matrix with target platforms for the sandbox binaries. A separate list
     # from BuildMatrix because the sandbox cells carry extra per-arch knobs: the
-    # gn out dir (sbox.dll/v8host.exe land in out/sandbox-<cpu>) and whether
-    # the lockdown tier can run on the x64 build agent.
-    # RunTier is false for arm64 -- the binaries cross-compile on the x64 agent
-    # but AA64 cannot execute there, so the tier runs out-of-band on a native
-    # ARM64 agent (tracked as future work; the same model v8jsi uses).
+    # gn out dir (sbox.dll/v8host.exe land in out/sandbox-<cpu>) and whether the
+    # lockdown tier runs in this job (RunTier).
+    # RunTier is true for every arch: x64/x86 run on the x64 agent (x86 via
+    # WOW64) and arm64 runs natively on the ARM64 managed-image pool, so each
+    # cell executes its own Untrusted lockdown tier.
   - name: SandboxMatrix
     type: object
     default:
@@ -59,7 +59,7 @@ parameters:
         BuildPlatform: arm64
         Rid: win-arm64
         SboxOutDir: deps/chromium/out/sandbox-arm64
-        RunTier: false
+        RunTier: true
 
 resources:
   repositories:
@@ -202,6 +202,15 @@ extends:
 
           timeoutInMinutes: 1200
 
+          # ARM64 cells build natively on the ARM64 managed-image pool so their
+          # tests actually execute -- on an x64 agent build.ts can only cross-
+          # compile arm64 and skips the tests. windows-2025-1espt-arm64 is a
+          # single-image pool, so it takes no ImageOverride demand. x64/x86 cells
+          # inherit the top-level fabric-internal-pool-large pool, unchanged.
+          ${{ if eq(matrix.BuildPlatform, 'arm64') }}:
+            pool:
+              name: windows-2025-1espt-arm64
+
           variables:
           - name: Packaging.EnableSBOMSigning
             value: ${{ startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft') }}
@@ -218,8 +227,23 @@ extends:
               - output: pipelineArtifact
                 artifactName: ${{ matrix.Name }}-new
                 targetPath: $(Build.StagingDirectory)\out-new\pkg-staging
+                # The 1ES SBoM ManifestGenerator runs as an x64 process and can't
+                # load the arm64 agent's native .NET (hostfxr arch mismatch,
+                # 0x800700C1), and its x64-runtime self-install is blocked by
+                # network isolation. This per-cell artifact is intermediate -- the
+                # shipped NuGet's SBoM is produced by the V8JsiCreateNugetNew
+                # aggregator on x64 -- so skip SBoM here for arm64 only; x64/x86
+                # keep generating it.
+                ${{ if eq(matrix.BuildPlatform, 'arm64') }}:
+                  sbomEnabled: false
 
           steps:
+            # ARM64 agents ship no externals\node10, but the mandatory 1ES build-
+            # retention post-job still runs on the Node 10 handler; shim node10 to
+            # the image's Node so that post-job doesn't fail. Right after checkout.
+          - ${{ if eq(matrix.BuildPlatform, 'arm64') }}:
+            - template: /.ado/ensure-node10-shim.yml@self
+
           - task: UsePythonVersion@0
             displayName: Use Python 3.x
             inputs:
@@ -264,16 +288,15 @@ extends:
         #                         carry the V8 cage; x86 is the degraded no-cage
         #                         variant (the cage is 64-bit-only).
         #   * sbox.dll/v8host.exe -- the Chromium sandbox (gn + VS clang/ninja, via
-        #                         scripts/sbox-build.ts --target-cpu). The gn build
-        #                         cross-compiles all three arches on an x64 host.
-        #                         test_app.exe is the TEST harness and is NOT
-        #                         shipped/signed.
+        #                         scripts/sbox-build.ts --target-cpu). x64/x86
+        #                         build on the x64 agent; arm64 builds natively on
+        #                         the ARM64 pool. test_app.exe is the TEST harness
+        #                         and is NOT shipped/signed.
         # Hygiene gates (export allowlist + Hybrid CRT + BinSkim) run via --check.
-        # The Untrusted lockdown tier runs as a CI test for x64 + x86 (x86 via
-        # WOW64 on the x64 agent); arm64's AA64 binaries cannot execute on the x64
-        # agent, so its tier is deferred to a native ARM64 agent (RunTier: false)
-        # -- the same model v8jsi uses for arm64. The three shipped binaries are
-        # signed on the publishing build.
+        # The Untrusted lockdown tier runs as a CI test for every arch: x64 + x86
+        # on the x64 agent (x86 via WOW64) and arm64 natively on the ARM64 pool
+        # (RunTier: true). The three shipped binaries are signed on the publishing
+        # build.
         # =====================================================================
       - ${{ each sb in parameters.SandboxMatrix }}:
         - job: V8JsiBuildSandbox_${{ sb.Name }}
@@ -281,9 +304,17 @@ extends:
 
           timeoutInMinutes: 180
 
-          pool:
-            name: fabric-internal-pool-large
-            demands: ImageOverride -equals windows-2025-1espt
+          # ARM64 builds natively on the ARM64 managed-image pool so its Untrusted
+          # lockdown tier can execute (AA64 binaries can't run on an x64 agent).
+          # It's a single-image pool, so no ImageOverride demand. x64/x86 keep the
+          # existing image, unchanged.
+          ${{ if eq(sb.BuildPlatform, 'arm64') }}:
+            pool:
+              name: windows-2025-1espt-arm64
+          ${{ else }}:
+            pool:
+              name: fabric-internal-pool-large
+              demands: ImageOverride -equals windows-2025-1espt
 
           variables:
           - name: Packaging.EnableSBOMSigning
@@ -294,6 +325,14 @@ extends:
             - output: pipelineArtifact
               artifactName: sandbox-binaries-${{ sb.Rid }}
               targetPath: $(Build.StagingDirectory)\sandbox
+              # Same arm64 SBoM skip as the V8JsiBuildNew cell: the x64-only 1ES
+              # SBoM toolkit can't load the arm64 agent's native .NET (hostfxr arch
+              # mismatch, 0x800700C1). This per-RID artifact is intermediate -- the
+              # shipped NuGet's SBoM is produced by the V8JsiCreateNugetNew
+              # aggregator on x64 -- so skip SBoM here for arm64 only; x64/x86 keep
+              # generating it.
+              ${{ if eq(sb.BuildPlatform, 'arm64') }}:
+                sbomEnabled: false
 
           steps:
             # The vendored gn (deps/gn/gn.exe) is a Git LFS object; the default
@@ -301,6 +340,12 @@ extends:
             # can't find gn.
           - checkout: self
             lfs: true
+
+            # ARM64 agents ship no externals\node10, but the mandatory 1ES build-
+            # retention post-job still runs on the Node 10 handler; shim node10 to
+            # the image's Node so that post-job doesn't fail.
+          - ${{ if eq(sb.BuildPlatform, 'arm64') }}:
+            - template: /.ado/ensure-node10-shim.yml@self
 
           - task: UsePythonVersion@0
             displayName: Use Python 3.x
@@ -355,9 +400,9 @@ extends:
               # Lockdown tier test (product-default Untrusted = jitless + ACG):
               # stage the engine next to v8host (it LoadLibrary's v8jsisb.dll by
               # name) and run the test_app broker harness. RESULT: PASS +
-              # target exit=0 is the success signal. x64 + x86 only (x86 via WOW64
-              # on the x64 agent); arm64 (RunTier:false) cannot execute its AA64
-              # binaries here -- its tier runs out-of-band on a native ARM64 agent.
+              # target exit=0 is the success signal. Runs for every arch: x64 + x86
+              # on the x64 agent (x86 via WOW64) and arm64 natively on the ARM64
+              # pool.
             - ${{ if eq(sb.RunTier, true) }}:
               - pwsh: |
                   $sandboxOut = "$(Build.SourcesDirectory)\${{ sb.SboxOutDir }}"

--- a/scripts/sbox-build.ts
+++ b/scripts/sbox-build.ts
@@ -214,18 +214,26 @@ function resolveVsToolchain(targetCpu: TargetCpu): VsToolchain {
     );
   }
 
-  // VS ships a SEPARATE LLVM toolchain per host arch (VC\Tools\Llvm\x64 and
-  // \ARM64). clang runs as the host binary, so the base path follows the HOST
-  // arch; target_cpu selects what it emits (the host clang cross-compiles all
-  // targets — see the compiler-rt note below).
-  const hostArchDir = process.arch === "arm64" ? "ARM64" : "x64";
-  const clangBasePath = path.join(vsPath, "VC", "Tools", "Llvm", hostArchDir);
+  // Always use the x64 clang toolchain (VC\Tools\Llvm\x64), even on an arm64
+  // host. The vendored gn.exe is x64, so gn's host_cpu is x64, and Chromium's
+  // build (build/config/BUILDCONFIG.gn) deliberately builds host tools with the
+  // x64 host toolchain for arm64 targets -- "Windows ARM64 targets require an
+  // x64 host for cross build". That win_clang_x64 host toolchain relies on
+  // clang defaulting to the x64 target (it passes x64-only flags such as
+  // -msse3), so the base clang must be the x64 build; the arm64 clang defaults
+  // to aarch64 and rejects those flags. target_cpu still selects what the
+  // TARGET toolchain emits, so arm64 binaries are cross-compiled by this same
+  // x64 clang (exactly as when this ran on x64 agents). On an arm64 agent the
+  // x64 clang runs under emulation, which is fine.
+  const clangBasePath = path.join(vsPath, "VC", "Tools", "Llvm", "x64");
   const clangCl = path.join(clangBasePath, "bin", "clang-cl.exe");
   const clangExe = path.join(clangBasePath, "bin", "clang.exe");
   if (!fs.existsSync(clangCl) || !fs.existsSync(clangExe)) {
     floor(
-      `clang not found under ${clangBasePath}\\bin. Repair the VS Clang ` +
-        "component (C++ Clang Compiler for Windows).",
+      `x64 clang not found under ${clangBasePath}\\bin. Install or repair the ` +
+        'VS "C++ Clang Compiler for Windows" component. On an arm64 host the ' +
+        "x64 Llvm toolchain must also be present -- it is the cross-build host " +
+        "toolchain for arm64 targets (see the clangBasePath note above).",
     );
   }
 


### PR DESCRIPTION
## Summary

Run v8-jsi's **ARM64** build + test jobs natively on the `windows-2025-1espt-arm64`
managed pool, so ARM64 binaries are **built natively and their tests actually execute** —
instead of cross-compiling on x64 agents where ARM64 tests can't run. Only the
**Node.js-source build** and the **sandbox** move to ARM64; the legacy Google-V8 build and
**all x64/x86 jobs are unchanged**.

## Changes

### `.ado/windows-jobs.yml`
- **ARM64 → native pool.** The ARM64 cells of the new build (`V8JsiBuildNew_*`) and the
  sandbox (`V8JsiBuildSandbox_*`) get a per-job `pool: { name: windows-2025-1espt-arm64 }`,
  conditional on `arm64` (it's a single-image pool, so no `ImageOverride` demand). x64/x86
  cells keep inheriting the top-level pool; sandbox x64/x86 keep
  `fabric-internal-pool-large` + `ImageOverride` via the `${{ else }}`.
- **node10 retention shim** referenced first in each ARM64 cell (after checkout).
- **Sandbox arm64 `RunTier: false` → `true`** — the Untrusted lockdown tier now runs
  natively on the ARM64 agent.
- **SBoM disabled on the arm64 intermediate outputs** (`sbomEnabled: false`, arm64-only) —
  **both** the `V8JsiBuildNew` `<Name>-new` artifact and the `V8JsiBuildSandbox`
  `sandbox-binaries-<rid>` artifact: the 1ES SBoM toolkit is x64-only and can't load the
  arm64 agent's .NET; the **shipped NuGet's SBoM is still produced by the x64
  `V8JsiCreateNugetNew` aggregator**, so coverage is intact. (Verified against the 1ES
  template source: only `sbomEnabled: true` on non-production outputs is disallowed;
  `false` is always valid.)
- **Legacy `V8JsiBuild_*` (Google-V8 / depot_tools) untouched** — stays x64 cross-compile.

### `.ado/ensure-node10-shim.yml` (new)
- Steps template that symlinks `externals\node10\bin\node.exe` → the image's Node.js
  (falls back to the agent's bundled node). The mandatory 1ES
  `BuildArtifactRetentionPolicyTask@1` still targets the Node 10 handler, which agents
  ≥ 5.276 (and ARM64) no longer ship — without the shim the retention post-job fails.

### `scripts/sbox-build.ts`
- **Always resolve the x64 clang** (`VC\Tools\Llvm\x64`), even on an arm64 host. The
  vendored `deps/gn/gn.exe` is x64 → gn's `host_cpu=x64`, and Chromium builds host tools
  with the x64 host toolchain for arm64 targets (*"Windows ARM64 targets require an x64
  host for cross build"*). The arm64-default clang rejected the host toolchain's `-msse3`.
  `target_cpu=arm64` still cross-compiles the arm64 target with that same x64 clang (as on
  x64 agents); on the arm64 agent it runs under emulation.

## Validation (on the ARM64 pool)
- `V8JsiBuildNew_arm64`: **build + tests GREEN** — `v8jsi_test.exe` 116/116, `node_api_tests.exe`
  52/52 passed (build 51808225).
- Sandbox arm64: `sbox.dll` compiles green (the `-msse3` fix).
- Retention post-job green (node10 shim).
- x64/x86 jobs unchanged.