### PR TITLE
Auto-versioning for the v8-jsi packages

### DIFF
--- a/.ado/overlay-version-config.yml
+++ b/.ado/overlay-version-config.yml
@@ -1,0 +1,33 @@
+# Overlays the CI-computed config.json onto the checked-out working tree.
+#
+# The V8JsiComputeVersion job derives each package's version from git height
+# (scripts/compute-version.ts), writes them into config.json, and publishes it
+# as the `version-config` pipeline artifact. Every job that stamps, packs, or
+# tags a version downloads that artifact and overlays it here, so build.ts, the
+# RC generators (src/generate_version_info.ts, src/generate_version_rc.ts), the
+# NuGet aggregators, and the tag job read the computed version with no code
+# change -- and without needing the full git history that the height
+# calculation requires (only the version job checks out deep; every other job
+# stays shallow and gets the versions through this artifact).
+#
+# Prerequisites for the consuming job:
+#   * dependsOn: V8JsiComputeVersion  (so the artifact exists)
+#   * the repo checked out            (config.json is present to overwrite)
+# Reference this template BEFORE any step that reads config.json.
+
+steps:
+- task: DownloadPipelineArtifact@2
+  displayName: Download computed version-config
+  inputs:
+    artifact: version-config
+    path: $(Pipeline.Workspace)/version-config
+
+- powershell: |
+    $ErrorActionPreference = 'Stop'
+    $src = '$(Pipeline.Workspace)/version-config/config.json'
+    $dst = '$(Build.SourcesDirectory)/config.json'
+    if (-not (Test-Path $src)) { throw "Computed config.json not found at $src" }
+    Copy-Item -Force $src $dst
+    Write-Host "Overlaid computed config.json onto $dst :"
+    Get-Content $dst
+  displayName: Overlay computed config.json

--- a/.ado/windows-build-new.yml
+++ b/.ado/windows-build-new.yml
@@ -18,6 +18,11 @@ parameters:
 
 
 steps:
+  # Overlay the CI-computed config.json before build.ts runs. The gyp version
+  # action (src/generate_version_info.ts) reads config.json.v8jsi_version to
+  # stamp v8jsi.dll, and build.ts --pack reads it for the per-RID NuGet version.
+- template: /.ado/overlay-version-config.yml@self
+
 - ${{ if eq(parameters.fakeBuild, false) }}:
     # Every step is a single scripts/build.ts invocation so the whole flow is
     # reproducible locally. build.ts provisions NASM itself (needed for the

--- a/.ado/windows-build.yml
+++ b/.ado/windows-build.yml
@@ -18,6 +18,13 @@ parameters:
 
 
 steps:
+  # Overlay the CI-computed config.json before anything reads it. The legacy
+  # binary's version RC (src/generate_version_rc.ts) reads config.json.version
+  # during build.ps1, and build.ps1 then stages config.json into pkg-staging,
+  # which the V8JsiCreateNuget aggregator reads -- so this one overlay carries
+  # the computed version through both the binary stamp and the NuGet version.
+- template: /.ado/overlay-version-config.yml@self
+
 - ${{ if eq(parameters.fakeBuild, false) }}:
   - task: PowerShell@2
     displayName: Download and extract depot_tools.zip

--- a/.ado/windows-ci.yml
+++ b/.ado/windows-ci.yml
@@ -1,7 +1,23 @@
 name: v8jsi_ci_0.0.$(Date:yyMM.d)$(Rev:rrr)
 
