### PR TITLE
Fix acceptance snapshot shutdown deadlock

### DIFF
--- a/tools/mksnapshot/mkv8snapshot.cpp
+++ b/tools/mksnapshot/mkv8snapshot.cpp
@@ -180,5 +180,8 @@ int main(int argc, char** argv) {
   }
 
   std::fprintf(stderr, "[mkv8snapshot] wrote %s (%zu bytes)\n", outPath.c_str(), blobSize);
-  return 0;
+  std::fflush(stderr);
+  // Engine V8 background threads can deadlock during DLL/process teardown; blob is on disk.
+  ::TerminateProcess(::GetCurrentProcess(), 0);
+  return 0;  // unreachable
 }


### PR DESCRIPTION
## Summary

Prevent `mkv8snapshot.exe` from intermittently hanging after it has successfully
written a startup snapshot. The tool now flushes its final diagnostic and
terminates the process without unloading the engine DLL, avoiding the
shutdown deadlock that caused about half of the new-package acceptance jobs to
time out.

## Problem

The snapshot end-to-end test invokes `mkv8snapshot.exe` once for `v8jsi.dll`
and once for `v8jsisb.dll`. In failing jobs, the tool printed its final
`[mkv8snapshot] wrote ...` message and the blob was present on disk, but the
process never exited. The PowerShell harness therefore remained blocked until
the job timeout, even though snapshot creation had completed successfully.

This was a race and could affect either engine.

## Root cause

`mkv8snapshot.exe` loads the selected engine DLL, asks it to create the blob,
writes and closes the output file, and then returns from `main`. V8 background
threads can still be active at that point. Normal process shutdown unloads the
engine DLL and runs its detach path under the Windows loader lock, where those
threads can deadlock.

The completion diagnostic is emitted before normal process teardown, which is
why affected jobs showed a successful write immediately before hanging.

## Fix

After writing the blob and printing the completion diagnostic:

- Flush `stderr` so the final message is preserved.
- Call `TerminateProcess(GetCurrentProcess(), 0)` to bypass static destruction
  and DLL process-detach teardown.
- Keep an unreachable `return 0` after the termination call for the compiler.

Hard termination is appropriate here because `mkv8snapshot.exe` is a
single-purpose subprocess. Its only durable output is already closed and on
disk, and its final diagnostic is explicitly flushed. `ExitProcess` and
`_exit` are not suitable substitutes because they still run DLL detach code and
can encounter the same loader-lock deadlock.

## Scope

Only `tools/mksnapshot/mkv8snapshot.cpp` changes. There are no public API,
snapshot format, engine behavior, or test-harness changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/253)