### PR TITLE
Enable test runs in all PR and CI pipelines

### DIFF
--- a/.ado/windows-build-new.yml
+++ b/.ado/windows-build-new.yml
@@ -58,18 +58,20 @@ steps:
       displayName: Stage pkg-staging + pack per-RID NuGet
       workingDirectory: $(Build.SourcesDirectory)
 
-      # x64 Release cell runs the tests/ integration suite against the freshly-
-      # packed per-RID .nupkg through a real consumer (tests/consumer.vcxproj).
-      # build.ts --test-e2e drives the x64-only harness: the cross-CRT smoke in
-      # Release/Release (links the Release Hybrid-CRT DLL) and Debug/Release
-      # (cross-CRT boundary), plus the startup-snapshot e2e (build a snapshot
-      # with the packaged mkv8snapshot.exe and consume it via the public
+      # x64, x86, and ARM64 Release cells run the tests/ integration suite
+      # against the freshly-packed per-RID .nupkg through a real consumer
+      # (tests/consumer.vcxproj). build.ts --test-e2e drives the matching native
+      # harness: the cross-CRT smoke in Release/Release (links the Release
+      # Hybrid-CRT DLL) and Debug/Release (cross-CRT boundary), plus the
+      # startup-snapshot e2e (build a snapshot with the packaged
+      # mkv8snapshot.exe and consume it via the public
       # V8RuntimeArgs::startupSnapshotBlob surface). This per-RID pack carries
       # v8jsi.dll + mkv8snapshot.exe but not v8jsisb.dll (that ships from the
       # sandbox job and is merged only in the aggregator), so the snapshot
       # scenario runs the v8jsi leg here and auto-skips the v8jsisb + cross-engine
-      # legs until they run against a sandbox-complete pack.
-    - ${{ if eq(parameters.buildPlatform, 'x64') }}:
+      # legs until they run against a sandbox-complete pack. x86 builds the
+      # 32-bit (Win32) consumer and runs it via WOW64 on the x64 agent.
+    - ${{ if in(parameters.buildPlatform, 'x64', 'x86', 'arm64') }}:
       - pwsh: |
           node scripts/build.ts --no-build --no-test --test-e2e `
               --platform ${{parameters.buildPlatform}} `

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -338,6 +338,17 @@ extends:
               displayName: Build v8jsisb.dll (jitless sandbox engine, MSVC)
               workingDirectory: $(Build.SourcesDirectory)
 