-# The triggers are overridden by the ADO pipeline definitions.
-trigger: none
+# Continuous integration trigger, defined in YAML so the pipeline is driven from
+# source instead of the ADO pipeline UI. Runs on master and main, and skips runs
+# for changes that only touch the documentation and ownership-metadata files
+# excluded below. PR validation is handled separately by windows-pr.yml, so this
+# pipeline sets pr: none.
+trigger:
+  batch: false
+  branches:
+    include:
+    - master
+    - main
+  paths:
+    exclude:
+    - README.md
+    - docs/*
+    - AGENTS.md
+    - CLAUDE.md
+    - CODEOWNERS
 pr: none
 
 variables:

--- a/.ado/windows-jobs.yml
+++ b/.ado/windows-jobs.yml
@@ -122,9 +122,71 @@ extends:
     stages:
     - stage: main
       jobs:
+      # =====================================================================
+      # Compute versions. Runs first and is the ONLY job that needs the full
+      # git history: scripts/compute-version.ts derives each package's patch
+      # from git height (commits since its versions/*.version file last
+      # changed). It writes the computed versions into config.json and this job
+      # publishes that config.json as the `version-config` artifact. Every
+      # build/pack/tag job depends on this job and overlays the artifact (see
+      # .ado/overlay-version-config.yml), so they read the computed version with
+      # a shallow checkout and no code change. The write stays in the working
+      # tree / artifact only -- it is never committed (committing would move the
+      # height anchor). Also sets the pipeline run number to the
+      # Microsoft.JavaScript.V8 version so each run is identifiable.
+      # =====================================================================
+      - job: V8JsiComputeVersion
+        displayName: Compute versions
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            artifactName: version-config
+            targetPath: $(Build.StagingDirectory)\version-config
+        steps:
+          # Height is a commit count, so this job (and only this job) needs the
+          # complete first-parent history.
+        - checkout: self
+          fetchDepth: 0
+
+        - task: UseNode@1
+          displayName: Use Node.js 24.x
+          inputs:
+            version: '24.x'
+
+          # Materialize both computed versions into config.json (surgical field
+          # replace; formatting preserved) and stage it for publishing.
+        - pwsh: |
+            node scripts/compute-version.ts --write
+            $stage = "$(Build.StagingDirectory)\version-config"
+            New-Item -ItemType Directory -Force -Path $stage | Out-Null
+            Copy-Item -Force config.json (Join-Path $stage 'config.json')
+            Write-Host "Staged computed config.json:"
+            Get-Content config.json
+          displayName: Compute versions into config.json
+          workingDirectory: $(Build.SourcesDirectory)
+
+          # Keep the ADO run-id prefix (pipeline `name:`), then append both
+          # computed versions -> "<run-id> - <v8jsi> - <legacy>".
+        - pwsh: |
+            $ErrorActionPreference = 'Stop'
+            $info = node scripts/compute-version.ts --json | ConvertFrom-Json
+            $v8jsi = ($info.packages | Where-Object { $_.packageId -eq 'Microsoft.JavaScript.V8' }).version
+            $legacy = ($info.packages | Where-Object { $_.packageId -eq 'ReactNative.V8Jsi.Windows' }).version
+            if ([string]::IsNullOrWhiteSpace($v8jsi)) { throw 'Could not resolve the Microsoft.JavaScript.V8 version' }
+            if ([string]::IsNullOrWhiteSpace($legacy)) { throw 'Could not resolve the ReactNative.V8Jsi.Windows version' }
+            $runNumber = "$($env:BUILD_BUILDNUMBER) - $v8jsi - $legacy"
+            Write-Host "##vso[build.updatebuildnumber]$runNumber"
+            Write-Host "Pipeline run number set to $runNumber"
+          displayName: Set pipeline run number
+          workingDirectory: $(Build.SourcesDirectory)
+
+
       - ${{ each matrix in parameters.BuildMatrix }}:
         - job: V8JsiBuild_${{ matrix.Name }}
           displayName: Build V8-JSI ${{ matrix.Name }}
+
+          # Wait for the computed config.json (overlaid in windows-build.yml).
+          dependsOn: V8JsiComputeVersion
 
           timeoutInMinutes: 1200
 
@@ -168,6 +230,9 @@ extends:
       - ${{ each matrix in parameters.BuildMatrix }}:
         - job: V8JsiBuildNew_${{ matrix.Name }}
           displayName: Build V8-JSI (Node.js source) ${{ matrix.Name }}
+
+          # Wait for the computed config.json (overlaid in windows-build-new.yml).
+          dependsOn: V8JsiComputeVersion
 
           timeoutInMinutes: 1200
 
@@ -268,6 +333,9 @@ extends:
         - job: V8JsiBuildSandbox_${{ sb.Name }}
           displayName: Build Sandbox (${{ sb.Rid }})
 
+          # Wait for the computed config.json (overlaid below before building).
+          dependsOn: V8JsiComputeVersion
+
           timeoutInMinutes: 180
 
           # ARM64 builds natively on the ARM64 managed-image pool so its Untrusted
@@ -304,6 +372,13 @@ extends:
             # the image's Node so that post-job doesn't fail.
           - ${{ if eq(sb.BuildPlatform, 'arm64') }}:
             - template: /.ado/ensure-node10-shim.yml@self
+
+            # Overlay the CI-computed config.json before building. Both the
+            # jitless engine (build.ts --build-v8jsisb -> gyp
+            # generate_version_info.ts) and the Chromium sandbox binaries
+            # (sbox-build.ts -> gn rc) stamp their version from
+            # config.json.v8jsi_version.
+          - template: /.ado/overlay-version-config.yml@self
 
           - task: UseNode@1
             displayName: Use Node.js 24.x
@@ -528,6 +603,9 @@ extends:
           # packages.
         - ${{ each sb in parameters.SandboxMatrix }}:
           - V8JsiBuildSandbox_${{ sb.Name }}
+          # scripts/build.ts --pack reads config.json.v8jsi_version for the
+          # package version, so wait for the computed config.json and overlay it.
+        - V8JsiComputeVersion
         displayName: Create Nuget (Node.js source)
 
         templateContext:
@@ -541,6 +619,9 @@ extends:
           # headers + consumer source TUs from src/, and runs the 4-pack flow
           # (3 per-RID + 1 meta) for Microsoft.JavaScript.V8.
         - checkout: self
+
+          # Overlay the CI-computed config.json before build.ts --pack reads it.
+        - template: /.ado/overlay-version-config.yml@self
 
         - task: UseNode@1
           displayName: Use Node.js 24.x
@@ -678,13 +759,16 @@ extends:
         #   ReactNative.V8Jsi.Windows_v<version>   (config.json .version)
         #   Microsoft.JavaScript.V8_v<version>     (config.json .v8jsi_version)
         #
-        # config.json versions stay constant across many CI runs, so tagging
-        # every green build would fight over one tag. Instead reuse the release
-        # pipeline's own "is this version already on the public feed?" check
-        # (see .ado/templates/publish-nuget-to-ado-feed.yml): a tag is created
-        # only for the first build of a version not yet on the feed. That feed
-        # is anonymously readable, so the query needs no token. Idempotent: an
-        # existing tag is left untouched, never moved.
+        # The versions come from the computed config.json overlaid above, so a
+        # release build increments the patch per commit (git height) and each
+        # commit gets its own tag. Two guards keep tagging correct:
+        #   * Skip prerelease builds: a non-release branch produces a "-<sha>"
+        #     suffixed version, which must never mint a real release tag.
+        #   * Idempotent for re-runs of the same commit (same version): the feed
+        #     membership check and the ls-remote tag check both no-op if the
+        #     version is already published / already tagged. The public feed is
+        #     anonymously readable, so that query needs no token; an existing tag
+        #     is left untouched, never moved.
         # =====================================================================
       - ${{ if eq(parameters.isPublish, true) }}:
         - job: V8JsiTagRelease
@@ -694,9 +778,15 @@ extends:
           - ${{ each matrix in parameters.BuildMatrix }}:
             - ${{ if eq(matrix.BuildConfiguration, 'Release') }}:
               - V8JsiAcceptanceNew_${{ matrix.Name }}
+          # The tag version comes from the computed config.json overlaid below.
+          - V8JsiComputeVersion
           displayName: Tag published versions
           steps:
           - checkout: self
+
+            # Overlay the CI-computed config.json so the tags carry the computed
+            # per-build versions (and prerelease builds are skipped, below).
+          - template: /.ado/overlay-version-config.yml@self
 
           - pwsh: |
               $ErrorActionPreference = 'Stop'
@@ -732,6 +822,16 @@ extends:
                 $version = $f.Version
                 Write-Host "=== $id $version ==="
                 if ([string]::IsNullOrWhiteSpace($version)) { throw "Missing version for $id in config.json" }
+
+                # Release tags only. compute-version.ts appends a "-g<sha>"
+                # prerelease suffix on non-release branches, so a suffixed
+                # version marks a non-release build (a PR or a topic branch that
+                # publishes for testing) -- those must never mint a real release
+                # tag. A clean version therefore implies a release branch.
+                if ($version -match '-') {
+                  Write-Host "  $version is a prerelease build -- no release tag."
+                  continue
+                }
 
                 # Already on the public feed? Membership test, so feed ordering
                 # does not matter. 404 = never published -> treat as new.

--- a/.ado/windows-pr.yml
+++ b/.ado/windows-pr.yml
@@ -3,6 +3,7 @@ name: v8jsi_pr_0.0.$(Date:yyMM.d)$(Rev:rrr)
 trigger: none
 pr:
   - master
+  - main
   - "*-stable"
 
 variables:

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1035,10 +1035,13 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Validate arguments
-  const platforms = (args.platform ?? ["x64"]).map((p) => p.toLowerCase());
-  const configurations = (args.configuration ?? ["release"]).map((c) =>
-    c.toLowerCase(),
+  // Validate arguments. platform/configuration are parseArgs multiple:true
+  // options (always arrays), so narrow the string | string[] union.
+  const platforms = ((args.platform ?? ["x64"]) as string[]).map((p) =>
+    p.toLowerCase(),
+  );
+  const configurations = ((args.configuration ?? ["release"]) as string[]).map(
+    (c) => c.toLowerCase(),
   );
 
   for (const p of platforms) {

--- a/scripts/compute-version.ts
+++ b/scripts/compute-version.ts
@@ -1,0 +1,385 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Computes the NuGet package version for a v8-jsi package from git history, so
+ * the patch component never has to be hand-maintained. Read-only: it prints
+ * versions and changes no files. Run with Node.js v24+ (TypeScript strip-types).
+ *
+ * Each package has its own plain-text version file under versions/, named for
+ * the package (e.g. versions/Microsoft.JavaScript.V8.version). The first
+ * non-comment line is the version; `#` lines are comments. One file per package
+ * keeps each package's history isolated, so bumping one never perturbs another,
+ * and adding a package is just adding a version file.
+ *
+ * Model (deterministic git-height, à la Nerdbank.GitVersioning, simplified for
+ * our squash-only linear history):
+ * - The committed `major.minor.patch` in the file is a manually settable *floor*.
+ * - Computed patch = floor + git height, where height is the number of
+ *   first-parent commits *after* the commit that last set this file's version.
+ *   So at a hand-set bump the computed version equals the committed value, then
+ *   grows by one per commit; a manual bump resets the height. Seed the floor
+ *   >= the latest published patch so versions never overlap what's already out.
+ * - On a release branch (master/main) the version is clean: `major.minor.patch`.
+ *   Otherwise it is a prerelease `major.minor.patch-g<8-char sha>` (the `g`
+ *   marks a git commit id, per `git describe`), so test-branch builds can run
+ *   (and even publish) without colliding with releases.
+ *
+ * The git access mirrors the `GitRepo` pattern from `@rnx-kit/fork-sync`: a thin
+ * typed wrapper over a single command runner with a `fallback` for commands
+ * allowed to fail. Kept local and synchronous for now; it maps onto that module
+ * if this is ever promoted to rnx-kit.
+ *
+ * With `--write` the computed versions are materialized into config.json (a
+ * surgical field replace that preserves the file's exact formatting), so every
+ * existing consumer keeps reading config.json unchanged. CI does this in a
+ * dedicated job and publishes the result as an artifact; the write is never
+ * committed (committing would move the anchor and reset the height).
+ *
+ * @example
+ *   node scripts/compute-version.ts                                     # all packages
+ *   node scripts/compute-version.ts versions/Microsoft.JavaScript.V8.version
+ *   node scripts/compute-version.ts --json                              # machine-readable
+ *   node scripts/compute-version.ts --write                             # materialize into config.json
+ *
+ * @module compute-version
+ */
+
+import { parseArgs } from "node:util";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { repoRoot } from "./build-common.ts";
+
+// Release branches. Hardcoded for now (master today, migrating to main); this
+// can move to a config-driven spec later if we ever grow a richer branch model.
+const releaseBranches = ["master", "main"];
+
+// Per-package version files live here (one <PackageId>.version file each).
+const versionsDir = path.join(repoRoot, "versions");
+
+// Maps each package to the config.json field that mirrors its version. The
+// version files (versions/*.version) are the source of truth; `--write`
+// materializes the computed versions into these config.json fields so the
+// existing consumers (build.ts, the RC generators, the NuGet aggregators, the
+// tag job) keep reading config.json unchanged. This legacy-shaped adapter is
+// temporary: it goes away once config.json's version fields are retired.
+const configFieldByPackageId: Record<string, string> = {
+  "Microsoft.JavaScript.V8": "v8jsi_version",
+  "ReactNative.V8Jsi.Windows": "version",
+};
+
+// =============================================================================
+// Git access (mirrors the fork-sync GitRepo pattern: typed methods over one
+// command runner, with a `fallback` for commands allowed to fail)
+// =============================================================================
+
+/**
+ * Typed wrapper around a git repository directory. Synchronous (execFileSync,
+ * no shell, so ref syntax like `^{commit}` and `A..B` passes through intact).
+ */
+class GitRepo {
+  readonly dir: string;
+
+  constructor(dir: string) {
+    this.dir = dir;
+  }
+
+  /**
+   * Run a git command and return its trimmed stdout. On a non-zero exit, return
+   * `opts.fallback` when provided, otherwise rethrow. (System errors — e.g. git
+   * not found — always throw.)
+   */
+  run(args: string[], opts?: { fallback?: string }): string {
+    const fallback = opts?.fallback;
+    try {
+      return execFileSync("git", args, {
+        encoding: "utf-8",
+        cwd: this.dir,
+        // When a fallback is provided the caller tolerates failure, so silence
+        // git's stderr (e.g. "path ... exists on disk, but not in HEAD").
+        stdio: fallback !== undefined ? ["ignore", "pipe", "ignore"] : undefined,
+      }).trim();
+    } catch (error) {
+      if (fallback !== undefined) return fallback;
+      throw error;
+    }
+  }
+
+  /** Resolve a ref to its commit hash (optionally abbreviated). */
+  revParse(ref: string, opts?: { short?: number }): string {
+    const args = ["rev-parse"];
+    if (opts?.short) args.push(`--short=${opts.short}`);
+    args.push(ref);
+    return this.run(args);
+  }
+
+  /** Content of a git object (e.g. `<rev>:<path>`). */
+  show(objectRef: string, opts?: { fallback?: string }): string {
+    return this.run(["show", objectRef], opts);
+  }
+
+  /** Current branch name (`HEAD` when detached). */
+  currentBranch(): string {
+    return this.run(["rev-parse", "--abbrev-ref", "HEAD"]);
+  }
+
+  /** First-parent commit hashes that touched `pathspec`, newest first. */
+  logFirstParent(pathspec: string): string[] {
+    return this.run(["log", "--first-parent", "--format=%H", "--", pathspec], {
+      fallback: "",
+    })
+      .split(/\r?\n/)
+      .filter(Boolean);
+  }
+
+  /** First-parent commit count for a range like `<anchor>..HEAD`. */
+  countFirstParent(range: string): number {
+    return Number(this.run(["rev-list", "--count", "--first-parent", range]));
+  }
+
+  /** The repository's root (parentless) commit. */
+  rootCommit(): string {
+    return this.run([
+      "rev-list",
+      "--max-parents=0",
+      "--first-parent",
+      "HEAD",
+    ]).split(/\r?\n/)[0];
+  }
+}
+
+const repo = new GitRepo(repoRoot);
+
+// The version from plain-text .version content: the first non-blank line that
+// is not a `#` comment. Returns undefined if there is none.
+function parseVersionFile(text: string): string | undefined {
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed && !trimmed.startsWith("#")) return trimmed;
+  }
+  return undefined;
+}
+
+// The version recorded in a version file at a given commit (undefined if the
+// file did not exist there).
+function versionAt(repoRelPath: string, rev: string): string | undefined {
+  const text = repo.show(`${rev}:${repoRelPath}`, { fallback: "" });
+  return text ? parseVersionFile(text) : undefined;
+}
+
+// A repo-relative, forward-slash path for git (accepts absolute or cwd-relative).
+function toRepoRelPath(file: string): string {
+  return path.relative(repoRoot, path.resolve(file)).split(path.sep).join("/");
+}
+
+// =============================================================================
+// version calculation
+// =============================================================================
+
+// Split "major.minor.patch" into parts. The patch (default 0) is the manually
+// settable floor that the git height is added to.
+function parseVersion(version: string): {
+  major: string;
+  minor: string;
+  patch: number;
+} {
+  const parts = version.split(".");
+  return {
+    major: parts[0] ?? "0",
+    minor: parts[1] ?? "0",
+    patch: Number(parts[2] ?? "0") || 0,
+  };
+}
+
+function stripRefsHeads(ref: string | undefined): string | undefined {
+  return ref?.replace(/^refs\/heads\//, "");
+}
+
+// The current branch. ADO checks out a detached HEAD, so prefer the branch name
+// the pipeline provides; fall back to git for local runs.
+function detectBranch(): string {
+  const fromEnv =
+    stripRefsHeads(process.env.BUILD_SOURCEBRANCH) ??
+    process.env.BUILD_SOURCEBRANCHNAME;
+  if (fromEnv) return fromEnv;
+  return repo.currentBranch();
+}
+
+// The commit where this file's version last became its current value. Walk the
+// commits that touched the file (newest -> oldest, first-parent) and keep the
+// oldest contiguous one that still carries the current version; stop when it
+// differs. Comparing the parsed version (not "last commit that touched the
+// file") means editing a comment does not reset the height.
+function findAnchor(repoRelPath: string, currentVersion: string): string {
+  let anchor: string | undefined;
+  for (const commit of repo.logFirstParent(repoRelPath)) {
+    if (versionAt(repoRelPath, commit) !== currentVersion) break;
+    anchor = commit;
+  }
+  // No matching commit (brand-new file just added): count from the root commit.
+  return anchor ?? repo.rootCommit();
+}
+
+interface PackageVersion {
+  packageId: string;
+  file: string;
+  base: string;
+  floor: number;
+  height: number;
+  version: string;
+  prerelease: boolean;
+}
+
+// Compute one package's version from its version file. Versions take effect when
+// committed (like Nerdbank.GitVersioning): the floor is read from HEAD, so an
+// uncommitted edit is ignored until committed. A file not yet committed (initial
+// adoption) is treated as height 0 = the floor.
+function computeForFile(
+  file: string,
+  isRelease: boolean,
+  sha8: string,
+): PackageVersion {
+  const repoRelPath = toRepoRelPath(file);
+  const committed = versionAt(repoRelPath, "HEAD");
+  const current = committed ?? parseVersionFile(fs.readFileSync(file, "utf-8"));
+  if (!current) {
+    throw new Error(`${repoRelPath}: no version line found`);
+  }
+  const { major, minor, patch } = parseVersion(current);
+  const height =
+    committed === undefined
+      ? 0
+      : repo.countFirstParent(`${findAnchor(repoRelPath, current)}..HEAD`);
+  const core = `${major}.${minor}.${patch + height}`;
+  return {
+    packageId: path.basename(file).replace(/\.version$/, ""),
+    file: repoRelPath,
+    base: `${major}.${minor}`,
+    floor: patch,
+    height,
+    // Prerelease suffix is `-g<sha8>`: the `g` marks a git commit id (per
+    // `git describe`) and keeps the identifier non-numeric, so it is always a
+    // valid SemVer prerelease tag.
+    version: isRelease ? core : `${core}-g${sha8}`,
+    prerelease: !isRelease,
+  };
+}
+
+// =============================================================================
+// config.json writeback
+// =============================================================================
+
+// Materialize the computed versions into config.json. For each package with a
+// mapped field, surgically replace just that field's value, leaving the rest of
+// the file (including its exact formatting) untouched -- config.json is written
+// by PowerShell's ConvertTo-Json, and reformatting it would create noise. The
+// write is meant to stay in the working tree only (CI publishes it as an
+// artifact); committing it would move the height anchor.
+function writeConfig(configPath: string, results: PackageVersion[]): void {
+  let text = fs.readFileSync(configPath, "utf-8");
+  for (const r of results) {
+    const field = configFieldByPackageId[r.packageId];
+    if (!field) {
+      console.error(`  (no config.json field mapped for ${r.packageId}; skipped)`);
+      continue;
+    }
+    // Field names come from the fixed map above, so this pattern is safe.
+    const fieldPattern = new RegExp(`("${field}"\\s*:\\s*")[^"]*(")`);
+    if (!fieldPattern.test(text)) {
+      throw new Error(`${toRepoRelPath(configPath)} has no "${field}" field to update`);
+    }
+    text = text.replace(fieldPattern, `$1${r.version}$2`);
+  }
+  fs.writeFileSync(configPath, text);
+}
+
+// =============================================================================
+// CLI
+// =============================================================================
+
+function printHelp(): void {
+  console.log(
+    [
+      "Compute v8-jsi package versions from git history.",
+      "",
+      "Usage: node scripts/compute-version.ts [version-file...] [options]",
+      "",
+      "With no version-file, computes every versions/*.version file.",
+      "",
+      "Options:",
+      "  --write            Materialize the computed versions into config.json",
+      "                     (surgical field replace; formatting preserved). Leave",
+      "                     the result in the working tree -- do not commit it.",
+      "  --config <path>    config.json to write with --write (default: repo-root",
+      "                     config.json).",
+      "  --json             Emit machine-readable JSON.",
+      "  --help             Show this help.",
+    ].join("\n"),
+  );
+}
+
+function main(): void {
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    options: {
+      help: { type: "boolean", default: false },
+      json: { type: "boolean", default: false },
+      write: { type: "boolean", default: false },
+      config: { type: "string" },
+    },
+  });
+
+  if (values.help) {
+    printHelp();
+    return;
+  }
+
+  const files =
+    positionals.length > 0
+      ? positionals
+      : fs
+          .readdirSync(versionsDir)
+          .filter((name) => name.endsWith(".version"))
+          .map((name) => path.join(versionsDir, name));
+
+  if (files.length === 0) {
+    throw new Error(`no version files found in ${toRepoRelPath(versionsDir)}`);
+  }
+
+  const branch = detectBranch();
+  const isRelease = releaseBranches.includes(branch);
+  const commit = repo.revParse("HEAD");
+  const sha8 = repo.revParse("HEAD", { short: 8 });
+
+  const results = files.map((file) => computeForFile(file, isRelease, sha8));
+
+  if (values.write) {
+    const configPath = path.resolve(
+      values.config ?? path.join(repoRoot, "config.json"),
+    );
+    writeConfig(configPath, results);
+    // Status to stderr so `--write --json` keeps stdout clean for the JSON.
+    console.error(`Wrote computed versions to ${toRepoRelPath(configPath)}:`);
+    for (const r of results) {
+      const field = configFieldByPackageId[r.packageId];
+      if (field) console.error(`  ${field} = ${r.version}`);
+    }
+  }
+
+  if (values.json) {
+    console.log(
+      JSON.stringify({ branch, isRelease, commit, packages: results }, null, 2),
+    );
+  } else {
+    console.log(`branch: ${branch} (${isRelease ? "release" : "prerelease"})`);
+    console.log(`commit: ${commit}`);
+    for (const r of results) {
+      console.log(
+        `  ${r.packageId}: ${r.version}  (floor ${r.floor} + height ${r.height})`,
+      );
+    }
+  }
+}
+
+main();

