### PR TITLE
Omit registry URLs from the scripts lockfile

### DIFF
--- a/scripts/.npmrc
+++ b/scripts/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -14,7 +14,6 @@
     },
     "node_modules/@types/node": {
       "version": "26.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-26.1.1.tgz",
       "integrity": "sha1-utdY1gHpfWz0V9IE7najX8570Rk=",
       "dev": true,
       "license": "MIT",
@@ -24,7 +23,6 @@
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
       "integrity": "sha1-zcfOgdYPHgkDSWDd+x+4gNendrY=",
       "cpu": [
         "ppc64"
@@ -41,7 +39,6 @@
     },
     "node_modules/@typescript/typescript-darwin-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
       "integrity": "sha1-pV/fz6WN9Y0n2yI3zealweNacjU=",
       "cpu": [
         "arm64"
@@ -58,7 +55,6 @@
     },
     "node_modules/@typescript/typescript-darwin-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
       "integrity": "sha1-ONHJFygAqR1we+xk0qNwoBZjTbQ=",
       "cpu": [
         "x64"
@@ -75,7 +71,6 @@
     },
     "node_modules/@typescript/typescript-freebsd-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
       "integrity": "sha1-8f+IEAMLNdK1vg22otxlBGDqlPo=",
       "cpu": [
         "arm64"
@@ -92,7 +87,6 @@
     },
     "node_modules/@typescript/typescript-freebsd-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
       "integrity": "sha1-PYawPzU8WxupUWLrbONVM7/ClL0=",
       "cpu": [
         "x64"
@@ -109,7 +103,6 @@
     },
     "node_modules/@typescript/typescript-linux-arm": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
       "integrity": "sha1-rZS0HhruKk3MaimMe2fEM0X94y4=",
       "cpu": [
         "arm"
@@ -126,7 +119,6 @@
     },
     "node_modules/@typescript/typescript-linux-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
       "integrity": "sha1-2TNNltbaxv+F2pyGVYiUjek56R8=",
       "cpu": [
         "arm64"
@@ -143,7 +135,6 @@
     },
     "node_modules/@typescript/typescript-linux-loong64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
       "integrity": "sha1-KWWu5PyHM2ATnYk9qv5jl6KROK0=",
       "cpu": [
         "loong64"
@@ -160,7 +151,6 @@
     },
     "node_modules/@typescript/typescript-linux-mips64el": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
       "integrity": "sha1-Goh6MRvtOoM/gL/Uqe03wnGTbPA=",
       "cpu": [
         "mips64el"
@@ -177,7 +167,6 @@
     },
     "node_modules/@typescript/typescript-linux-ppc64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
       "integrity": "sha1-i2PJsvRFs5PrTkPsIdoiXa3jV30=",
       "cpu": [
         "ppc64"
@@ -194,7 +183,6 @@
     },
     "node_modules/@typescript/typescript-linux-riscv64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
       "integrity": "sha1-tuijXCibPql6kqQdRhqu7Q07NuE=",
       "cpu": [
         "riscv64"
@@ -211,7 +199,6 @@
     },
     "node_modules/@typescript/typescript-linux-s390x": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
       "integrity": "sha1-Lvlmk75IYfbReWVCflsAnLvtGj4=",
       "cpu": [
         "s390x"
@@ -228,7 +215,6 @@
     },
     "node_modules/@typescript/typescript-linux-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
       "integrity": "sha1-cyacsLq6UK6gygYERaa4jlg/HOI=",
       "cpu": [
         "x64"
@@ -245,7 +231,6 @@
     },
     "node_modules/@typescript/typescript-netbsd-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
       "integrity": "sha1-OjZJ+X+vohC05uN5jBXgZgXIqQE=",
       "cpu": [
         "arm64"
@@ -262,7 +247,6 @@
     },
     "node_modules/@typescript/typescript-netbsd-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
       "integrity": "sha1-R+xZSRpAxHDSgH3E0rglUo/Zeas=",
       "cpu": [
         "x64"
@@ -279,7 +263,6 @@
     },
     "node_modules/@typescript/typescript-openbsd-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
       "integrity": "sha1-eWvo2gvZidij+5bygB44qDZbS68=",
       "cpu": [
         "arm64"
@@ -296,7 +279,6 @@
     },
     "node_modules/@typescript/typescript-openbsd-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
       "integrity": "sha1-03/ipynrlCwHbEVO5/GBX699Vg8=",
       "cpu": [
         "x64"
@@ -313,7 +295,6 @@
     },
     "node_modules/@typescript/typescript-sunos-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
       "integrity": "sha1-q6jTRkw1ZacER4m6upaRa9SrLIg=",
       "cpu": [
         "x64"
@@ -330,7 +311,6 @@
     },
     "node_modules/@typescript/typescript-win32-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
       "integrity": "sha1-ud5QoXGWOD9iYgtfnQovNK07YNc=",
       "cpu": [
         "arm64"
@@ -347,7 +327,6 @@
     },
     "node_modules/@typescript/typescript-win32-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
       "integrity": "sha1-zzt7DWzlY12spMjgHBic3N5H7Dw=",
       "cpu": [
         "x64"
@@ -364,7 +343,6 @@
     },
     "node_modules/typescript": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-7.0.2.tgz",
       "integrity": "sha1-nsdz15VKjBgsF8xbvVdaoovFFYI=",
       "dev": true,
       "license": "Apache-2.0",
@@ -399,7 +377,6 @@
     },
     "node_modules/undici-types": {
       "version": "8.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha1-ROn8nzJEZIzeo15Pm7LWgelBCAk=",
       "dev": true,
       "license": "MIT"


### PR DESCRIPTION
## Summary

- Add `omit-lockfile-registry-resolved=true` to `scripts/.npmrc`.
- Regenerate `scripts/package-lock.json` with npm 11.19.0.
- Remove 23 registry `resolved` fields, including the Azure Artifacts proxy URLs.

Dependency versions, integrity hashes, `lockfileVersion`, and platform metadata are unchanged.

## Validation

- `npx --yes npm@11.19.0 config get omit-lockfile-registry-resolved` returned `true`.
- A second `npx --yes npm@11.19.0 install --package-lock-only --ignore-scripts --no-audit --no-fund` made no changes.
- Azure Artifacts feed URLs remaining in the lockfile: 0.
- `npx --yes npm@11.19.0 ci --ignore-scripts --no-audit --no-fund` passed.
- `npx --yes npm@11.19.0 run typecheck` passed.

npm config reference: https://docs.npmjs.com/cli/v8/using-npm/config#omit-lockfile-registry-resolved
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/v8-jsi/pull/256)