+              # The sandbox GYP build keeps the v8jsi target name but changes
+              # its product name, so v8jsi_test.exe and the Node-API suite's
+              # node_lite.exe child import v8jsisb.dll. Run both suites on every
+              # architecture (ARM64 natively, x86 via WOW64). Both suites pass
+              # unfiltered under jitless, so no JIT-specific exclusions apply.
+            - pwsh: |
+                node scripts/build.ts --no-build --test --build-v8jsisb `
+                    --platform ${{ sb.BuildPlatform }} --configuration release
+              displayName: Run JSI + Node-API gtests against v8jsisb.dll
+              workingDirectory: $(Build.SourcesDirectory)
+
               # Hygiene gates: export allowlist + Hybrid CRT + BinSkim, over this
               # arch's out dir (--target-cpu resolves it). Exits non-zero on any
               # unaccepted finding.
@@ -404,6 +415,28 @@ extends:
                   **\sbox.dll
                   **\v8host.exe
                   **\mkv8snapshot.exe
+
+              # Signed lockdown tier (publishing build only): re-run the
+              # Untrusted broker harness against the ESRP-signed binaries with
+              # NO SBOX_ALLOW_UNSIGNED override, so test_app.exe's WinVerifyTrust
+              # gate enforces genuine Authenticode on the exact sbox.dll /
+              # v8host.exe / v8jsisb.dll bytes that ship. Runs in ADDITION to the
+              # unsigned tier above and depends on the signing step, hence the
+              # isPublish gate. test_app.exe is the broker (never signature-
+              # checked), so overlaying the three signed images suffices.
+          - ${{ if and(eq(sb.RunTier, true), eq(parameters.isPublish, true), eq(parameters.fakeBuild, false)) }}:
+            - pwsh: |
+                $sandboxOut = "$(Build.SourcesDirectory)\${{ sb.SboxOutDir }}"
+                $signed = "$(Build.StagingDirectory)\sandbox\build\native\${{ sb.Rid }}"
+                foreach ($f in 'sbox.dll', 'v8host.exe', 'v8jsisb.dll') {
+                  Copy-Item (Join-Path $signed $f) $sandboxOut -Force
+                }
+                $env:DEPOT_TOOLS_WIN_TOOLCHAIN = '0'
+                # SBOX_ALLOW_UNSIGNED intentionally unset: enforce real signatures.
+                & "$sandboxOut\test_app.exe"
+                if ($LASTEXITCODE -ne 0) { Write-Error "Signed Untrusted tier FAILED (exit $LASTEXITCODE)" }
+              displayName: Lockdown tier test (Untrusted, signed)
+              workingDirectory: $(Build.SourcesDirectory)
 
       - job: V8JsiCreateNuget
         dependsOn:
@@ -569,3 +602,64 @@ extends:
               folderPath: $(Build.StagingDirectory)\out\pkg
               pattern: |
                 Microsoft.JavaScript.V8.*.nupkg
+
+        # =====================================================================
+        # Signed-pack acceptance (CI only). After the 4-pack is built and ESRP-
+        # signed, restore the final per-RID Microsoft.JavaScript.V8.<rid>
+        # package as a real consumer and run the full tests/ suite against the
+        # SIGNED bytes -- including the sandbox (v8jsisb) leg + cross-engine
+        # rejection, which the in-cell --test-e2e skips (a per-RID build cell's
+        # pack carries no v8jsisb.dll). This is the only stage that exercises the
+        # exact signed binaries + signed .nupkg a customer restores. PR builds
+        # skip it (nothing is signed there); their fast in-cell --test-e2e
+        # already covers the non-sandbox legs unsigned. One job per shipped RID:
+        # x64/x86 on the x64 image (x86 consumer via WOW64), arm64 native.
+        # =====================================================================
+      - ${{ each matrix in parameters.BuildMatrix }}:
+        - ${{ if and(eq(parameters.isPublish, true), eq(matrix.BuildConfiguration, 'Release')) }}:
+          - job: V8JsiAcceptanceNew_${{ matrix.Name }}
+            dependsOn: V8JsiCreateNugetNew
+            displayName: Acceptance signed pack ${{ matrix.Name }}
+
+            # arm64 runs natively on the ARM64 pool; x64/x86 inherit the top-
+            # level windows-2025-1espt image (x86 consumer runs via WOW64).
+            ${{ if eq(matrix.BuildPlatform, 'arm64') }}:
+              pool:
+                name: windows-2025-1espt-arm64
+
+            steps:
+            - checkout: self
+
+              # ARM64 agents ship no externals\node10; shim it so the mandatory
+              # 1ES retention post-job (Node 10 handler) doesn't fail.
+            - ${{ if eq(matrix.BuildPlatform, 'arm64') }}:
+              - template: /.ado/ensure-node10-shim.yml@self
+
+            - task: UseNode@1
+              displayName: Use Node.js 24.x
+              inputs:
+                version: '24.x'
+
+              # The consumer restore (run-smoke.ps1 / run-snapshot.ps1) needs
+              # nuget.exe on PATH.
+            - task: NuGetToolInstaller@1
+              displayName: Install NuGet tools
+              inputs:
+                versionSpec: ">=4.6.0"
+
+              # The final signed 4-pack (3 per-RID + meta) from the aggregator.
+            - task: DownloadPipelineArtifact@2
+              displayName: Download published-packages-new
+              inputs:
+                artifact: published-packages-new
+                path: $(Build.StagingDirectory)\acceptance\pkg
+
+              # Restore the signed per-RID package as a real consumer and run the
+              # smoke + snapshot suite (both engines) against it. --test-acceptance
+              # forces the sandbox leg on: the final pack MUST carry v8jsisb.dll.
+            - pwsh: |
+                node scripts/build.ts --no-build --no-test --test-acceptance `
+                    --platform ${{ matrix.BuildPlatform }} `
+                    --output-path $(Build.StagingDirectory)\acceptance
+              displayName: Acceptance tests against signed pack
+              workingDirectory: $(Build.SourcesDirectory)

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -57,6 +57,7 @@ const options = {
   pack: { type: "boolean" as const, default: false },
   smoke: { type: "boolean" as const, default: false },
   "test-e2e": { type: "boolean" as const, default: false },
+  "test-acceptance": { type: "boolean" as const, default: false },
   binskim: { type: "boolean" as const, default: false },
   "check-crt": { type: "boolean" as const, default: false },
   "check-size": { type: "boolean" as const, default: false },
@@ -308,12 +309,15 @@ Boolean flags (all support --no- prefix):
   --test              Run v8jsi_test.exe
   --pack              Create NuGet package
   --smoke             Run the real-consumer smoke (tests/run-smoke.ps1) against
-                      the packed .nupkg (x64; Release + Debug)
+                      the packed .nupkg (x64/x86/arm64; Release + Debug)
   --test-e2e          Run the full tests/ integration suite against the packed
-                      .nupkg (x64): the consumer smoke + the startup-snapshot
+                      .nupkg (x64/x86/arm64): the consumer smoke + the startup-snapshot
                       e2e (build a snapshot with packaged mkv8snapshot.exe and
                       consume it via V8RuntimeArgs::startupSnapshotBlob, both
                       engines, incl. cross-engine rejection)
+  --test-acceptance   Like --test-e2e but against an already-built pack (e.g. the
+                      downloaded signed NuGet in CI); forces the sandbox-engine
+                      leg on (the final multi-engine pack always carries v8jsisb.dll)
   --binskim           Run BinSkim security validation
   --check-crt         Report v8jsi.dll's C/C++ runtime imports (Hybrid CRT check)
   --check-size        Enforce the binary-size budget (v8jsisb.dll <= 18 MiB)
@@ -403,7 +407,8 @@ async function runBuild(
 // =============================================================================
 
 function runTests(platform: string, configuration: string): void {
-  console.log(`\n=== Testing v8jsi (${platform} ${configuration}) ===\n`);
+  const engineName = args["build-v8jsisb"] ? "v8jsisb" : "v8jsi";
+  console.log(`\n=== Testing ${engineName} (${platform} ${configuration}) ===\n`);
 
   if (isCrossPlatformBuild(platform)) {
     console.log(
@@ -891,81 +896,110 @@ function packNuGet(outputPath: string, platforms: string[], configurations: stri
 // =============================================================================
 
 // Run one tests/ scenario (tests/run-<scenario>.ps1) against the freshly-packed
-// per-RID .nupkg. The harness is x64-only. Each scenario runs against the
-// default engine (v8jsi) in the given consumer configs, then once more on the
-// sandbox engine (v8jsisb, -UseV8Sandbox) when the pack actually carries it.
+// per-RID .nupkg. The harness supports x64, x86, and arm64. Each scenario runs
+// against the default engine (v8jsi) in the given consumer configs, then once
+// more on the sandbox engine (v8jsisb, -UseV8Sandbox). requireSandbox forces the
+// sandbox leg on (acceptance against a sandbox-complete pack); otherwise it runs
+// only when the pack actually staged a v8jsisb.dll for this RID.
 function runHarnessScenario(
   scenario: string,
   outputPath: string,
   platforms: string[],
   consumerConfigs: string[],
+  requireSandbox: boolean = false,
 ): void {
-  if (!platforms.includes("x64")) {
+  const harnessPlatforms = platforms.filter(
+    (platform) =>
+      platform === "x64" || platform === "x86" || platform === "arm64",
+  );
+  if (harnessPlatforms.length === 0) {
     console.log(
-      `Skipping ${scenario}: the harness is x64-only and x64 was not targeted.`,
+      `Skipping ${scenario}: the harness supports x64, x86, and arm64, but none was targeted.`,
     );
     return;
   }
 
   const script = path.join(repoRoot, "tests", `run-${scenario}.ps1`);
   const pkgDir = path.join(outputPath, "pkg");
-  const invoke = (config: string, sandbox: boolean): void => {
-    const psArgs = [
-      "-NoProfile",
-      "-ExecutionPolicy",
-      "Bypass",
-      "-File",
-      `"${script}"`,
-      "-Configuration",
-      config,
-      "-Platform",
-      "x64",
-      "-PkgDir",
-      `"${pkgDir}"`,
-    ];
-    if (sandbox) psArgs.push("-UseV8Sandbox");
-    run("powershell.exe", psArgs);
-  };
+  for (const platform of harnessPlatforms) {
+    const invoke = (config: string, sandbox: boolean): void => {
+      const psArgs = [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        `"${script}"`,
+        "-Configuration",
+        config,
+        "-Platform",
+        platform,
+        "-PkgDir",
+        `"${pkgDir}"`,
+      ];
+      if (sandbox) psArgs.push("-UseV8Sandbox");
+      run("powershell.exe", psArgs);
+    };
 
-  for (const config of consumerConfigs) {
-    invoke(config, /*sandbox*/ false);
-  }
+    for (const config of consumerConfigs) {
+      invoke(config, /*sandbox*/ false);
+    }
 
-  // Sandbox-engine leg: only when the pack actually carries the sandbox
-  // binaries (a non-sandbox build doesn't). Drives v8jsisb.dll.
-  const stagedV8jsisb = path.join(
-    outputPath,
-    "pkg-staging",
-    "build",
-    "native",
-    "win-x64",
-    "v8jsisb.dll",
-  );
-  if (fs.existsSync(stagedV8jsisb)) {
-    console.log(`\n=== ${scenario} (sandbox engine) ===\n`);
-    invoke("Release", /*sandbox*/ true);
-  } else {
-    console.log(
-      `Skipping ${scenario} sandbox leg: no v8jsisb.dll staged (non-sandbox pack).`,
+    // Sandbox-engine leg: only when the pack actually carries the sandbox
+    // binaries (a non-sandbox build doesn't). Drives v8jsisb.dll.
+    const stagedV8jsisb = path.join(
+      outputPath,
+      "pkg-staging",
+      "build",
+      "native",
+      platformToRid(platform),
+      "v8jsisb.dll",
     );
+    if (requireSandbox || fs.existsSync(stagedV8jsisb)) {
+      console.log(`\n=== ${scenario} (${platform}, sandbox engine) ===\n`);
+      invoke("Release", /*sandbox*/ true);
+    } else {
+      console.log(
+        `Skipping ${scenario} sandbox leg for ${platform}: no v8jsisb.dll staged (non-sandbox pack).`,
+      );
+    }
   }
 }
 
 // Real-consumer smoke: builds the consumer in Release + Debug against the
 // Release v8jsi.dll (the Debug/Release leg exercises the Hybrid CRT cross-CRT
 // boundary) and runs the JSI ABI checks.
-function runSmoke(outputPath: string, platforms: string[]): void {
+function runSmoke(
+  outputPath: string,
+  platforms: string[],
+  requireSandbox: boolean = false,
+): void {
   console.log("\n=== Smoke (real-consumer) ===\n");
-  runHarnessScenario("smoke", outputPath, platforms, ["Release", "Debug"]);
+  runHarnessScenario(
+    "smoke",
+    outputPath,
+    platforms,
+    ["Release", "Debug"],
+    requireSandbox,
+  );
 }
 
 // Startup-snapshot e2e: builds a snapshot with the packaged mkv8snapshot.exe and
 // consumes it via the public V8RuntimeArgs::startupSnapshotBlob surface, for both
 // engines, including cross-engine rejection. Release consumer is sufficient (the
 // scenario exercises the snapshot path, not the cross-CRT matrix).
-function runSnapshotE2E(outputPath: string, platforms: string[]): void {
+function runSnapshotE2E(
+  outputPath: string,
+  platforms: string[],
+  requireSandbox: boolean = false,
+): void {
   console.log("\n=== Snapshot e2e ===\n");
-  runHarnessScenario("snapshot", outputPath, platforms, ["Release"]);
+  runHarnessScenario(
+    "snapshot",
+    outputPath,
+    platforms,
+    ["Release"],
+    requireSandbox,
+  );
 }
 
 // =============================================================================
@@ -1074,13 +1108,16 @@ async function main(): Promise<void> {
   }
 
   // Real-consumer integration tests (after packing). --test-e2e runs the full
-  // suite (smoke + snapshot); --smoke is the focused subset. Either implies the
-  // smoke; only --test-e2e adds the snapshot e2e.
-  if (args.smoke || args["test-e2e"]) {
-    runSmoke(outputPath, platforms);
+  // suite (smoke + snapshot); --smoke is the focused subset. --test-acceptance
+  // runs the same suite against an already-built pack (e.g. the downloaded
+  // signed NuGet) and forces the sandbox-engine leg on. --smoke/--test-e2e
+  // imply the smoke; --test-e2e/--test-acceptance add the snapshot e2e.
+  const requireSandbox = args["test-acceptance"];
+  if (args.smoke || args["test-e2e"] || args["test-acceptance"]) {
+    runSmoke(outputPath, platforms, requireSandbox);
   }
-  if (args["test-e2e"]) {
-    runSnapshotE2E(outputPath, platforms);
+  if (args["test-e2e"] || args["test-acceptance"]) {
+    runSnapshotE2E(outputPath, platforms, requireSandbox);
   }
 
   // Report elapsed time

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,9 +14,12 @@ node scripts/build.ts --no-build --pack --test-e2e --platform x64 --configuratio
 ```
 
 `--test-e2e` runs the whole suite; `--smoke` runs just the consumer smoke. The