--- a/scripts/fetch_code.ps1
+++ b/scripts/fetch_code.ps1
@@ -45,7 +45,9 @@ Push-Location $SourcesPath
 $ourGitHash = ((git rev-parse --verify HEAD) | Out-String).Trim()
 Pop-Location
 
-$version = [version]$config.version
+# Strip any prerelease suffix (e.g. 0.79.8-g0564e49f) before the numeric cast;
+# a Windows FILEVERSION is numeric major.minor.build only.
+$version = [version]($config.version -replace '-.*$', '')
 
 $gitRevision = ""
 $v8Version = ""
@@ -73,15 +75,6 @@ Write-Host "##vso[task.setvariable variable=V8JSI_VERSION;]$verString"
     -replace ('V8JSI_GIT_HASH', $ourGitHash) `
     -replace ('V8JSIVER_V8REF', $v8Version) |`
     Set-Content "$SourcesPath\src\source_link_gen.json"
-
-# Update ADO build version string when run from ADO pipeline
-if ($env:BUILD_BUILDNUMBER) {
-    $buildVersion = $env:BUILD_BUILDNUMBER
-    if (!$buildVersion.EndsWith($v8Version.Replace('.', '_'))) {
-        $buildVersion = $buildVersion + " - " + $config.v8jsi_version + " - " + $version.Major + "." + $version.Minor + "." + $version.Build + "." + $v8Version.Replace('.', '_')
-        Write-Host "##vso[build.updateBuildNumber]$buildVersion"
-    }
-}
 
 # Install build dependencies for Android
 if ($AppPlatform -eq "android") {

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,408 @@
+{
+  "name": "v8jsi-scripts",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "v8jsi-scripts",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/node": "^26.1.1",
+        "typescript": "^7.0.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha1-utdY1gHpfWz0V9IE7najX8570Rk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha1-zcfOgdYPHgkDSWDd+x+4gNendrY=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha1-pV/fz6WN9Y0n2yI3zealweNacjU=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha1-ONHJFygAqR1we+xk0qNwoBZjTbQ=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha1-8f+IEAMLNdK1vg22otxlBGDqlPo=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha1-PYawPzU8WxupUWLrbONVM7/ClL0=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha1-rZS0HhruKk3MaimMe2fEM0X94y4=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha1-2TNNltbaxv+F2pyGVYiUjek56R8=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha1-KWWu5PyHM2ATnYk9qv5jl6KROK0=",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha1-Goh6MRvtOoM/gL/Uqe03wnGTbPA=",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha1-i2PJsvRFs5PrTkPsIdoiXa3jV30=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha1-tuijXCibPql6kqQdRhqu7Q07NuE=",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha1-Lvlmk75IYfbReWVCflsAnLvtGj4=",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha1-cyacsLq6UK6gygYERaa4jlg/HOI=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha1-OjZJ+X+vohC05uN5jBXgZgXIqQE=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha1-R+xZSRpAxHDSgH3E0rglUo/Zeas=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha1-eWvo2gvZidij+5bygB44qDZbS68=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha1-03/ipynrlCwHbEVO5/GBX699Vg8=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha1-q6jTRkw1ZacER4m6upaRa9SrLIg=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha1-ud5QoXGWOD9iYgtfnQovNK07YNc=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha1-zzt7DWzlY12spMjgHBic3N5H7Dw=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha1-nsdz15VKjBgsF8xbvVdaoovFFYI=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha1-ROn8nzJEZIzeo15Pm7LWgelBCAk=",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "v8jsi-scripts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "TypeScript build/tooling scripts for v8-jsi. Run directly with Node.js v24+ (strip-types); no build step. Types are for editor/CI type-checking only.",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "typescript": "^7.0.2"
+  }
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  // Type-checking config for the v8-jsi build/tooling scripts. These run
+  // directly with `node scripts/<name>.ts` (Node.js strip-types) — there is no
+  // build step, so this config never emits; it exists for editor IntelliSense
+  // and `npm run typecheck`.
+  "compilerOptions": {
+    // Match Node's native ESM + TypeScript execution.
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2023",
+    "lib": ["es2023"],
+
+    // Node globals/built-ins (process, node:fs, ...). Fixes the "Cannot find
+    // name 'process'/'node:*'" squiggles that appear without @types/node.
+    "types": ["node"],
+
+    // The scripts import each other with an explicit ".ts" extension (e.g.
+    // "./build-common.ts"), which is how Node runs them. Allowed only with
+    // noEmit / emitDeclarationOnly.
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+
+    // Node strip-types only erases types; it cannot transform runtime TS syntax
+    // (parameter properties, enums, namespaces). Flag those at type-check time
+    // so a script can't compile here yet fail to run under `node`.
+    "erasableSyntaxOnly": true,
+
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  // Top-level scripts only. fork-sync/ is its own package with its own config.
+  "include": ["*.ts"]
+}

--- a/src/generate_version_info.ts
+++ b/src/generate_version_info.ts
@@ -27,7 +27,10 @@ const { values } = parseArgs({
 
 const config = JSON.parse(readFileSync(values.config!, "utf8"));
 const version = (config.v8jsi_version as string) ?? "0.0.0";
-const [major = "0", minor = "0", build = "0"] = version.split(".");
+// A Windows binary version is numeric major.minor.build.revision. Auto-versioned
+// prerelease builds carry a SemVer suffix (e.g. 24.1.2-g0564e49f); drop it before
+// splitting, since the suffix can't appear in FILEVERSION/PRODUCTVERSION.
+const [major = "0", minor = "0", build = "0"] = version.split("-")[0].split(".");
 const revision = "0";
 const versionStr = `${major}.${minor}.${build}.${revision}`;
 

--- a/src/generate_version_rc.ts
+++ b/src/generate_version_rc.ts
@@ -16,7 +16,9 @@ const { values } = parseArgs({
 });
 
 const config = JSON.parse(readFileSync(values.config!, "utf8"));
-const [major, minor, build] = (config.version as string).split(".");
+// A Windows binary version is numeric major.minor.build. Drop any prerelease
+// suffix (e.g. 0.79.8-g0564e49f) before splitting.
+const [major, minor, build] = (config.version as string).split("-")[0].split(".");
 
 const template = readFileSync(values.template!, "utf8");
 const result = template

--- a/versions/Microsoft.JavaScript.V8.version
+++ b/versions/Microsoft.JavaScript.V8.version
@@ -1,0 +1,13 @@
+# Base version for the Microsoft.JavaScript.V8 NuGet package.
+#
+# scripts/compute-version.ts computes the shipped version as:
+#   major.minor.(patch + git height)
+# where "git height" is the number of commits since the version below was last
+# changed. The patch here is therefore a FLOOR: the shipped patch is this value
+# plus the commits added since. At the commit that sets it, height is 0 and the
+# shipped version equals this exactly; it then grows by one per commit.
+#
+# To start a new version line, edit the value below (any component). Set it at
+# or above the latest already-published patch so versions never overlap. On
+# non-release branches the build appends "-<8-char commit sha>" (prerelease).
+24.1.2

--- a/versions/ReactNative.V8Jsi.Windows.version
+++ b/versions/ReactNative.V8Jsi.Windows.version
@@ -1,0 +1,13 @@
+# Base version for the ReactNative.V8Jsi.Windows NuGet package (legacy).
+#
+# scripts/compute-version.ts computes the shipped version as:
+#   major.minor.(patch + git height)
+# where "git height" is the number of commits since the version below was last
+# changed. The patch here is therefore a FLOOR: the shipped patch is this value
+# plus the commits added since. At the commit that sets it, height is 0 and the
+# shipped version equals this exactly; it then grows by one per commit.
+#
+# To start a new version line, edit the value below (any component). Set it at
+# or above the latest already-published patch so versions never overlap. On
+# non-release branches the build appends "-<8-char commit sha>" (prerelease).
+0.79.8


### PR DESCRIPTION
## Summary

Package versions were maintained by hand in `config.json`, which was easy to
forget — a publishing run could then find the version already on the feed and
ship nothing. This change derives each package's version automatically from Git
history, so every squash-merged PR produces a new version with no manual step.
The two packages shipped during the migration — `Microsoft.JavaScript.V8` (new)
and `ReactNative.V8Jsi.Windows` (legacy) — are versioned independently.

## How the version is computed (floor + Git height)

Deterministic Git-height versioning — the model used by Nerdbank.GitVersioning,
simplified for our squash-only, linear `master`/`main` history.

- Each package has a plain-text version file under `versions/`, named for the
  package (e.g. `versions/Microsoft.JavaScript.V8.version`); the first non-`#`
  line is a `major.minor.patch` value.
- That committed patch is a **floor**. The shipped version is
  `major.minor.(patch + height)`, where **height** is the number of first-parent
  commits since that file's value last changed. At the commit that sets the
  value, height is 0 (shipped equals committed); it then increases by one per
  commit — one patch bump per squash-merged PR.
- On a release branch (`master`/`main`) the version is clean (e.g. `24.1.5`); on
  any other branch it is a prerelease `24.1.5-g<8-char commit>` (the `g` prefix
  follows `git describe` and keeps the identifier a valid, non-numeric SemVer
  tag), so PR and topic-branch builds never collide with releases.

One file per package keeps each package's history isolated, so bumping one never
affects the other, and adding a package later is just a new file.

**To bump** a major, minor, or patch floor, edit the value in that package's
`versions/*.version` file (set it at or above the latest published patch);
everything else is automatic. Preview locally with
`node scripts/compute-version.ts` (add `--json` for machine-readable output).

## CI integration

`config.json` stays the single shape every consumer reads. One
`V8JsiComputeVersion` job checks out full history (the only deep checkout),
computes both versions, writes them into `config.json` (a surgical field replace
that preserves formatting), and publishes the result as the `version-config`
pipeline artifact; it never commits the change (a commit would move the height
anchor). Every other job stays on a shallow checkout and overlays that artifact
(`.ado/overlay-version-config.yml`) before reading `config.json`, so `build.ts`,
the version-resource generators, and the NuGet aggregators consume the computed
version unchanged. The release-tag job creates `<package>_v<version>` only on a
release branch with no prerelease suffix. (Binary `FILEVERSION` resources use the
numeric `major.minor.build` core, since a resource version must be integers.)

## Related: `master` → `main` preparation

Adjacent to the versioning work, the CI and PR pipelines now trigger on both
`master` and `main`, and the CI trigger is defined in YAML — with documentation
and ownership-metadata paths excluded — rather than in the pipeline UI.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/251)