### PR TITLE
Fix SBoM on ARM64

### DIFF
--- a/.ado/image/README.md
+++ b/.ado/image/README.md
@@ -1,0 +1,186 @@
+# v8-jsi CI/Release VM images
+
+This folder holds the **1ES managed-image definitions** used by the v8-jsi
+Azure DevOps pipelines. Each JSON is an ordered list of provisioning *artifacts*
+(tools/features) applied to a base Windows Server 2025 image to produce the VM
+image the build agents run on.
+
+| File | Architecture | Built image name |
+|------|--------------|------------------|
+| [`windows-2025-1espt-x64.json`](./windows-2025-1espt-x64.json) | x64 (also runs x86) | `windows-2025-1espt` |
+| [`windows-2025-1espt-arm64.json`](./windows-2025-1espt-arm64.json) | ARM64 (native) | `windows-2025-1espt-arm64` |
+
+Both images share one toolchain — **Visual Studio 2026 Enterprise + Clang, the
+current Windows SDK, Node.js 24, the latest Python, and .NET 10** — so x64, x86,
+and ARM64 all build and test with the same tools. The two JSONs are intentionally
+kept as close to identical as possible; they differ only where the architecture
+forces it (see [Per-architecture differences](#per-architecture-differences)).
+
+## Pool ↔ image mapping (how pipelines select an image)
+
+The build/test jobs run in two different ways depending on target architecture:
+
+- **x64 / x86** → pool **`fabric-internal-pool-large`**, image **`windows-2025-1espt`**,
+  selected with an explicit image demand:
+  ```yaml
+  pool:
+    name: fabric-internal-pool-large
+    demands: ImageOverride -equals windows-2025-1espt
+  ```
+  `fabric-internal-pool-large` hosts multiple images, so the image **must** be
+  named via `ImageOverride`. This is set once on the top-level pool in
+  `.ado/windows-jobs.yml`, and every x64/x86 job inherits it (the x64 sandbox job
+  also states it explicitly in its non-ARM64 branch).
+
+- **ARM64** → pool **`windows-2025-1espt-arm64`**, image **`windows-2025-1espt-arm64`**,
+  with **no** image demand:
+  ```yaml
+  pool:
+    name: windows-2025-1espt-arm64
+  ```
+  `windows-2025-1espt-arm64` is a **single-image pool** — `windows-2025-1espt-arm64`
+  is its one default image — so **no `ImageOverride` demand is used (or needed)**.
+  ARM64 binaries can't execute on an x64 agent, so ARM64 cells build *and run their
+  tests* natively on this pool.
+
+> The `windows-release.yml` pipeline runs its publish/download jobs on the hosted
+> `Azure-Pipelines-1ESPT-ExDShared` pool (it does not build v8-jsi), so it does not
+> use `fabric-internal-pool-large` and needs no `ImageOverride`.
+
+## How the images are built and refreshed
+
+These JSONs are the **source of truth** for the image contents, but they are not
+applied by the CI pipeline itself. They are consumed by the 1ES managed-image
+build, which provisions a fresh VM, runs each artifact in order, and captures the
+result as the named image. Building + replicating a new image takes time (hours),
+so a pipeline run always uses the *currently published* image, not the JSON on the
+branch. **After editing a JSON, the image must be rebuilt** before pipelines see
+the change.
+
+Most artifacts accept parameters; the managed-image build passes each JSON
+`parameters` entry to the artifact **by name**.
+
+## Visual Studio toolset (shared by both images)
+
+Both images install VS 2026 Enterprise via `windows-visualstudio-bootstrapper`
+(`VSBootstrapperURL: https://aka.ms/vs/18/stable/vs_Enterprise.exe` — VS "18" is
+the 2026 product line), with the **same** workload string ending in
+`--includeRecommended --includeOptional`:
+
+| Component(s) | Why |
+|--------------|-----|
+| `Workload.ManagedDesktop`, `Workload.NativeDesktop`, `Workload.Universal` | .NET desktop, C++ desktop, and UWP workloads |
+| `ComponentGroup.NativeDesktop.Core`, `ComponentGroup.UWP.Support`, `ComponentGroup.UWP.VC` | core native + UWP support |
+| `Component.MSBuild`, `VC.CoreBuildTools`, `VC.CoreIde` | MSBuild + core C++ build tooling |
+| `VC.Tools.x86.x64` **and** `VC.Tools.ARM64` | native MSVC for x64 **and** ARM64 |
+| `VC.Llvm.Clang`, `VC.Llvm.ClangToolset` | Clang/LLVM (Clang 22 ships in VS 2026); the Node.js ≥ 24 build uses `clang-cl` |
+| `VC.CMake.Project` | CMake (used by the sandbox `gn`/`ninja` build) |
+| `Windows11SDK.26100` | current Windows SDK |
+| `Windows11SDK.22621` | **kept deliberately** — consumers (e.g. react-native-windows default props) still target `10.0.22621.0` |
+| `Windows11Sdk.WindowsPerformanceToolkit` | WPA/WPR/xperf |
+| `VC.ATL`, `VC.ATLMFC`, `VC.ATL.ARM64`, `VC.MFC.ARM64`, `UWP.VC.ARM64` | ATL/MFC/UWP for x64 and ARM64 |
+| `VC.Runtimes.x86.x64.Spectre`, `VC.Runtimes.ARM64.Spectre`, `VC.ATL.Spectre`, `VC.ATL.ARM64.Spectre` | Spectre-mitigated runtimes required by SDL |
+
+## Artifacts (in provisioning order)
+
+Shared by both images unless marked. Ordering matters — helper/runtime artifacts
+come before the artifacts that depend on them.
+
+| Artifact | Purpose |
+|----------|---------|
+| `windows-EnableDeveloperMode` | Enable Windows Developer Mode |
+| `windows-enable-long-paths` | Enable NTFS long paths (deep `node_modules` / vendored source trees) |
+| `Windows-ServerAddFeature` (`Web-Server`) | IIS Web Server role |
+| `Windows-ServerAddFeature` (`Web-Scripting-Tools`) | IIS scripting tools |
+| `windows-gitinstall` | Git for Windows |
+| `windows-git-lfs` | Git LFS (required — some build inputs, e.g. the vendored `gn.exe`, are LFS objects) |
+| `windows-AzPipeline-ImageHelpers` | Azure Pipelines image-helper PowerShell modules used by later artifacts |
+| `windows-AzPipeline-InitializeVM` | Baseline VM initialization |
+| `windows-AzPipeline-powershellCore` | PowerShell 7 (`pwsh`); arch-aware (native on both) |
+| `windows-1es-install-winget` | **ARM64 only** — provision winget (all-users, sysprep-safe) into the shipped image |
+| `windows-AzPipeline-7zip` | **x64 only** — install 7-zip via Chocolatey |
+| `windows-AzPipeline-Install-7zip` | **ARM64 only** — install 7-zip by direct download (pinned version + SHA256); see [7-zip note](#7-zip-on-arm64) |
+| `windows-visualstudio-bootstrapper` | VS 2026 Enterprise + the workload above |
+| `Windows-NodeJS` | Node.js `24.x` (`UseARM` selects the architecture) |
+| `windows-install-python` | Latest python.org build; see [Python note](#python) |
+| `windows-chrome` | Google Chrome (UI/WinAppDriver tests) |
+| `windows-AzPipeline-WinAppDriver` | WinAppDriver |
+| `windows-dotnetcore-sdk` | .NET SDK; see [.NET note](#net-sdk) |
+| `windows-setenvvar` (`DOTNET_ROOT_X64`) | **ARM64 only** — point x64 .NET hosts at the x64 runtime; see [.NET note](#net-sdk) |
+| `Windows-AzureCLI` | Azure CLI |
+
+## Per-architecture differences
+
+Everything else is identical; only these entries differ between the two JSONs:
+
+| Aspect | x64 image | ARM64 image |
+|--------|-----------|-------------|
+| 7-zip | `windows-AzPipeline-7zip` (Chocolatey) | `windows-AzPipeline-Install-7zip` (direct download, pinned) |
+| winget | not provisioned separately | `windows-1es-install-winget` added |
+| `Windows-NodeJS` | `Version: 24.x`, `UseARM: false` | `Version: 24.x`, `UseARM: true` |
+| `windows-install-python` | `Architecture: x64` | `Architecture: arm64` (native) |
+| `.NET` | one `windows-dotnetcore-sdk` (native) | **two** — native arm64 **plus** an x64 SDK at `C:\Program Files\dotnet\x64` + `DOTNET_ROOT_X64` |
+
+## Key decisions
+
+### Python
+
+`windows-install-python` (`Version: latest`) installs the newest stable python.org
+release to `C:\Python` and adds it to the machine `PATH`. It does **not** populate
+the Azure Pipelines *hosted tool cache*. Consequently the pipelines do **not** use
+the `UsePythonVersion@0` task (which resolves **only** from the tool cache) — the
+build picks up `python` from `PATH`. If you reintroduce `UsePythonVersion@0`, you
+must switch back to a tool-cache-populating Python artifact, or the task will fail
+to find a version.
+
+### .NET SDK
+
+All `windows-dotnetcore-sdk` entries float on the latest **.NET 10.0** servicing
+build via `Channel: 10.0` + `DotNetCoreVersion: latest`, rather than pinning an
+exact build. This picks up servicing/security patches automatically and avoids a
+pinned build being de-listed. Note: the installer has **no `10.x` wildcard** for a
+specific version — the supported "track a band" mechanism is the 2-part `Channel`,
+and a 3-part `DotNetCoreVersion` would override (pin) the channel, so `latest` is
+required for the channel to take effect.
+
+### x64 .NET on the ARM64 image
+
+The ARM64 image installs a **second, x64** .NET SDK side-by-side with the native
+arm64 SDK (`Architecture: x64`, `InstallDir: C:\Program Files\dotnet\x64`) and sets
+the machine variable `DOTNET_ROOT_X64` to that path. Reason: the SBoM (Software
+Bill of Materials) generation tool used by the release build is an **x64** process;
+on a native ARM64 agent it can't load the arm64 `hostfxr.dll`
+(`HRESULT 0x800700C1`, bad-image-format). Providing an x64 runtime it can discover
+(via `DOTNET_ROOT_X64`, which an x64 .NET host probes first on an arm64 OS) lets
+SBoM run on the ARM64 cells.
+
+### 7-zip on ARM64
+
+The ARM64 image can't use the Chocolatey/winget 7-zip paths during provisioning
+(winget isn't on the provisioning `PATH` at that point). It uses
+`windows-AzPipeline-Install-7zip`, which downloads the installer directly from the
+official `ip7z/7zip` GitHub release. That artifact **requires an integrity hash**:
+it verifies the download against either an inline `SpecificVersionExpectedHash` or
+its internal approved-hash list (which ships x64 hashes only). So the ARM64 entry
+pins an explicit `InstallSpecificVersion` + `SpecificVersionExpectedHash` for the
+arm64 installer. This is intentional — "install latest" is not possible here
+without dropping the hash check. To move to a newer 7-zip, update the version and
+its arm64 SHA256 together.
+
+### Both Windows SDKs are kept
+
+`Windows11SDK.26100` (current) and `Windows11SDK.22621` are both installed.
+Consumers of these images still target `10.0.22621.0` in some projects, so 22621
+must remain until those consumers migrate.
+
+## Updating an image
+
+1. Edit the relevant JSON (and keep the two in sync where the change is not
+   architecture-specific).
+2. Trigger a managed-image rebuild for the affected image(s).
+3. Once the new image is published, the pools serve it automatically — pipelines
+   need no change (they select by pool + `ImageOverride`, not by image version).
+
+When changing anything that a build step depends on at runtime (a tool version, a
+new SDK, an environment variable), rebuild the image **before** relying on it in
+the pipeline; a branch edit to the JSON alone does not change the running agents.

--- a/.ado/image/windows-2025-1espt-arm64.json
+++ b/.ado/image/windows-2025-1espt-arm64.json
@@ -1,0 +1,103 @@
+{
+    "artifacts": [
+        {
+            "name": "windows-EnableDeveloperMode"
+        },
+        {
+            "name": "windows-enable-long-paths"
+        },
+        {
+            "name": "Windows-ServerAddFeature",
+            "parameters": {
+                "FeatureName": "Web-Server"
+            }
+        },
+        {
+            "name": "Windows-ServerAddFeature",
+            "parameters": {
+                "FeatureName": "Web-Scripting-Tools"
+            }
+        },
+        {
+            "name": "windows-gitinstall"
+        },
+        {
+            "name": "windows-git-lfs"
+        },
+        {
+            "name": "windows-AzPipeline-ImageHelpers"
+        },
+        {
+            "name": "windows-AzPipeline-InitializeVM"
+        },
+        {
+            "name": "windows-AzPipeline-powershellCore"
+        },
+        {
+            "name": "windows-1es-install-winget"
+        },
+        {
+            "name": "windows-AzPipeline-Install-7zip",
+            "parameters": {
+                "InstallLatest": "0",
+                "InstallSpecificVersion": "26.02",
+                "InstallVersionPatternSuffix": "-arm64",
+                "SpecificVersionExpectedHash": "sha256:7c6fde79ed5e11b81c7bb6573b7962d3b6322aa5fce69c33ed19f672b55173ab"
+            }
+        },
+        {
+            "name": "windows-visualstudio-bootstrapper",
+            "parameters": {
+                "Workloads": "--add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.Universal --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core --add Microsoft.VisualStudio.ComponentGroup.UWP.Support --add Microsoft.VisualStudio.ComponentGroup.UWP.VC --add Microsoft.Component.MSBuild --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.CoreIde --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.Windows11SDK.26100 --add Microsoft.VisualStudio.Component.Windows11Sdk.WindowsPerformanceToolkit --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.MFC.ARM64 --add Microsoft.VisualStudio.Component.UWP.VC.ARM64 --add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre --add Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre --add Microsoft.VisualStudio.Component.VC.ATL.Spectre --add Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre --includeRecommended --includeOptional",
+                "SKU": "Enterprise",
+                "VSBootstrapperURL": "https://aka.ms/vs/18/stable/vs_Enterprise.exe"
+            }
+        },
+        {
+            "name": "Windows-NodeJS",
+            "parameters": {
+                "Version": "24.x",
+                "UseARM": "true"
+            }
+        },
+        {
+            "name": "windows-install-python",
+            "parameters": {
+                "Version": "latest",
+                "Architecture": "arm64"
+            }
+        },
+        {
+            "name": "windows-chrome"
+        },
+        {
+            "name": "windows-AzPipeline-WinAppDriver"
+        },
+        {
+            "name": "windows-dotnetcore-sdk",
+            "parameters": {
+                "DotNetCoreVersion": "latest",
+                "Channel": "10.0"
+            }
+        },
+        {
+            "name": "windows-dotnetcore-sdk",
+            "parameters": {
+                "DotNetCoreVersion": "latest",
+                "Channel": "10.0",
+                "Architecture": "x64",
+                "InstallDir": "C:\\Program Files\\dotnet\\x64"
+            }
+        },
+        {
+            "name": "windows-setenvvar",
+            "parameters": {
+                "Variable": "DOTNET_ROOT_X64",
+                "Value": "C:\\Program Files\\dotnet\\x64"
+            }
+        },
+        {
+            "name": "Windows-AzureCLI"
+        }
+    ]
+}

--- a/.ado/image/windows-2025-1espt-x64.json
+++ b/.ado/image/windows-2025-1espt-x64.json
@@ -1,0 +1,78 @@
+{
+    "artifacts": [
+        {
+            "name": "windows-EnableDeveloperMode"
+        },
+        {
+            "name": "windows-enable-long-paths"
+        },
+        {
+            "name": "Windows-ServerAddFeature",
+            "parameters": {
+                "FeatureName": "Web-Server"
+            }
+        },
+        {
+            "name": "Windows-ServerAddFeature",
+            "parameters": {
+                "FeatureName": "Web-Scripting-Tools"
+            }
+        },
+        {
+            "name": "windows-gitinstall"
+        },
+        {
+            "name": "windows-git-lfs"
+        },
+        {
+            "name": "windows-AzPipeline-ImageHelpers"
+        },
+        {
+            "name": "windows-AzPipeline-InitializeVM"
+        },
+        {
+            "name": "windows-AzPipeline-powershellCore"
+        },
+        {
+            "name": "windows-AzPipeline-7zip"
+        },
+        {
+            "name": "windows-visualstudio-bootstrapper",
+            "parameters": {
+                "Workloads": "--add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.Universal --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core --add Microsoft.VisualStudio.ComponentGroup.UWP.Support --add Microsoft.VisualStudio.ComponentGroup.UWP.VC --add Microsoft.Component.MSBuild --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.CoreIde --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.Windows11SDK.26100 --add Microsoft.VisualStudio.Component.Windows11Sdk.WindowsPerformanceToolkit --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.VC.MFC.ARM64 --add Microsoft.VisualStudio.Component.UWP.VC.ARM64 --add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre --add Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre --add Microsoft.VisualStudio.Component.VC.ATL.Spectre --add Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre --includeRecommended --includeOptional",
+                "SKU": "Enterprise",
+                "VSBootstrapperURL": "https://aka.ms/vs/18/stable/vs_Enterprise.exe"
+            }
+        },
+        {
+            "name": "Windows-NodeJS",
+            "parameters": {
+                "Version": "24.x",
+                "UseARM": "false"
+            }
+        },
+        {
+            "name": "windows-install-python",
+            "parameters": {
+                "Version": "latest",
+                "Architecture": "x64"
+            }
+        },
+        {
+            "name": "windows-chrome"
+        },
+        {
+            "name": "windows-AzPipeline-WinAppDriver"
+        },
+        {
+            "name": "windows-dotnetcore-sdk",
+            "parameters": {
+                "DotNetCoreVersion": "latest",
+                "Channel": "10.0"
+            }
+        },
+        {
+            "name": "Windows-AzureCLI"
+        }
+    ]
+}

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -139,13 +139,6 @@ extends:
               targetPath: $(Build.StagingDirectory)\out\pkg-staging
 
           steps:
-          - task: UsePythonVersion@0
-            displayName: Use Python 3.x
-            inputs:
-              versionSpec: '3.x'
-              addToPath: true
-              architecture: 'x64'
-
           - template: /.ado/windows-build.yml@self
             parameters:
               outputPath: $(Build.StagingDirectory)\out\pkg-staging
@@ -194,15 +187,6 @@ extends:
               - output: pipelineArtifact
                 artifactName: ${{ matrix.Name }}-new
                 targetPath: $(Build.StagingDirectory)\out-new\pkg-staging
-                # The 1ES SBoM ManifestGenerator runs as an x64 process and can't
-                # load the arm64 agent's native .NET (hostfxr arch mismatch,
-                # 0x800700C1), and its x64-runtime self-install is blocked by
-                # network isolation. This per-cell artifact is intermediate -- the
-                # shipped NuGet's SBoM is produced by the V8JsiCreateNugetNew
-                # aggregator on x64 -- so skip SBoM here for arm64 only; x64/x86
-                # keep generating it.
-                ${{ if eq(matrix.BuildPlatform, 'arm64') }}:
-                  sbomEnabled: false
 
           steps:
             # ARM64 agents ship no externals\node10, but the mandatory 1ES build-
@@ -210,13 +194,6 @@ extends:
             # the image's Node so that post-job doesn't fail. Right after checkout.
           - ${{ if eq(matrix.BuildPlatform, 'arm64') }}:
             - template: /.ado/ensure-node10-shim.yml@self
-
-          - task: UsePythonVersion@0
-            displayName: Use Python 3.x
-            inputs:
-              versionSpec: '3.x'
-              addToPath: true
-              architecture: 'x64'
 
           - task: UseNode@1
             displayName: Use Node.js 24.x
@@ -304,14 +281,6 @@ extends:
             - output: pipelineArtifact
               artifactName: sandbox-binaries-${{ sb.Rid }}
               targetPath: $(Build.StagingDirectory)\sandbox
-              # Same arm64 SBoM skip as the V8JsiBuildNew cell: the x64-only 1ES
-              # SBoM toolkit can't load the arm64 agent's native .NET (hostfxr arch
-              # mismatch, 0x800700C1). This per-RID artifact is intermediate -- the
-              # shipped NuGet's SBoM is produced by the V8JsiCreateNugetNew
-              # aggregator on x64 -- so skip SBoM here for arm64 only; x64/x86 keep
-              # generating it.
-              ${{ if eq(sb.BuildPlatform, 'arm64') }}:
-                sbomEnabled: false
 
           steps:
             # The vendored gn (deps/gn/gn.exe) is a Git LFS object; the default
@@ -325,13 +294,6 @@ extends:
             # the image's Node so that post-job doesn't fail.
           - ${{ if eq(sb.BuildPlatform, 'arm64') }}:
             - template: /.ado/ensure-node10-shim.yml@self
-
-          - task: UsePythonVersion@0
-            displayName: Use Python 3.x
-            inputs:
-              versionSpec: '3.x'
-              addToPath: true
-              architecture: 'x64'
 
           - task: UseNode@1
             displayName: Use Node.js 24.x

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -88,6 +88,7 @@ extends:
         skipBuildTagsForGitHubPullRequests: true
     pool:
       name: fabric-internal-pool-large
+      demands: ImageOverride -equals windows-2025-1espt
     sdl:
       # Also disable the PREfast scan itself -- clang-cl can't run /analyze. (The
       # injection above is the actual build-breaker; this is belt-and-suspenders.)
@@ -166,7 +167,8 @@ extends:
           # tests actually execute -- on an x64 agent build.ts can only cross-
           # compile arm64 and skips the tests. windows-2025-1espt-arm64 is a
           # single-image pool, so it takes no ImageOverride demand. x64/x86 cells
-          # inherit the top-level fabric-internal-pool-large pool, unchanged.
+          # inherit the top-level fabric-internal-pool-large pool, which pins the
+          # windows-2025-1espt image.
           ${{ if eq(matrix.BuildPlatform, 'arm64') }}:
             pool:
               name: windows-2025-1espt-arm64

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -128,6 +128,14 @@ extends:
 
           timeoutInMinutes: 1200
 
+          # The legacy Google-V8 (depot_tools) build supports only up to VS 2022
+          # (17.0), but the windows-2025-1espt image ships VS 2026 -- so this build
+          # must NOT run on it. Take the pool's default image (which provides a
+          # supported VS) instead of the top-level windows-2025-1espt ImageOverride.
+          # The Node.js-source build and sandbox keep the pinned image.
+          pool:
+            name: fabric-internal-pool-large
+
           variables:
           - name: Packaging.EnableSBOMSigning
             value: ${{ startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft') }}

--- a/.ado/windows-release.yml
+++ b/.ado/windows-release.yml
@@ -214,12 +214,20 @@ extends:
             targetPath: $(Pipeline.Workspace)\symbols\Desktop_x86_Release-new
           - input: pipelineArtifact
             pipeline: microsoft.v8-jsi.ci
+            artifactName: Desktop_ARM64_Release-new
+            targetPath: $(Pipeline.Workspace)\symbols\Desktop_ARM64_Release-new
+          - input: pipelineArtifact
+            pipeline: microsoft.v8-jsi.ci
             artifactName: sandbox-binaries-win-x64
             targetPath: $(Pipeline.Workspace)\symbols\sandbox-binaries-win-x64
           - input: pipelineArtifact
             pipeline: microsoft.v8-jsi.ci
             artifactName: sandbox-binaries-win-x86
             targetPath: $(Pipeline.Workspace)\symbols\sandbox-binaries-win-x86
+          - input: pipelineArtifact
+            pipeline: microsoft.v8-jsi.ci
+            artifactName: sandbox-binaries-win-arm64
+            targetPath: $(Pipeline.Workspace)\symbols\sandbox-binaries-win-arm64
 
         steps:
         - pwsh: |

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
-    "version":  "0.79.6",
+    "version":  "0.79.7",
     "v8ref":  "refs/branch-heads/12.1",
     "buildNumber":  "285",
-    "v8jsi_version":  "24.1.0",
+    "v8jsi_version":  "24.1.1",
     "nodejs_version":  "24.15.1"
 }


### PR DESCRIPTION
## Summary

ARM64 build/test jobs run natively on the `windows-2025-1espt-arm64` pool, but SBoM was
disabled on the ARM64 cells: the 1ES SBoM tool is x64 and the agent had only native ARM64
.NET, so it couldn't load `hostfxr.dll` (`HRESULT 0x800700C1`). This PR lands the
managed-image definitions with a side-by-side **x64 .NET SDK** on the ARM64 image, re-enables
ARM64 SBoM, and restores ARM64 symbol publishing. It also switches Python to the latest
release and floats the .NET SDK to the newest 10.0 servicing build.

## Changes

- **ARM64 image gets x64 .NET** — a second `windows-dotnetcore-sdk` (`Architecture: x64`,
  `InstallDir: C:\Program Files\dotnet\x64`) beside the native arm64 SDK, plus
  `windows-setenvvar` `DOTNET_ROOT_X64` so the x64 SBoM host finds it. This is the core fix.
- **Re-enable ARM64 SBoM** (`windows-jobs.yml`) — removed the two arm64 `sbomEnabled: false`
  skips on the `V8JsiBuildNew` and sandbox outputs.
- **Restore ARM64 symbols** (`windows-release.yml`) — re-added `Desktop_ARM64_Release-new` and
  `sandbox-binaries-win-arm64` to the symbol-publish job.
- **Latest Python** — both images use `windows-install-python` (`latest`) instead of a pinned
  `windows-python-3xx`. It installs onto `PATH` (not the hosted tool cache), so the three
  `UsePythonVersion@0` tasks (tool-cache-only) were removed.
- **Floating .NET** — every `windows-dotnetcore-sdk` entry uses `Channel: 10.0` +
  `DotNetCoreVersion: latest` (newest 10.0 servicing build) instead of pinning `10.0.300`.
- **Pin the shared pool image** (`windows-jobs.yml`) — the top-level `fabric-internal-pool-large`
  pool now demands `ImageOverride -equals windows-2025-1espt`, so the Node.js-source build,
  sandbox, and NuGet jobs use it explicitly. The **legacy Google-V8 build keeps the pool's
  default image** (it supports only up to VS 2022; `windows-2025-1espt` ships VS 2026). ARM64
  uses the single-image `windows-2025-1espt-arm64` pool (no override); release runs on a hosted
  pool (untouched).
- **New `.ado/image/README.md`** — documents both images, the pool/image mapping, the VS
  workload, every artifact, and these decisions.
- **Package version bumps** (`config.json`) — `version` 0.79.6 → **0.79.7** (legacy
  `ReactNative.V8Jsi.Windows` NuGet) and `v8jsi_version` 24.1.0 → **24.1.1** (new
  `Microsoft.JavaScript.V8` NuGet). Needed so the post-build release publishes new package
  versions instead of colliding with the versions already on the feed.

## Notes for reviewers

- **Both Windows SDKs are kept** (`26100` + `22621`): consumers still target `10.0.22621.0`
  (e.g. react-native-windows default props), so dropping 22621 would break them.
- **No image-factory change** — the existing `windows-dotnetcore-sdk` artifact already accepts
  `-Architecture`/`-InstallDir`; the image build passes the JSON params to it by name.
- **The ARM64 image must be rebuilt** from these JSONs (x64 .NET + latest Python + floated
  .NET) before the ARM64 SBoM cells can pass — editing the JSON alone doesn't change the
  running agents.

## Validation

CI (`microsoft.v8-jsi.ci`) and the release symbol-publish validation are green on this branch:
SBoM now passes on both ARM64 cells (`V8JsiBuildNew` + sandbox) — the direct signal that the
x64 .NET install + `DOTNET_ROOT_X64` discovery work. x64/x86 unchanged.

## Follow-ups (not in this PR)

- Sandbox jobs don't yet run the JSI/Node-API gtests against `v8jsisb.dll`.
- Converge the react-native-windows image onto this spec (add an ARM64 sibling).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/248)