-harness is **x64-only** and needs `nuget.exe` + Visual Studio (MSBuild via vswhere)
-on the machine. The sandbox-engine (`v8jsisb.dll`) and cross-engine legs run only
-when the pack actually carries the sandbox binaries; otherwise they auto-skip.
+harness supports native x64, x86, and ARM64; pass `--platform x86` or
+`--platform arm64` to target those (x86 builds the 32-bit Win32 consumer, which
+runs via WOW64 on an x64 host). It needs `nuget.exe` + Visual Studio (MSBuild via
+vswhere) on the machine. The sandbox-engine (`v8jsisb.dll`) and cross-engine legs
+run only when the pack actually carries the sandbox binaries; otherwise they
+auto-skip.
 
 ## Layout
 

--- a/tests/consumer.vcxproj
+++ b/tests/consumer.vcxproj
@@ -4,9 +4,8 @@
 
   Consumes the freshly-packed Microsoft.JavaScript.V8.<rid> NuGet the same way
   a downstream consumer does. The v8-jsi NuGet is multi-package (1 meta + 3
-  per-RID); for an x64 consumer the smoke restores
-  Microsoft.JavaScript.V8.win-x64.<version>.nupkg directly. The package's
-  Microsoft.JavaScript.V8.win-x64.targets file injects the v8jsi.dll.lib link
+  per-RID); the smoke restores the matching per-RID package directly. The
+  package's RID-specific .targets file injects the v8jsi.dll.lib link
   reference plus the consumer-side V8JsiRuntime.cpp / JsiAbiRuntime.cpp /
   jsi.cpp <ClCompile> items.
 
