### PR TITLE
Tag published versions from CI

### DIFF
--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -663,3 +663,108 @@ extends:
                     --output-path $(Build.StagingDirectory)\acceptance
               displayName: Acceptance tests against signed pack
               workingDirectory: $(Build.SourcesDirectory)
+
+        # =====================================================================
+        # Tag published versions (publishing CI build only). After the NuGet
+        # aggregators and the signed-pack acceptance jobs succeed, create a Git
+        # tag on github.com/microsoft/v8-jsi for each package version this build
+        # is about to publish, so every shipped version is pinned to the commit
+        # it was built from. The release pipeline can't do this -- its agent
+        # can't enlist sources and only sees the CI artifacts -- so tagging runs
+        # here in CI, which checks out the repo.
+        #
+        # Two independently versioned families ship during the migration, so
+        # each gets its own package-qualified tag (mirroring RNW's _v<version>):
+        #   ReactNative.V8Jsi.Windows_v<version>   (config.json .version)
+        #   Microsoft.JavaScript.V8_v<version>     (config.json .v8jsi_version)
+        #
+        # config.json versions stay constant across many CI runs, so tagging
+        # every green build would fight over one tag. Instead reuse the release
+        # pipeline's own "is this version already on the public feed?" check
+        # (see .ado/templates/publish-nuget-to-ado-feed.yml): a tag is created
+        # only for the first build of a version not yet on the feed. That feed
+        # is anonymously readable, so the query needs no token. Idempotent: an
+        # existing tag is left untouched, never moved.
+        # =====================================================================
+      - ${{ if eq(parameters.isPublish, true) }}:
+        - job: V8JsiTagRelease
+          dependsOn:
+          - V8JsiCreateNuget
+          - V8JsiCreateNugetNew
+          - ${{ each matrix in parameters.BuildMatrix }}:
+            - ${{ if eq(matrix.BuildConfiguration, 'Release') }}:
+              - V8JsiAcceptanceNew_${{ matrix.Name }}
+          displayName: Tag published versions
+          steps:
+          - checkout: self
+
+          - pwsh: |
+              $ErrorActionPreference = 'Stop'
+
+              # Both families ship to the public ms/react-native-public feed,
+              # which is anonymously readable -- no access token needed to query.
+              $feedUrl = 'https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json'
+
+              # Discover the flat-container (PackageBaseAddress) URL from the V3
+              # index -- the same lookup the publish template uses.
+              $index = Invoke-RestMethod -Uri $feedUrl
+              $baseAddress = ($index.resources |
+                Where-Object { $_.'@type' -like 'PackageBaseAddress*' } |
+                Select-Object -First 1).'@id'
+              if (-not $baseAddress) { throw "No PackageBaseAddress in $feedUrl" }
+              if (-not $baseAddress.EndsWith('/')) { $baseAddress += '/' }
+
+              # GitHub tag-push auth: the bearer header the permission POC proved.
+              $authHeader = "AUTHORIZATION: bearer $env:SYSTEM_ACCESSTOKEN"
+              Write-Host "##vso[task.setsecret]$authHeader"
+
+              $config = Get-Content "$(Build.SourcesDirectory)\config.json" | ConvertFrom-Json
+              $commit = "$(Build.SourceVersion)"
+
+              # One package-qualified tag per independently versioned family.
+              $families = @(
+                @{ Id = 'ReactNative.V8Jsi.Windows'; Version = [string]$config.version },
+                @{ Id = 'Microsoft.JavaScript.V8';   Version = [string]$config.v8jsi_version }
+              )
+
+              foreach ($f in $families) {
+                $id = $f.Id
+                $version = $f.Version
+                Write-Host "=== $id $version ==="
+                if ([string]::IsNullOrWhiteSpace($version)) { throw "Missing version for $id in config.json" }
+
+                # Already on the public feed? Membership test, so feed ordering
+                # does not matter. 404 = never published -> treat as new.
+                $versionsUrl = "$baseAddress$($id.ToLower())/index.json"
+                $published = $false
+                try {
+                  $result = Invoke-RestMethod -Uri $versionsUrl -ErrorAction Stop
+                  if ($version.ToLower() -in $result.versions) { $published = $true }
+                } catch {
+                  if ($_.Exception.Response.StatusCode -ne [System.Net.HttpStatusCode]::NotFound) { throw }
+                }
+                if ($published) {
+                  Write-Host "  $version already on the feed -- no tag needed."
+                  continue
+                }
+
+                $tag = "${id}_v${version}"
+
+                # Idempotent: never move an existing tag.
+                $existing = git -c http.extraheader="$authHeader" ls-remote --tags origin "refs/tags/$tag"
+                if ($LASTEXITCODE -ne 0) { Write-Error "ls-remote failed for $tag"; exit 1 }
+                if ($existing) {
+                  Write-Host "  tag '$tag' already exists -- no-op."
+                  continue
+                }
+
+                Write-Host "  creating tag '$tag' at $commit"
+                git tag $tag $commit
+                if ($LASTEXITCODE -ne 0) { Write-Error "git tag failed for $tag"; exit 1 }
+                git -c http.extraheader="$authHeader" push origin "refs/tags/$tag"
+                if ($LASTEXITCODE -ne 0) { Write-Error "git push failed for $tag"; exit 1 }
+                Write-Host "  pushed $tag"
+              }
+            displayName: Create and push release tags
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
-    "version":  "0.79.7",
+    "version":  "0.79.8",
     "v8ref":  "refs/branch-heads/12.1",
     "buildNumber":  "285",