@@ -16,9 +15,9 @@
   auto-import + .props RID-detection path that a real PackageReference consumer
   would use.
 
-  Release|x64 is the baseline; Debug|x64 additionally exercises the Hybrid CRT
-  cross-CRT boundary: the consumer EXE links /MDd (Debug-CRT) while the
-  package's v8jsi.dll is the Release Hybrid-CRT build (the package ships a
+  Release is the baseline for each platform; Debug additionally exercises the
+  Hybrid CRT cross-CRT boundary: the consumer EXE links /MDd (Debug-CRT) while
+  the package's v8jsi.dll is the Release Hybrid-CRT build (the package ships a
   single Release config, so Debug consumers link the Release v8jsi.dll).
 
   When the driver passes /p:UseV8Sandbox=true, the package .targets add the
@@ -27,9 +26,25 @@
 -->
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|arm64">
+      <Configuration>Debug</Configuration>
+      <Platform>arm64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|arm64">
+      <Configuration>Release</Configuration>
+      <Platform>arm64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
@@ -46,18 +61,48 @@
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|arm64'">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|arm64'">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
 
@@ -90,6 +135,20 @@
     </Link>
   </ItemDefinitionGroup>
 
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm64'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -104,7 +163,39 @@
     </Link>
   </ItemDefinitionGroup>
 
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm64'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>Disabled</Optimization>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>Disabled</Optimization>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Optimization>Disabled</Optimization>
@@ -136,10 +227,10 @@
 
     The .props sets V8Jsi* property defaults (V8JsiIncludePublicHeaders=True
     etc.) and does RID detection (bypassed here by an explicit
-    /p:V8JsiRuntimeIdentifier=win-x64 from the smoke driver). The .targets
-    is the body that wires include dirs, link references, and the consumer
-    source TUs — all gated on V8JsiRuntimeIdentifier matching this
-    package's RID.
+    /p:V8JsiRuntimeIdentifier matching the selected platform from the smoke
+    driver). The .targets is the body that wires include dirs, link references,
+    and the consumer source TUs — all gated on V8JsiRuntimeIdentifier matching
+    this package's RID.
 
     A real PackageReference consumer has NuGet auto-import both files
     based on filename = package id. The smoke uses packages.config +

--- a/tests/test-helpers.ps1
+++ b/tests/test-helpers.ps1
@@ -118,12 +118,17 @@ function Build-Consumer {
     )
     $msbuild = Get-MSBuild
     $vcxproj = Join-Path $HarnessDir 'consumer.vcxproj'
+    # VC++ has no 'x86' platform - 32-bit is 'Win32'. Translate the harness
+    # platform vocabulary (x64/x86/arm64, matching the RID and CI buildPlatform)
+    # to the MSBuild platform the consumer project defines. The explicit
+    # V8JsiRuntimeIdentifier below still selects the win-x86 package payload.
+    $msbuildPlatform = if ($Platform -eq 'x86') { 'Win32' } else { $Platform }
     # Pass V8JsiRuntimeIdentifier explicitly to bypass the .props RID
     # auto-detection (a real PackageReference consumer lets that run on its own).
     $mbArgs = @(
         $vcxproj,
         "/p:Configuration=$Configuration",
-        "/p:Platform=$Platform",
+        "/p:Platform=$msbuildPlatform",
         "/p:V8JsiPackageProps=$PkgProps",
         "/p:V8JsiPackageTargets=$PkgTargets",
         "/p:V8JsiRuntimeIdentifier=$Rid"
@@ -136,7 +141,7 @@ function Build-Consumer {
     & $msbuild @mbArgs /restore:false /nologo /v:minimal | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "msbuild failed (exit $LASTEXITCODE)" }
 
-    $exe = Join-Path $HarnessDir "bin\$Configuration\$Platform\v8jsi_smoke.exe"
+    $exe = Join-Path $HarnessDir "bin\$Configuration\$msbuildPlatform\v8jsi_smoke.exe"
     if (-not (Test-Path $exe)) { throw "Expected EXE not produced: $exe" }
     return $exe
 }