-    "v8jsi_version":  "24.1.1",
+    "v8jsi_version":  "24.1.2",
     "nodejs_version":  "24.15.1"
 }


### PR DESCRIPTION
## Summary

Adds a CI job that creates a Git tag on the repo for each NuGet version we ship,
so every released version is pinned to the commit it was built from. Today only
ad-hoc manual tags exist (e.g. `v0.74.7`).

Two files change: the new `V8JsiTagRelease` job in `.ado/windows-jobs.yml`, and a
version bump in `config.json` (`0.79.7`→`0.79.8`, `24.1.1`→`24.1.2`). The bump is
intentional — the previous versions are now on the feed, so without it the first
post-merge publishing run would have nothing new to tag.

## Why in CI, not the release pipeline

The release pipeline runs on a pool that can't enlist sources — it only consumes
CI artifacts and never checks out the repo, so it has no remote to push a tag
to. CI already checks out the repo, so tagging goes here.

## How it works

`V8JsiTagRelease` runs only in publishing builds (`isPublish=true`) after both
NuGet aggregators and the Release acceptance jobs succeed. For each shipped
package family it:

1. reads the version from the root `config.json`;
2. asks the public `ms/react-native-public` feed whether that version is already
   published (the same flat-container check
   `.ado/templates/publish-nuget-to-ado-feed.yml` uses);
3. if not yet published, creates a lightweight, package-qualified tag at the CI
   commit and pushes it. An existing tag is left as-is — never moved.

| Package | Version source | Tag |
| --- | --- | --- |
| `ReactNative.V8Jsi.Windows` | `config.json` `version` | `ReactNative.V8Jsi.Windows_v<version>` |
| `Microsoft.JavaScript.V8` | `config.json` `v8jsi_version` | `Microsoft.JavaScript.V8_v<version>` |

The feed check is what keeps CI from re-tagging: `config.json` versions persist
across many builds, so a tag is created only for the first build of a version
not yet on the feed. A tag therefore means "built, acceptance-passed, and about
to publish" — not "publication confirmed"; if a later publish fails, the tag
still points at the right commit and the next run is a no-op. Tag push uses the
job's `System.AccessToken`; the feed read needs no token (the feed is public).

## Reviewer heads-up

- Runs only for `isPublish=true`; PR validation never tags (the job is compiled
  out of PR builds), so a green PR build correctly shows no tags.
- The first publishing run after merge creates
  `ReactNative.V8Jsi.Windows_v0.79.8` and `Microsoft.JavaScript.V8_v24.1.2`.
  Historical versions are not back-filled.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/250)