### PR DESCRIPTION
## Summary

[PR #248](https://github.com/microsoft/v8-jsi/pull/248) (Fix SBoM on ARM64) rebuilt the 1ES
managed images, moving the x64 image from VS 2022 to VS 2026. The real-consumer test harness
(`tests/consumer.vcxproj`) pinned `PlatformToolset = v143` (VS 2022), so on the rebuilt image
CI/PR validation failed and blocked #248's release.

**Primary goal:** unblock CI/PR validation on the VS 2026 x64 image. **Then:** broaden test
coverage so this class of gap is caught on every platform.

## What changed

1. **Toolset fix (the unblock):** consumer harness `PlatformToolset` `v143` →
   `$(DefaultPlatformToolset)`, so it builds on whatever VS the image ships.
2. **End-user harness on every platform:** the real-consumer smoke + startup-snapshot e2e now
   run on x86 and ARM64, not just x64 (added Win32 + ARM64 consumer configs; the harness maps
   `x86` → MSBuild `Win32`, ARM64 runs natively).
3. **Sandbox engine unit tests:** the JSI + Node-API gtests now also run against the jitless
   sandbox engine `v8jsisb.dll` on all platforms.
4. **Signed acceptance (official CI):** new jobs restore the final ESRP-signed NuGet and run
   the harness against the signed bytes — including the sandbox consumer leg (never exercised
   before). A signed sandbox lockdown tier runs alongside the existing unsigned one.

## Testing strategy

Coverage now spans four axes — **platform × engine × test kind × signing/stage**:

| Test kind | What it checks | Engine(s) | Platforms | PR | Official CI |
|---|---|---|---|---|---|
| **Unit** (`v8jsi_test`, `node_api_tests`) | engine internals, in-process | v8jsi + v8jsisb | x64, x86, arm64 | unsigned | unsigned |
| **End-user harness** (consumer smoke + snapshot e2e) | the shipped NuGet as a real consumer uses it: headers, import lib, cross-CRT, snapshot | v8jsi | x64, x86, arm64 | unsigned | unsigned |
| **Acceptance harness** (same + sandbox leg + cross-engine) | the exact **signed** binaries + signed `.nupkg` a customer restores | v8jsi + v8jsisb | x64, x86, arm64 | — | **signed** |
| **Sandbox lockdown** (`test_app`, Untrusted CIG/ACG) | untrusted JS runs jitless under lockdown | v8jsisb + sbox | x64, x86, arm64 | unsigned | unsigned **+ signed** |

- **All platforms:** x64 + x86 on the x64 image (x86 via WOW64), ARM64 native on its managed-image pool.
- **Unit vs end-user harness:** unit tests drive the engine from inside the DLL; the harness builds and runs a real consumer against the packed NuGet.
- **Unsigned vs signed:** PR and in-cell runs use unsigned binaries (fast feedback); official CI additionally re-runs the end-user + lockdown tests against ESRP-signed binaries — testing what actually ships.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/249)